### PR TITLE
Implement pause and resume

### DIFF
--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - yorkie
   yorkie:
-    image: 'yorkieteam/yorkie:latest'
+    image: 'yorkieteam/yorkie:0.3.1'
     container_name: 'yorkie'
     command: [
       'server',

--- a/examples/texteditor/src/main/java/com/example/texteditor/EditorViewModel.kt
+++ b/examples/texteditor/src/main/java/com/example/texteditor/EditorViewModel.kt
@@ -117,6 +117,14 @@ class EditorViewModel(private val client: Client) : ViewModel(), YorkieEditText.
         _peerSelectionInfos.remove(actorID)
     }
 
+    override fun handleHangulCompositionStart() {
+        client.pause(document)
+    }
+
+    override fun handleHangulCompositionEnd() {
+        client.resume(document)
+    }
+
     override fun onCleared() {
         TerminationScope.launch {
             client.detachAsync(document).await()

--- a/examples/texteditor/src/main/java/com/example/texteditor/YorkieEditText.kt
+++ b/examples/texteditor/src/main/java/com/example/texteditor/YorkieEditText.kt
@@ -67,7 +67,7 @@ class YorkieEditText @JvmOverloads constructor(
     }
 
     private fun CharSequence.isHangulComposing(): Boolean {
-        return isNotEmpty() && last() !in hangulVowels && last() in hangulConsonants + hangulSyllables
+        return lastOrNull() !in hangulVowels && lastOrNull() in hangulConsonants + hangulSyllables
     }
 
     fun withRemoteChange(action: (EditText) -> Unit) {

--- a/examples/texteditor/src/main/java/com/example/texteditor/YorkieEditText.kt
+++ b/examples/texteditor/src/main/java/com/example/texteditor/YorkieEditText.kt
@@ -1,5 +1,6 @@
 package com.example.texteditor
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.widget.EditText
@@ -8,6 +9,7 @@ import androidx.core.text.toSpannable
 import androidx.core.widget.doAfterTextChanged
 import androidx.core.widget.doOnTextChanged
 
+@SuppressLint("ClickableViewAccessibility")
 class YorkieEditText @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -16,7 +18,20 @@ class YorkieEditText @JvmOverloads constructor(
 
     private var applyingRemoteChange = false
 
+    private var isComposing = false
+
+    private var selectionFromTextChange = false
+
+    private val hangulConsonants = '\u3131'..'\u314E'
+    private val hangulVowels = '\u314F'..'\u3163'
+    private val hangulSyllables = '\uAC00'..'\uD7AF'
+
     init {
+        setOnTouchListener { _, _ ->
+            selectionFromTextChange = false
+            false
+        }
+
         doOnTextChanged { text, start, before, count ->
             if (applyingRemoteChange) {
                 return@doOnTextChanged
@@ -25,6 +40,8 @@ class YorkieEditText @JvmOverloads constructor(
                 start,
                 (start + count),
             )?.toSpannable() ?: return@doOnTextChanged
+
+            handleHangulComposition(spannable)
 
             textEventHandler?.handleEditEvent(
                 start,
@@ -35,7 +52,22 @@ class YorkieEditText @JvmOverloads constructor(
 
         doAfterTextChanged {
             applyingRemoteChange = false
+            selectionFromTextChange = true
         }
+    }
+
+    private fun handleHangulComposition(content: CharSequence) {
+        if (!isComposing && content.isHangulComposing()) {
+            isComposing = true
+            textEventHandler?.handleHangulCompositionStart()
+        } else if (isComposing && !content.isHangulComposing()) {
+            isComposing = false
+            textEventHandler?.handleHangulCompositionEnd()
+        }
+    }
+
+    private fun CharSequence.isHangulComposing(): Boolean {
+        return isNotEmpty() && last() !in hangulVowels && last() in hangulConsonants + hangulSyllables
     }
 
     fun withRemoteChange(action: (EditText) -> Unit) {
@@ -44,6 +76,10 @@ class YorkieEditText @JvmOverloads constructor(
     }
 
     override fun onSelectionChanged(selStart: Int, selEnd: Int) {
+        if (selectionFromTextChange) {
+            selectionFromTextChange = false
+            return
+        }
         textEventHandler?.handleSelectEvent(selStart, selEnd)
         super.onSelectionChanged(selStart, selEnd)
     }
@@ -53,5 +89,9 @@ class YorkieEditText @JvmOverloads constructor(
         fun handleEditEvent(from: Int, to: Int, content: CharSequence)
 
         fun handleSelectEvent(from: Int, to: Int)
+
+        fun handleHangulCompositionStart()
+
+        fun handleHangulCompositionEnd()
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
@@ -4,9 +4,9 @@ import dev.yorkie.document.Document
 
 internal data class Attachment(
     val document: Document,
-    var isRealTimeSync: Boolean,
+    val isRealTimeSync: Boolean,
     val peerPresences: Peers = UninitializedPresences,
-    var remoteChangeEventReceived: Boolean = false,
+    val remoteChangeEventReceived: Boolean = false,
 ) {
 
     companion object {

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
@@ -4,7 +4,7 @@ import dev.yorkie.document.Document
 
 internal data class Attachment(
     val document: Document,
-    val isRealTimeSync: Boolean,
+    var isRealTimeSync: Boolean,
     val peerPresences: Peers = UninitializedPresences,
     var remoteChangeEventReceived: Boolean = false,
 ) {

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -297,7 +297,9 @@ public class Client @VisibleForTesting internal constructor(
                 emitPeerStatus()
             }
             DocEventType.DOC_EVENT_TYPE_DOCUMENTS_CHANGED -> {
-                attachments.value += documentKey to attachment.copy(remoteChangeEventReceived = true)
+                attachments.value += documentKey to attachment.copy(
+                    remoteChangeEventReceived = true,
+                )
                 eventStream.emit(Event.DocumentsChanged(listOf(documentKey)))
             }
             DocEventType.DOC_EVENT_TYPE_PRESENCE_CHANGED -> {

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -377,7 +377,7 @@ public class Client @VisibleForTesting internal constructor(
      */
     public fun attachAsync(
         document: Document,
-        isManualSync: Boolean = false,
+        isRealSync: Boolean = true,
     ): Deferred<Boolean> {
         return scope.async {
             require(isActive) {
@@ -397,7 +397,7 @@ public class Client @VisibleForTesting internal constructor(
             }
             val pack = response.changePack.toChangePack()
             document.applyChangePack(pack)
-            attachments.value += document.key to Attachment(document, !isManualSync)
+            attachments.value += document.key to Attachment(document, isRealSync)
             waitForInitialization(document.key)
             true
         }
@@ -467,6 +467,27 @@ public class Client @VisibleForTesting internal constructor(
                 this == null || !isRealTimeSync || peerPresences != UninitializedPresences
             }
         }
+    }
+
+    /**
+     * Pauses the realtime synchronization of the given [document].
+     */
+    public fun pause(document: Document) {
+        changeRealTimeSetting(document, false)
+    }
+
+    /**
+     * Resumes the realtime synchronization of the given [document].
+     */
+    public fun resume(document: Document) {
+        changeRealTimeSetting(document, true)
+    }
+
+    private fun changeRealTimeSetting(document: Document, isRealTimeSync: Boolean) {
+        require(isActive) {
+            "client is not active"
+        }
+        attachments.value[document.key]?.isRealTimeSync = isRealTimeSync
     }
 
     private data class SyncResult(val document: Document, val result: Result<Unit>)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- Implement the pause and resume functions.
- Pause the real time sync when the Hangul composition starts, and resume when it ends
- Detect the Hangul composition by using Unicode [Hangul Jamo](https://en.wiktionary.org/wiki/Appendix:Unicode/Hangul_Compatibility_Jamo) and [Syllables](https://en.wiktionary.org/wiki/Appendix:Unicode/Hangul_Syllables).

#### Any background context you want to provide?
implemented based on the [iOS SDK implementation](https://github.com/yorkie-team/yorkie-ios-sdk/pull/62).

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
