### PR TITLE
fix concurrent modification on gc

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtRoot.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtRoot.kt
@@ -15,9 +15,9 @@ import dev.yorkie.util.YorkieLogger
  */
 internal class CrdtRoot(val rootObject: CrdtObject) {
     private val elementPairMapByCreatedAt =
-        hashMapOf(rootObject.createdAt to CrdtElementPair(rootObject))
-    private val removedElementSetByCreatedAt = hashSetOf<TimeTicket>()
-    private val textWithGarbageSetByCreatedAt = hashSetOf<TimeTicket>()
+        mutableMapOf(rootObject.createdAt to CrdtElementPair(rootObject))
+    private val removedElementSetByCreatedAt = mutableSetOf<TimeTicket>()
+    private val textWithGarbageSetByCreatedAt = mutableSetOf<TimeTicket>()
 
     val elementMapSize
         get() = elementPairMapByCreatedAt.size
@@ -128,7 +128,7 @@ internal class CrdtRoot(val rootObject: CrdtObject) {
      */
     fun garbageCollect(executedAt: TimeTicket): Int {
         var count = 0
-        removedElementSetByCreatedAt.forEach { createdAt ->
+        removedElementSetByCreatedAt.toSet().forEach { createdAt ->
             val pair = elementPairMapByCreatedAt[createdAt] ?: return@forEach
             if (pair.element.isRemoved && pair.element.removedAt <= executedAt) {
                 pair.parent?.delete(pair.element)
@@ -136,13 +136,15 @@ internal class CrdtRoot(val rootObject: CrdtObject) {
             }
         }
 
-        textWithGarbageSetByCreatedAt.forEach { createdAt ->
-            val pair = elementPairMapByCreatedAt[createdAt] ?: return@forEach
+        val textGarbageIterator = textWithGarbageSetByCreatedAt.iterator()
+        while (textGarbageIterator.hasNext()) {
+            val createdAt = textGarbageIterator.next()
+            val pair = elementPairMapByCreatedAt[createdAt] ?: continue
             val text = pair.element as CrdtTextElement
 
             val removedNodeCount = text.deleteTextNodesWithGarbage(executedAt)
             if (removedNodeCount > 0) {
-                textWithGarbageSetByCreatedAt.remove(text.createdAt)
+                textGarbageIterator.remove()
             }
             count += removedNodeCount
         }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtRootTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtRootTest.kt
@@ -65,4 +65,17 @@ class CrdtRootTest {
         assertEquals(k2_1_1, root.findByCreatedAt(k2_1_1.createdAt))
         assertEquals("$.k2.1.1", root.createPath(k2_1_1.createdAt))
     }
+
+    @Test
+    fun `test gc`() {
+        val obj = CrdtObject(TimeTicket.InitialTimeTicket, RhtPQMap())
+        obj["k1"] = CrdtPrimitive("v1", TimeTicket.InitialTimeTicket.copy(lamport = 1))
+        obj["k2"] = CrdtPrimitive("v2", TimeTicket.InitialTimeTicket.copy(lamport = 2))
+        val root = CrdtRoot(obj)
+        obj["k1"].remove(TimeTicket.InitialTimeTicket.copy(lamport = 3))
+        obj["k2"].remove(TimeTicket.InitialTimeTicket.copy(lamport = 4))
+        root.registerRemovedElement(obj["k1"])
+        root.registerRemovedElement(obj["k2"])
+        root.garbageCollect(TimeTicket.InitialTimeTicket.copy(lamport = 5))
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
fix concurrent modification on gc.
I used iterator for `textWithGarbageSetByCreatedAt`, but snapshot for `removedElementSetByCreatedAt` because gc flow is quite complex here.

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
