### PR TITLE
Set InitialTimeTicket to dummyHead

### DIFF
--- a/examples/src/main/kotlin/dev/yorkie/examples/KanbanBoardViewModel.kt
+++ b/examples/src/main/kotlin/dev/yorkie/examples/KanbanBoardViewModel.kt
@@ -95,7 +95,7 @@ class KanbanBoardViewModel : ViewModel() {
     }
 
     companion object {
-        private const val DOCUMENT_KEY = "test key3"
+        private const val DOCUMENT_KEY = "vuejs-kanban"
         private const val DOCUMENT_LIST_KEY = "lists"
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeList.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeList.kt
@@ -1,7 +1,7 @@
 package dev.yorkie.document.crdt
 
 import dev.yorkie.document.time.TimeTicket
-import dev.yorkie.document.time.TimeTicket.Companion.NullTimeTicket
+import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
 import dev.yorkie.document.time.TimeTicket.Companion.compareTo
 import dev.yorkie.util.SplayTreeSet
 
@@ -12,8 +12,8 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node> {
     private val dummyHead = Node(
         CrdtPrimitive(
             value = 1,
-            createdAt = NullTimeTicket,
-            _removedAt = NullTimeTicket,
+            createdAt = InitialTimeTicket,
+            _removedAt = InitialTimeTicket,
         ),
     )
     var last: Node = dummyHead

--- a/yorkie/src/main/kotlin/dev/yorkie/document/time/TimeTicket.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/time/TimeTicket.kt
@@ -28,7 +28,7 @@ public data class TimeTicket(
         internal const val MAX_DELIMITER = Int.MAX_VALUE
         internal const val MAX_LAMPORT = Long.MAX_VALUE
 
-        internal val NullTimeTicket = TimeTicket(
+        private val NullTimeTicket = TimeTicket(
             Long.MIN_VALUE,
             INITIAL_DELIMITER,
             INITIAL_ACTOR_ID,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Set InitialTimeTicket to dummyHead instead of NullTimeTicket.
(min lamport value is 0.)

#### Any background context you want to provide?
now we can test working with the [JS SDK's sample](https://github.com/yorkie-team/yorkie-js-sdk/tree/main/examples) as well.


https://user-images.githubusercontent.com/52355963/200747265-a783d56e-89c0-48e0-82d9-2f363ccbbde7.mov



#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
