### PR TITLE
Add RemoveDocument API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
+/.idea/deploymentTargetDropDown.xml
 .DS_Store
 /build
 build/

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Read the [full documentation](https://yorkie.dev/docs) for all details.
 
 ## Developing the SDK
 
+To work on this project, make sure you have Android Studio version `Electric Eel | 2022.1.1` or later installed.
+
 For developers with MAC, you should add `protoc_platform=osx-x86_64` to your `local.properties`.
 
 ## Testing yorkie-android-sdk with Envoy, Yorkie and MongoDB.

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - yorkie
   yorkie:
-    image: 'yorkieteam/yorkie:0.3.1'
+    image: 'yorkieteam/yorkie:latest'
     container_name: 'yorkie'
     command: [
       'server',

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - yorkie
   yorkie:
-    image: 'yorkieteam/yorkie:latest'
+    image: 'yorkieteam/yorkie:0.3.1'
     container_name: 'yorkie'
     command: [
       'server',

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     # If you're using Mac or Windows, this special domain name("host.docker.internal" which makes containers able to connect to the host)
     # is supported by default.
     # But if you're using Linux and want an envoy container to communicate with the host,
-    # it may help to define "host.docker.internal" in extra_hosts. 
+    # it may help to define "host.docker.internal" in extra_hosts.
     # (Actually, other hostnames are available, but in that case you should update clusters[].host configurations of envoy.yaml)
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/examples/kanban/src/main/java/com/example/kanbanapp/KanbanBoardViewModel.kt
+++ b/examples/kanban/src/main/java/com/example/kanbanapp/KanbanBoardViewModel.kt
@@ -24,8 +24,7 @@ class KanbanBoardViewModel(private val client: Client) : ViewModel() {
 
     init {
         viewModelScope.launch {
-            if (client.activateAsync().await()) {
-                client.attachAsync(document).await()
+            if (client.activateAsync().await() && client.attachAsync(document).await()) {
                 client.syncAsync().await()
             }
         }

--- a/examples/texteditor/src/main/java/com/example/texteditor/EditorViewModel.kt
+++ b/examples/texteditor/src/main/java/com/example/texteditor/EditorViewModel.kt
@@ -53,8 +53,7 @@ class EditorViewModel(private val client: Client) : ViewModel(), YorkieEditText.
 
     init {
         viewModelScope.launch {
-            if (client.activateAsync().await()) {
-                client.attachAsync(document).await()
+            if (client.activateAsync().await() && client.attachAsync(document).await()) {
                 document.getRoot().getAsOrNull<JsonText>(TEXT_KEY)
                     ?.onChanges(remoteChangeEventHandler)
                     ?: run {

--- a/yorkie/proto/src/main/proto/yorkie/v1/resources.proto
+++ b/yorkie/proto/src/main/proto/yorkie/v1/resources.proto
@@ -250,10 +250,6 @@ message Client {
   Presence presence = 2;
 }
 
-message Clients {
-  repeated Client clients = 1;
-}
-
 message Checkpoint {
   int64 server_seq = 1 [jstype = JS_STRING];
   uint32 client_seq = 2;
@@ -297,5 +293,5 @@ enum DocEventType {
 message DocEvent {
   DocEventType type = 1;
   Client publisher = 2;
-  repeated string document_keys = 3;
+  string document_id = 3;
 }

--- a/yorkie/proto/src/main/proto/yorkie/v1/resources.proto
+++ b/yorkie/proto/src/main/proto/yorkie/v1/resources.proto
@@ -29,12 +29,15 @@ option java_package = "dev.yorkie.api.v1";
 // Messages for ChangePack             //
 /////////////////////////////////////////
 
+// ChangePack is a message that contains all changes that occurred in a document.
+// It is used to synchronize changes between clients and servers.
 message ChangePack {
   string document_key = 1;
   Checkpoint checkpoint = 2;
   bytes snapshot = 3;
   repeated Change changes = 4;
   TimeTicket min_synced_ticket = 5;
+  bool is_removed = 6;
 }
 
 message Change {

--- a/yorkie/proto/src/main/proto/yorkie/v1/yorkie.proto
+++ b/yorkie/proto/src/main/proto/yorkie/v1/yorkie.proto
@@ -26,82 +26,98 @@ option java_package = "dev.yorkie.api.v1";
 
 // Yorkie is a service that provides a API for SDKs.
 service YorkieService {
-    rpc ActivateClient (ActivateClientRequest) returns (ActivateClientResponse) {}
-    rpc DeactivateClient (DeactivateClientRequest) returns (DeactivateClientResponse) {}
-    rpc UpdatePresence (UpdatePresenceRequest) returns (UpdatePresenceResponse) {}
+  rpc ActivateClient (ActivateClientRequest) returns (ActivateClientResponse) {}
+  rpc DeactivateClient (DeactivateClientRequest) returns (DeactivateClientResponse) {}
+  rpc UpdatePresence (UpdatePresenceRequest) returns (UpdatePresenceResponse) {}
 
-    rpc AttachDocument (AttachDocumentRequest) returns (AttachDocumentResponse) {}
-    rpc DetachDocument (DetachDocumentRequest) returns (DetachDocumentResponse) {}
-    rpc WatchDocuments (WatchDocumentsRequest) returns (stream WatchDocumentsResponse) {}
-    rpc PushPull (PushPullRequest) returns (PushPullResponse) {}
+  rpc AttachDocument (AttachDocumentRequest) returns (AttachDocumentResponse) {}
+  rpc DetachDocument (DetachDocumentRequest) returns (DetachDocumentResponse) {}
+  rpc RemoveDocument (RemoveDocumentRequest) returns (RemoveDocumentResponse) {}
+  rpc PushPullChanges (PushPullChangesRequest) returns (PushPullChangesResponse) {}
+
+  rpc WatchDocuments (WatchDocumentsRequest) returns (stream WatchDocumentsResponse) {}
 }
 
 message ActivateClientRequest {
-    string client_key = 1;
+  string client_key = 1;
 }
 
 message ActivateClientResponse {
-    string client_key = 1;
-    bytes client_id = 2;
+  string client_key = 1;
+  bytes client_id = 2;
 }
 
 message DeactivateClientRequest {
-    bytes client_id = 1;
+  bytes client_id = 1;
 }
 
 message DeactivateClientResponse {
-    bytes client_id = 1;
+  bytes client_id = 1;
 }
 
 message AttachDocumentRequest {
-    bytes client_id = 1;
-    ChangePack change_pack = 2;
+  bytes client_id = 1;
+  ChangePack change_pack = 2;
 }
 
 message AttachDocumentResponse {
-    bytes client_id = 1;
-    ChangePack change_pack = 2;
+  bytes client_id = 1;
+  string document_id = 2;
+  ChangePack change_pack = 3;
 }
 
 message DetachDocumentRequest {
-    bytes client_id = 1;
-    ChangePack change_pack = 2;
+  bytes client_id = 1;
+  string document_id = 2;
+  ChangePack change_pack = 3;
 }
 
 message DetachDocumentResponse {
-    string client_key = 1;
-    ChangePack change_pack = 2;
+  string client_key = 1;
+  ChangePack change_pack = 2;
 }
 
 message WatchDocumentsRequest {
-    Client client = 1;
-    repeated string document_keys = 2;
+  Client client = 1;
+  repeated string document_keys = 2;
 }
 
 message WatchDocumentsResponse {
-    message Initialization {
-        map<string, Clients> peers_map_by_doc = 1;
-    }
+  message Initialization {
+    map<string, Clients> peers_map_by_doc = 1;
+  }
 
-    oneof body {
-        Initialization initialization = 1;
-        DocEvent event = 2;
-    }
+  oneof body {
+    Initialization initialization = 1;
+    DocEvent event = 2;
+  }
 }
 
-message PushPullRequest {
-    bytes client_id = 1;
-    ChangePack change_pack = 2;
+message RemoveDocumentRequest {
+  bytes client_id = 1;
+  string document_id = 2;
+  ChangePack change_pack = 3;
 }
 
-message PushPullResponse {
-    bytes client_id = 1;
-    ChangePack change_pack = 2;
+message RemoveDocumentResponse {
+  string client_key = 1;
+  ChangePack change_pack = 2;
+}
+
+message PushPullChangesRequest {
+  bytes client_id = 1;
+  string document_id = 2;
+  ChangePack change_pack = 3;
+}
+
+message PushPullChangesResponse {
+  bytes client_id = 1;
+  ChangePack change_pack = 2;
 }
 
 message UpdatePresenceRequest {
-    Client client = 1;
-    repeated string document_keys = 2;
+  Client client = 1;
+  repeated string document_keys = 2;
 }
 
 message UpdatePresenceResponse {}

--- a/yorkie/proto/src/main/proto/yorkie/v1/yorkie.proto
+++ b/yorkie/proto/src/main/proto/yorkie/v1/yorkie.proto
@@ -35,7 +35,7 @@ service YorkieService {
   rpc RemoveDocument (RemoveDocumentRequest) returns (RemoveDocumentResponse) {}
   rpc PushPullChanges (PushPullChangesRequest) returns (PushPullChangesResponse) {}
 
-  rpc WatchDocuments (WatchDocumentsRequest) returns (stream WatchDocumentsResponse) {}
+  rpc WatchDocument (WatchDocumentRequest) returns (stream WatchDocumentResponse) {}
 }
 
 message ActivateClientRequest {
@@ -77,14 +77,14 @@ message DetachDocumentResponse {
   ChangePack change_pack = 2;
 }
 
-message WatchDocumentsRequest {
+message WatchDocumentRequest {
   Client client = 1;
-  repeated string document_keys = 2;
+  string document_id = 2;
 }
 
-message WatchDocumentsResponse {
+message WatchDocumentResponse {
   message Initialization {
-    map<string, Clients> peers_map_by_doc = 1;
+    repeated Client peers = 1;
   }
 
   oneof body {
@@ -117,7 +117,7 @@ message PushPullChangesResponse {
 
 message UpdatePresenceRequest {
   Client client = 1;
-  repeated string document_keys = 2;
+  string document_id = 2;
 }
 
 message UpdatePresenceResponse {}

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -182,7 +182,7 @@ class ClientTest {
 
     @Test
     fun test_peer_presence_consistency() {
-        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+        withTwoClientsAndDocuments { client1, client2, _, _, key ->
             client1.updatePresenceAsync("name", "A").await()
             client2.updatePresenceAsync("name", "B").await()
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -1,7 +1,6 @@
 package dev.yorkie.core
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
 import dev.yorkie.core.Client.DocumentSyncResult
 import dev.yorkie.core.Client.Event.DocumentSynced
 import dev.yorkie.core.Client.Event.DocumentsChanged

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
@@ -1,0 +1,151 @@
+package dev.yorkie.core
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.yorkie.document.Document
+import dev.yorkie.document.Document.DocumentStatus
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class DocumentTest {
+
+    @Test
+    fun test_single_client_deleting_document() {
+        runBlocking {
+            val client = createClient()
+            val documentKey = UUID.randomUUID().toString().toDocKey()
+            val document = Document(documentKey)
+
+            // 01. client is not activated.
+            assertThrows(IllegalArgumentException::class.java) {
+                runBlocking {
+                    client.removeAsync(document).await()
+                }
+            }
+
+            // 02. document is not attached.
+            client.activateAsync().await()
+            assertFalse(client.removeAsync(document).await())
+
+            // 03. document is attached.
+            client.attachAsync(document).await()
+            client.removeAsync(document).await()
+            assertEquals(DocumentStatus.Removed, document.status)
+
+            // 04. try to update a removed document.
+            assertFalse(document.updateAsync { it["key"] = 0 }.await())
+
+            // 05. try to attach a removed document.
+            assertFalse(client.attachAsync(document).await())
+
+            client.detachAsync(document).await()
+            client.deactivateAsync().await()
+        }
+    }
+
+    @Test
+    fun test_creating_document_with_removed_document_key() {
+        withTwoClientsAndDocuments { client1, _, document1, document2, key ->
+            document1.updateAsync { it["key"] = 1 }.await()
+            assertTrue(client1.removeAsync(document1).await())
+
+            val document3 = Document(key)
+            client1.attachAsync(document3).await()
+
+            val doc2Content = document2.toJson()
+            val doc3Content = document3.toJson()
+            assertEquals(doc2Content, doc3Content)
+        }
+    }
+
+    @Test
+    fun test_removed_document_push_and_pull() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, _ ->
+            document1.updateAsync { it["key"] = 1 }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document1.updateAsync { it["key"] = 2 }.await()
+            client1.removeAsync(document1).await()
+
+            client2.syncAsync().await()
+            assertEquals(document1.status, document2.status)
+        }
+    }
+
+    @Test
+    fun test_removed_document_detachment() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, _ ->
+            document1.updateAsync { it["key"] = 1 }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            client1.removeAsync(document1).await()
+            client2.detachAsync(document2).await()
+            assertEquals(DocumentStatus.Removed, document1.status)
+            assertEquals(DocumentStatus.Removed, document2.status)
+        }
+    }
+
+    @Test
+    fun test_removing_already_removed_document() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, _ ->
+            document1.updateAsync { it["key"] = 1 }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            client1.removeAsync(document1).await()
+            client2.removeAsync(document2).await()
+            assertEquals(DocumentStatus.Removed, document1.status)
+            assertEquals(DocumentStatus.Removed, document2.status)
+        }
+    }
+
+    // State transition of document
+    // ┌──────────┐ Attach ┌──────────┐ Remove ┌─────────┐
+    // │ Detached ├───────►│ Attached ├───────►│ Removed │
+    // └──────────┘        └─┬─┬──────┘        └─────────┘
+    //           ▲           │ │     ▲
+    //           └───────────┘ └─────┘
+    //              Detach     PushPull
+    @Test
+    fun test_document_state_transition() {
+        runBlocking {
+            val client = createClient()
+            val documentKey = UUID.randomUUID().toString().toDocKey()
+            val document = Document(documentKey)
+
+            client.activateAsync().await()
+
+            // 01. abnormal behavior on detached state
+            assertFalse(client.detachAsync(document).await())
+            assertFalse(client.syncAsync().await())
+            assertFalse(client.removeAsync(document).await())
+
+            // 02. abnormal behavior on attached state
+            client.attachAsync(document).await()
+            assertFalse(client.attachAsync(document).await())
+
+            // 03. abnormal behavior on removed state
+            client.removeAsync(document).await()
+            assertFalse(client.removeAsync(document).await())
+            assertFalse(client.syncAsync().await())
+            assertFalse(client.detachAsync(document).await())
+
+            client.detachAsync(document).await()
+            client.deactivateAsync().await()
+        }
+    }
+}

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
@@ -4,11 +4,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import dev.yorkie.document.Document
 import dev.yorkie.document.Document.DocumentStatus
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -23,15 +23,15 @@ class DocumentTest {
             val document = Document(documentKey)
 
             // 01. client is not activated.
-            assertThrows(IllegalArgumentException::class.java) {
-                runBlocking {
-                    client.removeAsync(document).await()
-                }
+            assertFailsWith(IllegalArgumentException::class) {
+                client.removeAsync(document).await()
             }
 
             // 02. document is not attached.
             client.activateAsync().await()
-            assertFalse(client.removeAsync(document).await())
+            assertFailsWith(IllegalArgumentException::class) {
+                client.removeAsync(document).await()
+            }
 
             // 03. document is attached.
             client.attachAsync(document).await()
@@ -39,10 +39,14 @@ class DocumentTest {
             assertEquals(DocumentStatus.Removed, document.status)
 
             // 04. try to update a removed document.
-            assertFalse(document.updateAsync { it["key"] = 0 }.await())
+            assertFailsWith(IllegalArgumentException::class) {
+                document.updateAsync { it["key"] = 0 }.await()
+            }
 
             // 05. try to attach a removed document.
-            assertFalse(client.attachAsync(document).await())
+            assertFailsWith(IllegalArgumentException::class) {
+                client.attachAsync(document).await()
+            }
 
             client.detachAsync(document).await()
             client.deactivateAsync().await()
@@ -130,19 +134,29 @@ class DocumentTest {
             client.activateAsync().await()
 
             // 01. abnormal behavior on detached state
-            assertFalse(client.detachAsync(document).await())
+            assertFailsWith(IllegalArgumentException::class) {
+                client.detachAsync(document).await()
+            }
             assertFalse(client.syncAsync().await())
-            assertFalse(client.removeAsync(document).await())
+            assertFailsWith(IllegalArgumentException::class) {
+                client.removeAsync(document).await()
+            }
 
             // 02. abnormal behavior on attached state
             client.attachAsync(document).await()
-            assertFalse(client.attachAsync(document).await())
+            assertFailsWith(IllegalArgumentException::class) {
+                client.attachAsync(document).await()
+            }
 
             // 03. abnormal behavior on removed state
             client.removeAsync(document).await()
-            assertFalse(client.removeAsync(document).await())
+            assertFailsWith(IllegalArgumentException::class) {
+                client.removeAsync(document).await()
+            }
             assertFalse(client.syncAsync().await())
-            assertFalse(client.detachAsync(document).await())
+            assertFailsWith(IllegalArgumentException::class) {
+                client.detachAsync(document).await()
+            }
 
             client.detachAsync(document).await()
             client.deactivateAsync().await()

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
@@ -20,7 +20,9 @@ fun String.toDocKey(): Document.Key {
     )
 }
 
-fun withTwoClientsAndDocuments(callback: suspend CoroutineScope.(Client, Client, Document, Document, Document.Key) -> Unit) {
+fun withTwoClientsAndDocuments(
+    callback: suspend CoroutineScope.(Client, Client, Document, Document, Document.Key) -> Unit,
+) {
     runBlocking {
         val client1 = createClient()
         val client2 = createClient()

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
@@ -21,6 +21,7 @@ fun String.toDocKey(): Document.Key {
 }
 
 fun withTwoClientsAndDocuments(
+    detachDocuments: Boolean = true,
     callback: suspend CoroutineScope.(Client, Client, Document, Document, Document.Key) -> Unit,
 ) {
     runBlocking {
@@ -38,8 +39,10 @@ fun withTwoClientsAndDocuments(
 
         callback.invoke(this, client1, client2, document1, document2, documentKey)
 
-        client1.detachAsync(document1).await()
-        client2.detachAsync(document2).await()
+        if (detachDocuments) {
+            client1.detachAsync(document1).await()
+            client2.detachAsync(document2).await()
+        }
         client1.deactivateAsync().await()
         client2.deactivateAsync().await()
     }

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
@@ -1,0 +1,44 @@
+package dev.yorkie.core
+
+import androidx.test.platform.app.InstrumentationRegistry
+import dev.yorkie.document.Document
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
+import java.util.UUID
+
+fun createClient() = Client(
+    InstrumentationRegistry.getInstrumentation().targetContext,
+    "10.0.2.2",
+    8080,
+    usePlainText = true,
+)
+
+fun String.toDocKey(): Document.Key {
+    return Document.Key(
+        lowercase().replace("[^a-z\\d-]".toRegex(), "-")
+            .substring(0, length.coerceAtMost(120)),
+    )
+}
+
+fun withTwoClientsAndDocuments(callback: suspend CoroutineScope.(Client, Client, Document, Document, Document.Key) -> Unit) {
+    runBlocking {
+        val client1 = createClient()
+        val client2 = createClient()
+        val documentKey = UUID.randomUUID().toString().toDocKey()
+        val document1 = Document(documentKey)
+        val document2 = Document(documentKey)
+
+        client1.activateAsync().await()
+        client2.activateAsync().await()
+
+        client1.attachAsync(document1).await()
+        client2.attachAsync(document2).await()
+
+        callback.invoke(this, client1, client2, document1, document2, documentKey)
+
+        client1.detachAsync(document1).await()
+        client2.detachAsync(document2).await()
+        client1.deactivateAsync().await()
+        client2.deactivateAsync().await()
+    }
+}

--- a/yorkie/src/main/kotlin/dev/yorkie/api/ChangeConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/ChangeConverter.kt
@@ -75,6 +75,7 @@ internal fun PBChangePack.toChangePack(): ChangePack {
         changes = changesList.toChanges(),
         snapshot = snapshot.takeUnless { it.isEmpty },
         minSyncedTicket = minSyncedTicketOrNull?.toTimeTicket(),
+        isRemoved = isRemoved,
     )
 }
 
@@ -90,5 +91,6 @@ internal fun ChangePack.toPBChangePack(): PBChangePack {
         } else {
             clearMinSyncedTicket()
         }
+        isRemoved = changePack.isRemoved
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
@@ -4,6 +4,7 @@ import dev.yorkie.document.Document
 
 internal data class Attachment(
     val document: Document,
+    val documentID: String,
     val isRealTimeSync: Boolean,
     val peerPresences: Peers = UninitializedPresences,
     var remoteChangeEventReceived: Boolean = false,

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -413,7 +413,7 @@ public class Client @VisibleForTesting internal constructor(
                 return@async true
             }
 
-            document.setStatus(DocumentStatus.Attached)
+            document.status = DocumentStatus.Attached
             attachments.value += document.key to Attachment(
                 document,
                 response.documentId,
@@ -455,7 +455,7 @@ public class Client @VisibleForTesting internal constructor(
             val pack = response.changePack.toChangePack()
             document.applyChangePack(pack)
             if (document.status != DocumentStatus.Removed) {
-                document.setStatus(DocumentStatus.Detached)
+                document.status = DocumentStatus.Detached
             }
             attachments.value -= document.key
             true
@@ -501,7 +501,6 @@ public class Client @VisibleForTesting internal constructor(
                 return@async false
             }
 
-            document.setStatus(DocumentStatus.Removed)
             val request = removeDocumentRequest {
                 clientId = requireClientId().toByteString()
                 changePack = document.createChangePack().toPBChangePack()

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -390,9 +390,8 @@ public class Client @VisibleForTesting internal constructor(
             require(isActive) {
                 "client is not active"
             }
-            if (document.status != DocumentStatus.Detached) {
-                YorkieLogger.e("Client.attach", "document is not detached")
-                return@async false
+            require(document.status == DocumentStatus.Detached) {
+                "document is not detached"
             }
             document.setActor(requireClientId())
 
@@ -437,10 +436,8 @@ public class Client @VisibleForTesting internal constructor(
             require(isActive) {
                 "client is not active"
             }
-            val attachment = attachments.value[document.key] ?: run {
-                YorkieLogger.e("Client.detach", "document is not attached")
-                return@async false
-            }
+            val attachment = attachments.value[document.key]
+                ?: throw IllegalArgumentException("document is not attached")
             val request = detachDocumentRequest {
                 clientId = requireClientId().toByteString()
                 changePack = document.createChangePack().toPBChangePack()
@@ -496,10 +493,8 @@ public class Client @VisibleForTesting internal constructor(
             require(isActive) {
                 "client is not active"
             }
-            val attachment = attachments.value[document.key] ?: run {
-                YorkieLogger.e("Client.remove", "document is not attached")
-                return@async false
-            }
+            val attachment = attachments.value[document.key]
+                ?: throw IllegalArgumentException("document is not attached")
 
             val request = removeDocumentRequest {
                 clientId = requireClientId().toByteString()

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -390,7 +390,7 @@ public class Client @VisibleForTesting internal constructor(
             require(isActive) {
                 "client is not active"
             }
-            if (document.status == DocumentStatus.Detached) {
+            if (document.status != DocumentStatus.Detached) {
                 YorkieLogger.e("Client.attach", "document is not detached")
                 return@async false
             }

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -9,7 +9,7 @@ import dev.yorkie.api.toPBChangePack
 import dev.yorkie.api.toPBClient
 import dev.yorkie.api.toPresence
 import dev.yorkie.api.v1.DocEventType
-import dev.yorkie.api.v1.WatchDocumentsResponse
+import dev.yorkie.api.v1.WatchDocumentResponse
 import dev.yorkie.api.v1.YorkieServiceGrpcKt
 import dev.yorkie.api.v1.activateClientRequest
 import dev.yorkie.api.v1.attachDocumentRequest
@@ -18,7 +18,7 @@ import dev.yorkie.api.v1.detachDocumentRequest
 import dev.yorkie.api.v1.pushPullChangesRequest
 import dev.yorkie.api.v1.removeDocumentRequest
 import dev.yorkie.api.v1.updatePresenceRequest
-import dev.yorkie.api.v1.watchDocumentsRequest
+import dev.yorkie.api.v1.watchDocumentRequest
 import dev.yorkie.core.Attachment.Companion.UninitializedPresences
 import dev.yorkie.core.Client.DocumentSyncResult.SyncFailed
 import dev.yorkie.core.Client.DocumentSyncResult.Synced
@@ -40,7 +40,7 @@ import io.grpc.StatusException
 import io.grpc.android.AndroidChannelBuilder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelChildren
@@ -51,13 +51,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.retry
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
 import java.util.UUID
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -179,10 +178,15 @@ public class Client @VisibleForTesting internal constructor(
      * Pushes local changes of the attached documents to the server and
      * receives changes of the remote replica from the server then apply them to local documents.
      */
-    public fun syncAsync(): Deferred<Boolean> {
+    public fun syncAsync(document: Document? = null): Deferred<Boolean> {
         return scope.async {
             var isAllSuccess = true
-            val attachments: List<Attachment> = attachments.value.values.toList()
+            val attachments = document?.let {
+                listOf(
+                    attachments.value[it.key]
+                        ?: throw IllegalArgumentException("document is not attached"),
+                )
+            } ?: attachments.value.values
             attachments.asSyncFlow().collect { (document, result) ->
                 eventStream.emit(
                     if (result.isSuccess) {
@@ -197,7 +201,7 @@ public class Client @VisibleForTesting internal constructor(
         }
     }
 
-    private suspend fun List<Attachment>.asSyncFlow(): Flow<SyncResult> {
+    private suspend fun Collection<Attachment>.asSyncFlow(): Flow<SyncResult> {
         return asFlow()
             .map { attachment ->
                 val document = attachment.document
@@ -220,52 +224,70 @@ public class Client @VisibleForTesting internal constructor(
             }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     private fun runWatchLoop() {
         scope.launch(activationJob) {
-            attachments.map { it.filterValues { attachment -> attachment.isRealTimeSync } }
-                .map { it.keys }
-                .distinctUntilChanged()
-                .map {
-                    if (it.isNotEmpty()) {
-                        watchDocumentsRequest {
-                            client = toPBClient()
-                            documentKeys.addAll(it.map(Document.Key::value))
-                        }
+            attachments.map {
+                it.filterValues(Attachment::isRealTimeSync)
+            }.fold(emptyMap<Document.Key, WatchJobHolder>()) { accumulator, attachments ->
+                (accumulator.keys - attachments.keys).forEach {
+                    accumulator.getValue(it).job.cancel()
+                }
+                attachments.entries.associate { (key, attachment) ->
+                    val previous = accumulator[key]
+                    key to if (previous?.documentID == attachment.documentID &&
+                        previous.job.isActive
+                    ) {
+                        previous
                     } else {
-                        null
+                        previous?.job?.cancel()
+                        WatchJobHolder(attachment.documentID, createWatchJob(attachment))
                     }
-                }.flatMapLatest {
-                    it?.let(service::watchDocuments) ?: emptyFlow()
-                }.retry {
+                }
+            }
+        }
+    }
+
+    private suspend fun createWatchJob(attachment: Attachment): Job {
+        return supervisorScope {
+            launch {
+                service.watchDocument(
+                    watchDocumentRequest {
+                        client = toPBClient()
+                        documentId = attachment.documentID
+                    },
+                ).retry {
                     _streamConnectionStatus.emit(StreamConnectionStatus.Disconnected)
                     delay(options.reconnectStreamDelay.inWholeMilliseconds)
                     true
                 }.collect {
                     _streamConnectionStatus.emit(StreamConnectionStatus.Connected)
-                    handleWatchDocumentsResponse(it)
+                    handleWatchDocumentsResponse(attachment.document.key, it)
                 }
+            }
         }
     }
 
-    private suspend fun handleWatchDocumentsResponse(response: WatchDocumentsResponse) {
+    private suspend fun handleWatchDocumentsResponse(
+        documentKey: Document.Key,
+        response: WatchDocumentResponse,
+    ) {
         if (response.hasInitialization()) {
-            response.initialization.peersMapByDocMap.forEach { (documentKey, pbPeers) ->
-                val key = Document.Key(documentKey)
-                val attachment = attachments.value[key] ?: return@forEach
-                if (attachment.peerPresences == UninitializedPresences) {
-                    attachments.value += key to attachment.copy(peerPresences = Peers())
-                }
-                val peers = pbPeers.clientsList.associate { peer ->
-                    peer.id.toActorID() to peer.presence.toPresence()
-                }.asPeers()
-                val newAttachment = attachments.value
-                    .getValue(key)
-                    .copy(peerPresences = peers)
-                attachments.value += key to newAttachment
+            val pbPeers = response.initialization.peersList
+            val attachment = attachments.value[documentKey] ?: return
+            if (attachment.peerPresences == UninitializedPresences) {
+                attachments.value += documentKey to attachment.copy(peerPresences = Peers())
             }
-            val changedPeers = response.initialization.peersMapByDocMap.keys.map(Document::Key)
-                .associateWith { attachments.value[it]?.peerPresences.orEmpty().asPeers() }
+            val peers = pbPeers.associate { peer ->
+                peer.id.toActorID() to peer.presence.toPresence()
+            }.asPeers()
+            val newAttachment = attachments.value
+                .getValue(documentKey)
+                .copy(peerPresences = peers)
+            attachments.value += documentKey to newAttachment
+
+            val changedPeers = mapOf(
+                documentKey to attachments.value[documentKey]?.peerPresences.orEmpty().asPeers(),
+            )
             eventStream.emit(PeersChanged(Initialized(changedPeers)))
             emitPeerStatus()
             return
@@ -273,7 +295,6 @@ public class Client @VisibleForTesting internal constructor(
         val watchEvent = response.event
         val eventType = checkNotNull(watchEvent.type)
         // only single key will be received since 0.3.1 server.
-        val documentKey = watchEvent.documentKeysList.firstOrNull()?.let(Document::Key) ?: return
         val attachment = attachments.value[documentKey] ?: return
         val publisher = watchEvent.publisher.id.toActorID()
         val presence = watchEvent.publisher.presence.toPresence()
@@ -354,28 +375,24 @@ public class Client @VisibleForTesting internal constructor(
                 data = presenceInfo.data + (key to value),
             )
 
-            val documentKeys = realTimeAttachments().map { (key, attachment) ->
-                val newPeers = attachment.peerPresences + (requireClientId() to presenceInfo)
-                attachments.value += key to attachment.copy(peerPresences = newPeers)
-                key.value
-            }.takeIf {
-                it.isNotEmpty()
-            } ?: return@async true
-
+            realTimeAttachments().takeUnless { it.isEmpty() }
+                ?.forEach { (key, attachment) ->
+                    try {
+                        service.updatePresence(
+                            updatePresenceRequest {
+                                client = toPBClient()
+                                documentId = attachment.documentID
+                            },
+                        )
+                    } catch (e: StatusException) {
+                        YorkieLogger.e("Client.updatePresence", e.stackTraceToString())
+                        return@async false
+                    }
+                    val newPeers = attachment.peerPresences + (requireClientId() to presenceInfo)
+                    attachments.value += key to attachment.copy(peerPresences = newPeers)
+                } ?: return@async true
             emitPeerStatus()
-
-            try {
-                service.updatePresence(
-                    updatePresenceRequest {
-                        client = toPBClient()
-                        this.documentKeys.addAll(documentKeys)
-                    },
-                )
-                true
-            } catch (e: StatusException) {
-                YorkieLogger.e("Client.updatePresence", e.stackTraceToString())
-                false
-            }
+            true
         }
     }
 
@@ -385,7 +402,7 @@ public class Client @VisibleForTesting internal constructor(
      */
     public fun attachAsync(
         document: Document,
-        isRealSync: Boolean = true,
+        isRealTimeSync: Boolean = true,
     ): Deferred<Boolean> {
         return scope.async {
             require(isActive) {
@@ -417,7 +434,7 @@ public class Client @VisibleForTesting internal constructor(
             attachments.value += document.key to Attachment(
                 document,
                 response.documentId,
-                isRealSync,
+                isRealTimeSync,
             )
             waitForInitialization(document.key)
             true
@@ -454,8 +471,8 @@ public class Client @VisibleForTesting internal constructor(
             document.applyChangePack(pack)
             if (document.status != DocumentStatus.Removed) {
                 document.status = DocumentStatus.Detached
+                attachments.value -= document.key
             }
-            attachments.value -= document.key
             true
         }
     }
@@ -499,7 +516,7 @@ public class Client @VisibleForTesting internal constructor(
 
             val request = removeDocumentRequest {
                 clientId = requireClientId().toByteString()
-                changePack = document.createChangePack().toPBChangePack()
+                changePack = document.createChangePack(forceRemove = true).toPBChangePack()
                 documentId = attachment.documentID
             }
             val response = try {
@@ -529,17 +546,17 @@ public class Client @VisibleForTesting internal constructor(
      * Pauses the realtime synchronization of the given [document].
      */
     public fun pause(document: Document) {
-        changeRealTimeSetting(document, false)
+        changeRealTimeSyncSetting(document, false)
     }
 
     /**
      * Resumes the realtime synchronization of the given [document].
      */
     public fun resume(document: Document) {
-        changeRealTimeSetting(document, true)
+        changeRealTimeSyncSetting(document, true)
     }
 
-    private fun changeRealTimeSetting(document: Document, isRealTimeSync: Boolean) {
+    private fun changeRealTimeSyncSetting(document: Document, isRealTimeSync: Boolean) {
         require(isActive) {
             "client is not active"
         }
@@ -548,6 +565,8 @@ public class Client @VisibleForTesting internal constructor(
     }
 
     private data class SyncResult(val document: Document, val result: Result<Unit>)
+
+    private class WatchJobHolder(val documentID: String, val job: Job)
 
     /**
      * Represents the status of the client.

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -53,8 +53,8 @@ public class Document(public val key: Key) {
     internal val hasLocalChanges: Boolean
         get() = localChanges.isNotEmpty()
 
-    public var status = DocumentStatus.Detached
-        private set
+    @Volatile
+    internal var status = DocumentStatus.Detached
 
     /**
      * Executes the given [updater] to update this document.
@@ -124,7 +124,7 @@ public class Document(public val key: Key) {
         pack.minSyncedTicket?.let(::garbageCollect)
 
         if (pack.isRemoved) {
-            setStatus(DocumentStatus.Removed)
+            status = DocumentStatus.Removed
         }
     }
 
@@ -199,13 +199,6 @@ public class Document(public val key: Key) {
     private fun garbageCollect(ticket: TimeTicket): Int {
         clone?.garbageCollect(ticket)
         return root.garbageCollect(ticket)
-    }
-
-    /**
-     * Updates the status of this [Document].
-     */
-    public fun setStatus(status: DocumentStatus) {
-        this.status = status
     }
 
     private fun Change.createPaths(): List<String> {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -54,7 +54,8 @@ public class Document(public val key: Key) {
         get() = localChanges.isNotEmpty()
 
     @Volatile
-    internal var status = DocumentStatus.Detached
+    public var status = DocumentStatus.Detached
+        internal set
 
     /**
      * Executes the given [updater] to update this document.
@@ -64,9 +65,8 @@ public class Document(public val key: Key) {
         updater: (root: JsonObject) -> Unit,
     ): Deferred<Boolean> {
         return scope.async {
-            if (status == DocumentStatus.Removed) {
-                YorkieLogger.e("Document.update", "document is removed")
-                return@async false
+            require(status != DocumentStatus.Removed) {
+                "document is removed"
             }
 
             val clone = ensureClone()

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -162,7 +162,7 @@ public class Document(public val key: Key) {
     /**
      * Create [ChangePack] of [localChanges] to send to the remote server.
      */
-    internal suspend fun createChangePack() = withContext(dispatcher) {
+    internal suspend fun createChangePack(forceRemove: Boolean = false) = withContext(dispatcher) {
         val checkPoint = checkPoint.increaseClientSeq(localChanges.size)
         ChangePack(
             key.value,
@@ -170,7 +170,7 @@ public class Document(public val key: Key) {
             localChanges,
             null,
             null,
-            status == DocumentStatus.Removed,
+            forceRemove || status == DocumentStatus.Removed,
         )
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/ChangePack.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/ChangePack.kt
@@ -18,6 +18,7 @@ internal data class ChangePack(
     val changes: List<Change>,
     val snapshot: ByteString?,
     val minSyncedTicket: TimeTicket?,
+    val isRemoved: Boolean,
 ) {
 
     /**

--- a/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
@@ -124,6 +124,7 @@ class ConverterTest {
             listOf(change),
             null,
             null,
+            isRemoved = false,
         )
         val converted = changePack.toPBChangePack().toChangePack()
 
@@ -149,6 +150,7 @@ class ConverterTest {
             listOf(change),
             "snapshot".toByteStringUtf8(),
             InitialTimeTicket,
+            isRemoved = false,
         )
         val converted = changePack.toPBChangePack().toChangePack()
 

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -120,7 +120,7 @@ class ClientTest {
             target.activateAsync().await()
 
             val attachRequestCaptor = argumentCaptor<AttachDocumentRequest>()
-            target.attachAsync(document, true).await()
+            target.attachAsync(document, false).await()
             verify(service).attachDocument(attachRequestCaptor.capture())
             assertIsTestActorID(attachRequestCaptor.firstValue.clientId)
             assertIsEmptyChangePack(attachRequestCaptor.firstValue.changePack)

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -10,8 +10,9 @@ import dev.yorkie.api.v1.AttachDocumentRequest
 import dev.yorkie.api.v1.DeactivateClientRequest
 import dev.yorkie.api.v1.DetachDocumentRequest
 import dev.yorkie.api.v1.PushPullChangesRequest
+import dev.yorkie.api.v1.RemoveDocumentRequest
 import dev.yorkie.api.v1.UpdatePresenceRequest
-import dev.yorkie.api.v1.WatchDocumentsRequest
+import dev.yorkie.api.v1.WatchDocumentRequest
 import dev.yorkie.api.v1.YorkieServiceGrpcKt
 import dev.yorkie.assertJsonContentEquals
 import dev.yorkie.core.Client.Event.DocumentSynced
@@ -24,6 +25,7 @@ import dev.yorkie.core.Client.PeersChangedResult.Watched
 import dev.yorkie.core.MockYorkieService.Companion.ATTACH_ERROR_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.DETACH_ERROR_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.NORMAL_DOCUMENT_KEY
+import dev.yorkie.core.MockYorkieService.Companion.REMOVE_ERROR_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.SLOW_INITIALIZATION_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.TEST_ACTOR_ID
 import dev.yorkie.core.MockYorkieService.Companion.TEST_KEY
@@ -151,11 +153,11 @@ class ClientTest {
             val eventAsync = async(UnconfinedTestDispatcher()) {
                 target.events.take(3).toList()
             }
-            val watchRequestCaptor = argumentCaptor<WatchDocumentsRequest>()
+            val watchRequestCaptor = argumentCaptor<WatchDocumentRequest>()
             target.attachAsync(document).await()
             val events = eventAsync.await()
             val changeEvent = assertIs<DocumentsChanged>(events[1])
-            verify(service).watchDocuments(watchRequestCaptor.capture())
+            verify(service).watchDocument(watchRequestCaptor.capture())
             assertIsTestActorID(watchRequestCaptor.firstValue.client.id)
             assertEquals(1, changeEvent.documentKeys.size)
             assertEquals(NORMAL_DOCUMENT_KEY, changeEvent.documentKeys.first().value)
@@ -331,7 +333,7 @@ class ClientTest {
             assertTrue(slowAttach.isActive)
             target.attachAsync(document1).await()
             delay(100)
-            assertTrue(slowAttach.isCompleted)
+            assertTrue(slowAttach.await())
             assertTrue(target.peerStatus.value[Key(NORMAL_DOCUMENT_KEY)]!!.isNotEmpty())
             assertTrue(
                 target.peerStatus.value[Key(SLOW_INITIALIZATION_DOCUMENT_KEY)]!!.isNotEmpty(),
@@ -412,6 +414,40 @@ class ClientTest {
             delay(500)
             assertTrue(target.deactivateAsync().await())
             assertTrue(target.deactivateAsync().await())
+        }
+    }
+
+    @Test
+    fun `should remove document`() {
+        runTest {
+            val document = Document(Key(NORMAL_DOCUMENT_KEY))
+            target.activateAsync().await()
+            target.attachAsync(document).await()
+
+            val removeDocumentRequestCaptor = argumentCaptor<RemoveDocumentRequest>()
+            target.removeAsync(document).await()
+            verify(service).removeDocument(removeDocumentRequestCaptor.capture())
+            assertIsTestActorID(removeDocumentRequestCaptor.firstValue.clientId)
+            assertEquals(
+                InitialEmptyChangePack.copy(isRemoved = true),
+                removeDocumentRequestCaptor.firstValue.changePack.toChangePack(),
+            )
+
+            target.deactivateAsync().await()
+        }
+    }
+
+    @Test
+    fun `should return false on remove document error without exceptions`() {
+        runTest {
+            val document = Document(Key(REMOVE_ERROR_DOCUMENT_KEY))
+            target.activateAsync().await()
+            target.attachAsync(document).await()
+
+            assertFalse(target.removeAsync(document).await())
+
+            target.detachAsync(document).await()
+            target.deactivateAsync().await()
         }
     }
 

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -9,7 +9,7 @@ import dev.yorkie.api.v1.ActivateClientRequest
 import dev.yorkie.api.v1.AttachDocumentRequest
 import dev.yorkie.api.v1.DeactivateClientRequest
 import dev.yorkie.api.v1.DetachDocumentRequest
-import dev.yorkie.api.v1.PushPullRequest
+import dev.yorkie.api.v1.PushPullChangesRequest
 import dev.yorkie.api.v1.UpdatePresenceRequest
 import dev.yorkie.api.v1.WatchDocumentsRequest
 import dev.yorkie.api.v1.YorkieServiceGrpcKt
@@ -126,9 +126,9 @@ class ClientTest {
             assertIsEmptyChangePack(attachRequestCaptor.firstValue.changePack)
             assertJsonContentEquals("""{"k1": 4}""", document.toJson())
 
-            val syncRequestCaptor = argumentCaptor<PushPullRequest>()
+            val syncRequestCaptor = argumentCaptor<PushPullChangesRequest>()
             target.syncAsync().await()
-            verify(service).pushPull(syncRequestCaptor.capture())
+            verify(service).pushPullChanges(syncRequestCaptor.capture())
             assertIsTestActorID(syncRequestCaptor.firstValue.clientId)
             assertIsEmptyChangePack(syncRequestCaptor.firstValue.changePack)
             assertJsonContentEquals("""{"k2": 100.0}""", document.toJson())
@@ -160,9 +160,9 @@ class ClientTest {
             assertEquals(1, changeEvent.documentKeys.size)
             assertEquals(NORMAL_DOCUMENT_KEY, changeEvent.documentKeys.first().value)
 
-            val syncRequestCaptor = argumentCaptor<PushPullRequest>()
+            val syncRequestCaptor = argumentCaptor<PushPullChangesRequest>()
             val syncEvent = assertIs<DocumentSynced>(events.last())
-            verify(service).pushPull(syncRequestCaptor.capture())
+            verify(service).pushPullChanges(syncRequestCaptor.capture())
             assertIsTestActorID(syncRequestCaptor.firstValue.clientId)
             val synced = assertIs<Client.DocumentSyncResult.Synced>(syncEvent.result)
             assertEquals(document, synced.document)
@@ -430,6 +430,7 @@ class ClientTest {
             emptyList(),
             null,
             null,
+            false,
         )
     }
 }

--- a/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
@@ -15,8 +15,8 @@ import dev.yorkie.api.v1.DetachDocumentResponse
 import dev.yorkie.api.v1.DocEventType
 import dev.yorkie.api.v1.OperationKt.remove
 import dev.yorkie.api.v1.OperationKt.set
-import dev.yorkie.api.v1.PushPullRequest
-import dev.yorkie.api.v1.PushPullResponse
+import dev.yorkie.api.v1.PushPullChangesRequest
+import dev.yorkie.api.v1.PushPullChangesResponse
 import dev.yorkie.api.v1.UpdatePresenceRequest
 import dev.yorkie.api.v1.UpdatePresenceResponse
 import dev.yorkie.api.v1.ValueType
@@ -36,7 +36,7 @@ import dev.yorkie.api.v1.docEvent
 import dev.yorkie.api.v1.jSONElementSimple
 import dev.yorkie.api.v1.operation
 import dev.yorkie.api.v1.presence
-import dev.yorkie.api.v1.pushPullResponse
+import dev.yorkie.api.v1.pushPullChangesResponse
 import dev.yorkie.api.v1.watchDocumentsResponse
 import dev.yorkie.document.crdt.CrdtElement
 import dev.yorkie.document.crdt.CrdtObject
@@ -99,11 +99,11 @@ class MockYorkieService : YorkieServiceGrpcKt.YorkieServiceCoroutineImplBase() {
         }
     }
 
-    override suspend fun pushPull(request: PushPullRequest): PushPullResponse {
+    override suspend fun pushPullChanges(request: PushPullChangesRequest): PushPullChangesResponse {
         if (request.changePack.documentKey == WATCH_SYNC_ERROR_DOCUMENT_KEY) {
             throw StatusException(Status.UNAVAILABLE)
         }
-        return pushPullResponse {
+        return pushPullChangesResponse {
             clientId = request.clientId
             changePack = changePack {
                 minSyncedTicket = InitialTimeTicket.toPBTimeTicket()

--- a/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
@@ -17,19 +17,20 @@ import dev.yorkie.api.v1.OperationKt.remove
 import dev.yorkie.api.v1.OperationKt.set
 import dev.yorkie.api.v1.PushPullChangesRequest
 import dev.yorkie.api.v1.PushPullChangesResponse
+import dev.yorkie.api.v1.RemoveDocumentRequest
+import dev.yorkie.api.v1.RemoveDocumentResponse
 import dev.yorkie.api.v1.UpdatePresenceRequest
 import dev.yorkie.api.v1.UpdatePresenceResponse
 import dev.yorkie.api.v1.ValueType
-import dev.yorkie.api.v1.WatchDocumentsRequest
-import dev.yorkie.api.v1.WatchDocumentsResponse
-import dev.yorkie.api.v1.WatchDocumentsResponseKt.initialization
+import dev.yorkie.api.v1.WatchDocumentRequest
+import dev.yorkie.api.v1.WatchDocumentResponse
+import dev.yorkie.api.v1.WatchDocumentResponseKt.initialization
 import dev.yorkie.api.v1.YorkieServiceGrpcKt
 import dev.yorkie.api.v1.activateClientResponse
 import dev.yorkie.api.v1.attachDocumentResponse
 import dev.yorkie.api.v1.change
 import dev.yorkie.api.v1.changePack
 import dev.yorkie.api.v1.client
-import dev.yorkie.api.v1.clients
 import dev.yorkie.api.v1.deactivateClientResponse
 import dev.yorkie.api.v1.detachDocumentResponse
 import dev.yorkie.api.v1.docEvent
@@ -37,7 +38,8 @@ import dev.yorkie.api.v1.jSONElementSimple
 import dev.yorkie.api.v1.operation
 import dev.yorkie.api.v1.presence
 import dev.yorkie.api.v1.pushPullChangesResponse
-import dev.yorkie.api.v1.watchDocumentsResponse
+import dev.yorkie.api.v1.removeDocumentResponse
+import dev.yorkie.api.v1.watchDocumentResponse
 import dev.yorkie.document.crdt.CrdtElement
 import dev.yorkie.document.crdt.CrdtObject
 import dev.yorkie.document.crdt.CrdtPrimitive
@@ -87,6 +89,7 @@ class MockYorkieService : YorkieServiceGrpcKt.YorkieServiceCoroutineImplBase() {
                 ).toByteString()
                 minSyncedTicket = PBTimeTicket.getDefaultInstance()
             }
+            documentId = changePack.documentKey
         }
     }
 
@@ -139,65 +142,59 @@ class MockYorkieService : YorkieServiceGrpcKt.YorkieServiceCoroutineImplBase() {
         }
     }
 
-    override fun watchDocuments(request: WatchDocumentsRequest): Flow<WatchDocumentsResponse> {
-        val keys = request.documentKeysList
+    override fun watchDocument(request: WatchDocumentRequest): Flow<WatchDocumentResponse> {
+        val key = request.documentId
         return flow {
-            if (keys.size == 1 && keys.contains(SLOW_INITIALIZATION_DOCUMENT_KEY)) {
+            if (key == SLOW_INITIALIZATION_DOCUMENT_KEY) {
                 delay(5_000)
                 emit(
-                    watchDocumentsResponse {
+                    watchDocumentResponse {
                         initialization = initialization {
-                            peersMapByDoc[SLOW_INITIALIZATION_DOCUMENT_KEY] = clients {
-                                clients.add(
-                                    client {
-                                        id = request.client.id
-                                        presence = presence {
-                                            clock = 1
-                                            data["k1"] = "v1"
-                                        }
-                                    },
-                                )
-                            }
+                            peers.add(
+                                client {
+                                    id = request.client.id
+                                    presence = presence {
+                                        clock = 1
+                                        data["k1"] = "v1"
+                                    }
+                                },
+                            )
                         }
                     },
                 )
             } else {
                 emit(
-                    watchDocumentsResponse {
+                    watchDocumentResponse {
                         initialization = initialization {
-                            keys.forEach {
-                                peersMapByDoc[it] = clients {
-                                    clients.add(
-                                        client {
-                                            id = request.client.id
-                                            presence = presence {
-                                                clock = 1
-                                                data["k1"] = "v1"
-                                            }
-                                        },
-                                    )
-                                }
-                            }
+                            peers.add(
+                                client {
+                                    id = request.client.id
+                                    presence = presence {
+                                        clock = 1
+                                        data["k1"] = "v1"
+                                    }
+                                },
+                            )
                         }
                     },
                 )
             }
             delay(1_000)
-            if (keys.contains(WATCH_SYNC_ERROR_DOCUMENT_KEY)) {
+            if (key == WATCH_SYNC_ERROR_DOCUMENT_KEY) {
                 throw StatusException(Status.UNAVAILABLE)
             }
             emit(
-                watchDocumentsResponse {
+                watchDocumentResponse {
                     event = docEvent {
                         type = DocEventType.DOC_EVENT_TYPE_DOCUMENTS_CHANGED
                         publisher = request.client
-                        documentKeys.addAll(keys)
+                        documentId = key
                     }
                 },
             )
             delay(1_000)
             emit(
-                watchDocumentsResponse {
+                watchDocumentResponse {
                     event = docEvent {
                         type = DocEventType.DOC_EVENT_TYPE_DOCUMENTS_WATCHED
                         publisher = client {
@@ -207,13 +204,13 @@ class MockYorkieService : YorkieServiceGrpcKt.YorkieServiceCoroutineImplBase() {
                                 data["k1"] = "v1"
                             }
                         }
-                        documentKeys.addAll(keys)
+                        documentId = key
                     }
                 },
             )
             delay(3_000)
             emit(
-                watchDocumentsResponse {
+                watchDocumentResponse {
                     event = docEvent {
                         type = DocEventType.DOC_EVENT_TYPE_PRESENCE_CHANGED
                         publisher = client {
@@ -223,19 +220,19 @@ class MockYorkieService : YorkieServiceGrpcKt.YorkieServiceCoroutineImplBase() {
                                 data["k1"] = "v2"
                             }
                         }
-                        documentKeys.addAll(keys)
+                        documentId = key
                     }
                 },
             )
             delay(2_000)
             emit(
-                watchDocumentsResponse {
+                watchDocumentResponse {
                     event = docEvent {
                         type = DocEventType.DOC_EVENT_TYPE_DOCUMENTS_UNWATCHED
                         publisher = client {
                             id = ActorID.MAX_ACTOR_ID.toByteString()
                         }
-                        documentKeys.addAll(keys)
+                        documentId = key
                     }
                 },
             )
@@ -243,10 +240,29 @@ class MockYorkieService : YorkieServiceGrpcKt.YorkieServiceCoroutineImplBase() {
     }
 
     override suspend fun updatePresence(request: UpdatePresenceRequest): UpdatePresenceResponse {
-        if (request.documentKeysList.contains(UPDATE_PRESENCE_ERROR_DOCUMENT_KEY)) {
+        if (request.documentId == UPDATE_PRESENCE_ERROR_DOCUMENT_KEY) {
             throw StatusException(Status.UNAVAILABLE)
         }
         return UpdatePresenceResponse.getDefaultInstance()
+    }
+
+    override suspend fun removeDocument(request: RemoveDocumentRequest): RemoveDocumentResponse {
+        if (request.documentId == REMOVE_ERROR_DOCUMENT_KEY) {
+            throw StatusException(Status.UNAVAILABLE)
+        }
+        return removeDocumentResponse {
+            clientKey = TEST_KEY
+            changePack = changePack {
+                minSyncedTicket = InitialTimeTicket.toPBTimeTicket()
+                changes.add(
+                    change {
+                        operations.add(createSetOperation())
+                        operations.add(createRemoveOperation())
+                    },
+                )
+                isRemoved = true
+            }
+        }
     }
 
     companion object {
@@ -257,6 +273,7 @@ class MockYorkieService : YorkieServiceGrpcKt.YorkieServiceCoroutineImplBase() {
         internal const val DETACH_ERROR_DOCUMENT_KEY = "DETACH_ERROR_DOCUMENT_KEY"
         internal const val UPDATE_PRESENCE_ERROR_DOCUMENT_KEY = "UPDATE_PRESENCE_ERROR_DOCUMENT_KEY"
         internal const val SLOW_INITIALIZATION_DOCUMENT_KEY = "SLOW_INITIALIZATION_DOCUMENT_KEY"
+        internal const val REMOVE_ERROR_DOCUMENT_KEY = "REMOVE_ERROR_DOCUMENT_KEY"
         internal val TEST_ACTOR_ID = ActorID("0000000000ffff0000000000")
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- add RemoveDocument API
- apply WatchDocument API

#### Any background context you want to provide?
I have made it throw exceptions when documents have invalid states upon calling functions such as `attachAsync()`, `removeAsync()`, and `detachAsync()`. This approach is based on the implementation of other SDKs.

#### What are the relevant tickets?
- https://github.com/yorkie-team/yorkie/issues/464
- https://github.com/yorkie-team/yorkie/pull/484
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
