### PR TITLE
Make JsonText's values public

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtText.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtText.kt
@@ -22,9 +22,12 @@ internal data class CrdtText(
     val removedNodesLength: Int
         get() = rgaTreeSplit.removedNodesLength
 
-    val values
-        get() = rgaTreeSplit.filterNot { it.isRemoved }
-            .map { it.value.content to it.value.attributes }
+    val values: LinkedHashMap<String, Map<String, String>>
+        get() = rgaTreeSplit.filterNot {
+            it.isRemoved
+        }.associateTo(LinkedHashMap(rgaTreeSplit.length)) {
+            it.value.content to it.value.attributes
+        }
 
     val length: Int
         get() = rgaTreeSplit.length

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonText.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonText.kt
@@ -20,7 +20,7 @@ public class JsonText internal constructor(
     public val id: TimeTicket
         get() = target.id
 
-    internal val values
+    public val values: LinkedHashMap<String, Map<String, String>>
         get() = target.values
 
     public val length: Int


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
`JsonText`'s `values` is needed by clients when handling styled texts.
Also changed it's type to `LinkedHashMap` for better usage.

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
