### PR TITLE
Remove text dependency from RgaTreeSplit

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeSplit.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeSplit.kt
@@ -44,7 +44,7 @@ internal class RgaTreeSplit<T : RgaTreeSplitValue<T>> : Iterable<RgaTreeSplitNod
         executedAt: TimeTicket,
         value: T?,
         latestCreatedAtMapByActor: Map<ActorID, TimeTicket>? = null,
-    ): Triple<RgaTreeSplitNodePos, Map<ActorID, TimeTicket>, MutableList<TextChange>> {
+    ): Triple<RgaTreeSplitNodePos, Map<ActorID, TimeTicket>, List<ContentChange>> {
         // 1. Split nodes.
         val (toLeft, toRight) = findNodeWithSplit(range.second, executedAt)
         val (fromLeft, fromRight) = findNodeWithSplit(range.first, executedAt)
@@ -73,8 +73,7 @@ internal class RgaTreeSplit<T : RgaTreeSplitValue<T>> : Iterable<RgaTreeSplitNod
                 changes[changes.lastIndex] = changes.last().copy(content = it.toString())
             } else {
                 changes.add(
-                    TextChange(
-                        TextChangeType.Content,
+                    ContentChange(
                         executedAt.actorID,
                         index,
                         index,
@@ -186,7 +185,7 @@ internal class RgaTreeSplit<T : RgaTreeSplitValue<T>> : Iterable<RgaTreeSplitNod
         executedAt: TimeTicket,
         latestCreatedAtMapByActor: Map<ActorID, TimeTicket>?,
     ): Triple<
-        MutableList<TextChange>,
+        MutableList<ContentChange>,
         Map<ActorID, TimeTicket>,
         Map<RgaTreeSplitNodeID, RgaTreeSplitNode<T>>,
         > {
@@ -271,7 +270,7 @@ internal class RgaTreeSplit<T : RgaTreeSplitValue<T>> : Iterable<RgaTreeSplitNod
     private fun makeChanges(
         boundaries: List<RgaTreeSplitNode<T>?>,
         executedAt: TimeTicket,
-    ): List<TextChange> {
+    ): List<ContentChange> {
         return buildList {
             var (fromIndex, toIndex) = Pair(0, 0)
             for (index in 0..boundaries.size - 2) {
@@ -288,7 +287,7 @@ internal class RgaTreeSplit<T : RgaTreeSplitValue<T>> : Iterable<RgaTreeSplitNod
                 }
             }
             if (fromIndex < toIndex) {
-                add(TextChange(TextChangeType.Content, executedAt.actorID, fromIndex, toIndex))
+                add(ContentChange(executedAt.actorID, fromIndex, toIndex))
             }
         }.reversed()
     }
@@ -426,6 +425,13 @@ internal class RgaTreeSplit<T : RgaTreeSplitValue<T>> : Iterable<RgaTreeSplitNod
             }
         }
     }
