### PR TITLE
Fix invalid indexOf SplayTree with single node

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/util/SplayTreeSet.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/SplayTreeSet.kt
@@ -73,7 +73,7 @@ internal class SplayTreeSet<V>(
      */
     fun indexOf(value: V?): Int {
         val node = valueToNodes[value]
-        if (node == null || !node.hasLinks) {
+        if (node == null || node !== root && !node.hasLinks) {
             return -1
         }
         var index = 0

--- a/yorkie/src/test/kotlin/dev/yorkie/util/SplayTreeSetTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/util/SplayTreeSetTest.kt
@@ -99,6 +99,15 @@ class SplayTreeSetTest {
         assertIfRangeCutOff(nodes, 3..7)
     }
 
+    @Test
+    fun `should handle indexOf correctly with single node`() {
+        val node = Node("A")
+        target.insert(node)
+        assertEquals(0, target.indexOf(node))
+        target.delete(node)
+        assertEquals(-1, target.indexOf(node))
+    }
+
     private fun assertIfRangeCutOff(nodes: List<Node>, targetRange: IntRange) {
         assertEquals(
             0,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
from https://github.com/yorkie-team/yorkie/pull/470

> Fix invalid index of SplayTree with a single node.
> 
> This PR addresses an issue with the indexOf in SplayTree, which was failing to calculate the correct index when there was only one node in the tree. The conditional statement has been updated to account for this scenario.

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
