### PR TITLE
revert JsonText's values type back to List

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtText.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtText.kt
@@ -22,11 +22,11 @@ internal data class CrdtText(
     val removedNodesLength: Int
         get() = rgaTreeSplit.removedNodesLength
 
-    val values: LinkedHashMap<String, Map<String, String>>
+    val values: List<TextWithAttributes>
         get() = rgaTreeSplit.filterNot {
             it.isRemoved
-        }.associateTo(LinkedHashMap(rgaTreeSplit.length)) {
-            it.value.content to it.value.attributes
+        }.map {
+            TextWithAttributes(it.value.content to it.value.attributes)
         }
 
     val length: Int

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TextInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TextInfo.kt
@@ -75,3 +75,12 @@ internal data class TextValue(
         return content
     }
 }
+
+@JvmInline
+public value class TextWithAttributes(private val value: Pair<String, Map<String, String>>) {
+    val text: String
+        get() = value.first
+
+    val attributes: Map<String, String>
+        get() = value.second
+}

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonText.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonText.kt
@@ -3,6 +3,7 @@ package dev.yorkie.document.json
 import dev.yorkie.document.change.ChangeContext
 import dev.yorkie.document.crdt.CrdtText
 import dev.yorkie.document.crdt.TextChange
+import dev.yorkie.document.crdt.TextWithAttributes
 import dev.yorkie.document.operation.EditOperation
 import dev.yorkie.document.operation.SelectOperation
 import dev.yorkie.document.operation.StyleOperation
@@ -20,7 +21,7 @@ public class JsonText internal constructor(
     public val id: TimeTicket
         get() = target.id
 
-    public val values: LinkedHashMap<String, Map<String, String>>
+    public val values: List<TextWithAttributes>
         get() = target.values
 
     public val length: Int


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
In previous [PR](https://github.com/yorkie-team/yorkie-android-sdk/pull/94) I mistakenly changed values type to a map.
This reverts back to a list, so duplications are allowed.

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
