### PR TITLE
Improve interface for events

### DIFF
--- a/examples/kanban/src/main/java/com/example/kanbanapp/KanbanBoardViewModel.kt
+++ b/examples/kanban/src/main/java/com/example/kanbanapp/KanbanBoardViewModel.kt
@@ -31,7 +31,7 @@ class KanbanBoardViewModel(private val client: Client) : ViewModel() {
         }
 
         viewModelScope.launch {
-            client.collect {
+            client.events.collect {
                 if (it is Client.Event.DocumentSynced) {
                     try {
                         updateDocument(it.result.document.getRoot().getAs(DOCUMENT_LIST_KEY))

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -49,20 +49,20 @@ class ClientTest {
             val document2Events = mutableListOf<Document.Event>()
             val collectJobs = listOf(
                 launch(start = CoroutineStart.UNDISPATCHED) {
-                    client1.filterNot {
+                    client1.events.filterNot {
                         it is Client.Event.PeersChanged
                     }.collect(client1Events::add)
                 },
                 launch(start = CoroutineStart.UNDISPATCHED) {
-                    client2.filterNot {
+                    client2.events.filterNot {
                         it is Client.Event.PeersChanged
                     }.collect(client2Events::add)
                 },
                 launch(start = CoroutineStart.UNDISPATCHED) {
-                    document1.collect(document1Events::add)
+                    document1.events.collect(document1Events::add)
                 },
                 launch(start = CoroutineStart.UNDISPATCHED) {
-                    document2.collect(document2Events::add)
+                    document2.events.collect(document2Events::add)
                 },
             )
 

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -49,7 +49,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
@@ -587,7 +586,7 @@ public class Client @VisibleForTesting internal constructor(
 
     /**
      * Represents the type of the events that the client can emit.
-     * It can be delivered using [Client.collect].
+     * It can be delivered by [Client.events].
      */
     public interface Event {
         /**

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -68,13 +69,15 @@ import kotlin.time.Duration.Companion.milliseconds
 public class Client @VisibleForTesting internal constructor(
     private val channel: Channel,
     private val options: Options = Options(),
-    private val eventStream: MutableSharedFlow<Event> = MutableSharedFlow(),
-) : Flow<Client.Event> by eventStream {
+) {
     private val scope = CoroutineScope(
         SupervisorJob() +
             createSingleThreadDispatcher("Client(${options.key})"),
     )
     private val activationJob = SupervisorJob()
+
+    private val eventStream = MutableSharedFlow<Event>()
+    val events = eventStream.asSharedFlow()
 
     private val attachments = MutableStateFlow<Map<Document.Key, Attachment>>(emptyMap())
 

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -149,7 +149,7 @@ class ClientTest {
             target.activateAsync().await()
 
             val eventAsync = async(UnconfinedTestDispatcher()) {
-                target.take(3).toList()
+                target.events.take(3).toList()
             }
             val watchRequestCaptor = argumentCaptor<WatchDocumentsRequest>()
             target.attachAsync(document).await()
@@ -193,7 +193,7 @@ class ClientTest {
             document.updateAsync {
                 it["k1"] = 1
             }.await()
-            val syncEvent = assertIs<DocumentSynced>(target.first())
+            val syncEvent = assertIs<DocumentSynced>(target.events.first())
             val failed = assertIs<Client.DocumentSyncResult.SyncFailed>(syncEvent.result)
             assertEquals(document, failed.document)
 
@@ -345,7 +345,7 @@ class ClientTest {
         runTest {
             val document = Document(Key(NORMAL_DOCUMENT_KEY))
             val peerChangesAsync = async(UnconfinedTestDispatcher()) {
-                target.filterIsInstance<PeersChanged>().take(4).toList()
+                target.events.filterIsInstance<PeersChanged>().take(4).toList()
             }
             val peerStatusHistoryAsync = async(UnconfinedTestDispatcher()) {
                 target.peerStatus.take(5).toList()

--- a/yorkie/src/test/kotlin/dev/yorkie/document/DocumentTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/DocumentTest.kt
@@ -129,7 +129,7 @@ class DocumentTest {
         runTest {
             val events = mutableListOf<Document.Event>()
             val collectJob = launch(UnconfinedTestDispatcher()) {
-                target.collect(events::add)
+                target.events.collect(events::add)
             }
 
             assertFalse(target.hasLocalChanges)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Change Client and Document to provide event stream as a property rather than making themselves as a flow.
This is to resolve ambiguity with some of the events collecting methods such as `client.first()`.
Also, changed EditorViewModel to make use of the new peer change events.

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
