### PR TITLE
Fix deleteRange behavior

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeSplit.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeSplit.kt
@@ -323,7 +323,7 @@ internal class RgaTreeSplit<T : RgaTreeSplitValue<T>> : Iterable<RgaTreeSplitNod
             val rightBoundary = boundaries[index + 1]
             // If there is no node to delete between boundaries, do nothing.
             if (leftBoundary?.next != rightBoundary) {
-                treeByIndex.deleteRange(requireNotNull(leftBoundary), rightBoundary)
+                treeByIndex.cutOffRange(requireNotNull(leftBoundary), rightBoundary)
             }
         }
     }

--- a/yorkie/src/main/kotlin/dev/yorkie/util/SplayTreeSet.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/SplayTreeSet.kt
@@ -13,7 +13,8 @@ internal class SplayTreeSet<V>(
     private val lengthCalculator: LengthCalculator<V> =
         LengthCalculator.DEFAULT as LengthCalculator<V>,
 ) {
-    private val valueToNodes = mutableMapOf<V, Node<V>>()
+    @VisibleForTesting
+    internal val valueToNodes = mutableMapOf<V, Node<V>>()
 
     @VisibleForTesting
     var root: Node<V>? = null
@@ -161,15 +162,15 @@ internal class SplayTreeSet<V>(
      *
      * Boundary range are exclusive.
      */
-    fun deleteRange(leftBoundary: V, rightBoundary: V? = null) {
-        deleteRangeInternal(
+    fun cutOffRange(leftBoundary: V, rightBoundary: V? = null) {
+        cutOffRangeInternal(
             valueToNodes[leftBoundary]
                 ?: throw IllegalArgumentException("leftBoundary cannot be null"),
             valueToNodes[rightBoundary],
         )
     }
 
-    private fun deleteRangeInternal(leftBoundary: Node<V>, rightBoundary: Node<V>?) {
+    private fun cutOffRangeInternal(leftBoundary: Node<V>, rightBoundary: Node<V>?) {
         splayInternal(leftBoundary)
         if (rightBoundary == null) {
             cutOffRight(leftBoundary)
@@ -184,10 +185,7 @@ internal class SplayTreeSet<V>(
 
     private fun cutOffRight(node: Node<V>) {
         val nodesToFreeWeight = traversePostorder(node.right)
-        nodesToFreeWeight.forEach {
-            it.unlink()
-            valueToNodes.remove(it.value)
-        }
+        nodesToFreeWeight.forEach(Node<V>::initWeight)
         node.right = null
         updateTreeWeight(node)
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Changed `deleteRange` to cut off target node from the tree, as it can be later requested to be deleted on GC.
Also changed the naming to `cutOffRange` to better suit the changed behavior.


#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