+
+    data class ContentChange(
+        val actorID: ActorID,
+        val from: Int,
+        val to: Int,
+        val content: String? = null,
+    )
 
     companion object {
         private val InitialNodeID = RgaTreeSplitNodeID(InitialTimeTicket, 0)

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TextInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TextInfo.kt
@@ -64,7 +64,7 @@ internal data class TextValue(
         val attrs = _attributes.nodeKeyValueMap.entries.joinToString(",", "{", "}") {
             """"${it.key}":"${escapeString(it.value)}""""
         }
-        return """{"attrs":$attrs,"content":"${escapeString(content)}"}"""
+        return """{"attrs":$attrs,"val":"${escapeString(content)}"}"""
     }
 
     override fun toString(): String {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TextInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TextInfo.kt
@@ -61,10 +61,14 @@ internal data class TextValue(
     }
 
     fun toJson(): String {
-        val attrs = _attributes.nodeKeyValueMap.entries.joinToString(",", "{", "}") {
+        val attrs = _attributes.nodeKeyValueMap.entries.joinToString(",") {
             """"${it.key}":"${escapeString(it.value)}""""
         }
-        return """{"attrs":$attrs,"val":"${escapeString(content)}"}"""
+        return if (attrs.isEmpty()) {
+            """{"val":"${escapeString(content)}"}"""
+        } else {
+            """{"attrs":{$attrs},"val":"${escapeString(content)}"}"""
+        }
     }
 
     override fun toString(): String {

--- a/yorkie/src/test/kotlin/dev/yorkie/document/DocumentTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/DocumentTest.kt
@@ -116,7 +116,7 @@ class DocumentTest {
                             "k9": [true, 1, 100, 111.111, "test", "bytes", 10000, {"k1": 1}, [1, 2]],
                             "int": 100,
                             "long": 100,
-                            "text": [{"attrs":{"b":"1"},"content":"H"},{"attrs":{},"content":"ello World"}]
+                            "text": [{"attrs":{"b":"1"},"val":"H"},{"attrs":{},"val":"ello World"}]
                         }
                 }""",
                 target.toJson(),

--- a/yorkie/src/test/kotlin/dev/yorkie/document/DocumentTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/DocumentTest.kt
@@ -116,7 +116,7 @@ class DocumentTest {
                             "k9": [true, 1, 100, 111.111, "test", "bytes", 10000, {"k1": 1}, [1, 2]],
                             "int": 100,
                             "long": 100,
-                            "text": [{"attrs":{"b":"1"},"val":"H"},{"attrs":{},"val":"ello World"}]
+                            "text": [{"attrs":{"b":"1"},"val":"H"},{"val":"ello World"}]
                         }
                 }""",
                 target.toJson(),

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTextTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTextTest.kt
@@ -29,7 +29,7 @@ class CrdtTextTest {
 
         target.edit(target.createRange(3, 3), "\n", TimeTicket.InitialTimeTicket)
         assertEquals(
-            """[{"attrs":{"b":"1"},"val":"ABC"},{"attrs":{},"val":"\n"},""" +
+            """[{"attrs":{"b":"1"},"val":"ABC"},{"val":"\n"},""" +
                 """{"attrs":{"b":"1"},"val":"D"}]""",
             target.toJson(),
         )
@@ -38,11 +38,11 @@ class CrdtTextTest {
     @Test
     fun `should handle edit operations without attributes`() {
         target.edit(target.createRange(0, 0), "A", TimeTicket.InitialTimeTicket)
-        assertEquals("""[{"attrs":{},"val":"A"}]""", target.toJson())
+        assertEquals("""[{"val":"A"}]""", target.toJson())
 
         target.edit(target.createRange(0, 0), "B", TimeTicket.InitialTimeTicket)
         assertEquals(
-            """[{"attrs":{},"val":"A"},{"attrs":{},"val":"B"}]""",
+            """[{"val":"A"},{"val":"B"}]""",
             target.toJson(),
         )
     }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTextTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTextTest.kt
@@ -23,14 +23,14 @@ class CrdtTextTest {
             mapOf("b" to "1"),
         )
         assertEquals(
-            """[{"attrs":{"b":"1"},"content":"ABCD"}]""",
+            """[{"attrs":{"b":"1"},"val":"ABCD"}]""",
             target.toJson(),
         )
 
         target.edit(target.createRange(3, 3), "\n", TimeTicket.InitialTimeTicket)
         assertEquals(
-            """[{"attrs":{"b":"1"},"content":"ABC"},{"attrs":{},"content":"\n"},""" +
-                """{"attrs":{"b":"1"},"content":"D"}]""",
+            """[{"attrs":{"b":"1"},"val":"ABC"},{"attrs":{},"val":"\n"},""" +
+                """{"attrs":{"b":"1"},"val":"D"}]""",
             target.toJson(),
         )
     }
@@ -38,11 +38,11 @@ class CrdtTextTest {
     @Test
     fun `should handle edit operations without attributes`() {
         target.edit(target.createRange(0, 0), "A", TimeTicket.InitialTimeTicket)
-        assertEquals("""[{"attrs":{},"content":"A"}]""", target.toJson())
+        assertEquals("""[{"attrs":{},"val":"A"}]""", target.toJson())
 
         target.edit(target.createRange(0, 0), "B", TimeTicket.InitialTimeTicket)
         assertEquals(
-            """[{"attrs":{},"content":"A"},{"attrs":{},"content":"B"}]""",
+            """[{"attrs":{},"val":"A"},{"attrs":{},"val":"B"}]""",
             target.toJson(),
         )
     }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTextTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTextTest.kt
@@ -34,11 +34,11 @@ class JsonTextTest {
     @Test
     fun `should handle text edit operations`() {
         target.edit(0, 0, "Hello World")
-        assertEquals("""[{"attrs":{},"val":"Hello World"}]""", target.toJson())
+        assertEquals("""[{"val":"Hello World"}]""", target.toJson())
 
         target.edit(6, 11, "Yorkie", mapOf("b" to "1"))
         assertEquals(
-            """[{"attrs":{},"val":"Hello "},{"attrs":{"b":"1"},"val":"Yorkie"}]""",
+            """[{"val":"Hello "},{"attrs":{"b":"1"},"val":"Yorkie"}]""",
             target.toJson(),
         )
     }
@@ -46,11 +46,11 @@ class JsonTextTest {
     @Test
     fun `should handle style operations`() {
         target.edit(0, 0, "Hello World")
-        assertEquals("""[{"attrs":{},"val":"Hello World"}]""", target.toJson())
+        assertEquals("""[{"val":"Hello World"}]""", target.toJson())
 
         target.style(0, 1, mapOf("b" to "1"))
         assertEquals(
-            """[{"attrs":{"b":"1"},"val":"H"},{"attrs":{},"val":"ello World"}]""",
+            """[{"attrs":{"b":"1"},"val":"H"},{"val":"ello World"}]""",
             target.toJson(),
         )
     }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTextTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTextTest.kt
@@ -34,11 +34,11 @@ class JsonTextTest {
     @Test
     fun `should handle text edit operations`() {
         target.edit(0, 0, "Hello World")
-        assertEquals("""[{"attrs":{},"content":"Hello World"}]""", target.toJson())
+        assertEquals("""[{"attrs":{},"val":"Hello World"}]""", target.toJson())
 
         target.edit(6, 11, "Yorkie", mapOf("b" to "1"))
         assertEquals(
-            """[{"attrs":{},"content":"Hello "},{"attrs":{"b":"1"},"content":"Yorkie"}]""",
+            """[{"attrs":{},"val":"Hello "},{"attrs":{"b":"1"},"val":"Yorkie"}]""",
             target.toJson(),
         )
     }
@@ -46,11 +46,11 @@ class JsonTextTest {
     @Test
     fun `should handle style operations`() {
         target.edit(0, 0, "Hello World")
-        assertEquals("""[{"attrs":{},"content":"Hello World"}]""", target.toJson())
+        assertEquals("""[{"attrs":{},"val":"Hello World"}]""", target.toJson())
 
         target.style(0, 1, mapOf("b" to "1"))
         assertEquals(
-            """[{"attrs":{"b":"1"},"content":"H"},{"attrs":{},"content":"ello World"}]""",
+            """[{"attrs":{"b":"1"},"val":"H"},{"attrs":{},"val":"ello World"}]""",
             target.toJson(),
         )
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Remove JSON(Text) dependency from RgaTreeSplit.

#### Any background context you want to provide?
- set `attrs` conditionally in `toJson()` method.
- fixed JSON key from `content` to `val` just like other SDKs.

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
