### PR TITLE
change YorkieLogger visibility to public

### DIFF
--- a/examples/kanban/src/main/java/com/example/kanbanapp/KanbanBoardActivity.kt
+++ b/examples/kanban/src/main/java/com/example/kanbanapp/KanbanBoardActivity.kt
@@ -1,6 +1,7 @@
 package com.example.kanbanapp
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -13,6 +14,8 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import dev.yorkie.core.Client
+import dev.yorkie.util.Logger
+import dev.yorkie.util.YorkieLogger
 
 class KanbanBoardActivity : ComponentActivity() {
     private val viewModel: KanbanBoardViewModel by viewModels {
@@ -43,6 +46,22 @@ class KanbanBoardActivity : ComponentActivity() {
                     onNewCardAdded = onNewCardAdded,
                     onColumnDeleted = onColumnDeleted,
                 )
+            }
+        }
+    }
+
+    companion object {
+
+        init {
+            YorkieLogger.logger = object : Logger {
+
+                override fun d(tag: String, message: String) {
+                    Log.d(tag, message)
+                }
+
+                override fun e(tag: String, message: String) {
+                    Log.e(tag, message)
+                }
             }
         }
     }

--- a/examples/texteditor/src/main/java/com/example/texteditor/MainActivity.kt
+++ b/examples/texteditor/src/main/java/com/example/texteditor/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.text.Editable
 import android.text.Spannable
 import android.text.style.BackgroundColorSpan
+import android.util.Log
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.text.getSpans
@@ -15,6 +16,8 @@ import dev.yorkie.core.Client
 import dev.yorkie.document.crdt.TextChange
 import dev.yorkie.document.crdt.TextChangeType
 import dev.yorkie.document.time.ActorID
+import dev.yorkie.util.Logger
+import dev.yorkie.util.YorkieLogger
 import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
@@ -115,5 +118,18 @@ class MainActivity : AppCompatActivity() {
 
     companion object {
         private const val SELECTION_END = "selection end"
+
+        init {
+            YorkieLogger.logger = object : Logger {
+
+                override fun d(tag: String, message: String) {
+                    Log.d(tag, message)
+                }
+
+                override fun e(tag: String, message: String) {
+                    Log.e(tag, message)
+                }
+            }
+        }
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/util/YorkieLogger.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/YorkieLogger.kt
@@ -1,9 +1,9 @@
 package dev.yorkie.util
 
-internal object YorkieLogger {
+public object YorkieLogger {
     private const val TAG_PREFIX = "Yorkie."
 
-    private var logger: Logger? = null
+    public var logger: Logger? = null
 
     fun d(tag: String, message: String) {
         logger?.d("$TAG_PREFIX$tag", message)
@@ -14,7 +14,7 @@ internal object YorkieLogger {
     }
 }
 
-internal interface Logger {
+public interface Logger {
     fun d(tag: String, message: String)
 
     fun e(tag: String, message: String)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
There was no way for clients to set `YorkieLogger.logger `before.

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
