### PR TITLE
Allow specifying a topic when subscribing to a document

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.dropWhile
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapNotNull
@@ -93,7 +94,7 @@ class ClientTest {
                 it["k1"] = "v1"
             }.await()
 
-            withTimeout(1_000L) {
+            withTimeout(2_000) {
                 while (client2Events.none { it is DocumentSynced }) {
                     delay(50)
                 }
@@ -247,7 +248,7 @@ class ClientTest {
                 it["version"] = "v2"
             }.await()
             client1.syncAsync().await()
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (client2Events.size < 2) {
                     delay(50)
                 }
@@ -353,7 +354,7 @@ class ClientTest {
 
             val document1Events = mutableListOf<Document.Event>()
             val document2Events = mutableListOf<Document.Event>()
-            val document3Events = mutableListOf<Document.Event>()
+            val document3Ops = mutableListOf<OperationInfo>()
             val collectJobs = listOf(
                 launch(start = CoroutineStart.UNDISPATCHED) {
                     document1.events.collect(document1Events::add)
@@ -362,7 +363,9 @@ class ClientTest {
                     document2.events.collect(document2Events::add)
                 },
                 launch(start = CoroutineStart.UNDISPATCHED) {
-                    document3.events.collect(document3Events::add)
+                    document3.events.filterIsInstance<RemoteChange>().collect { event ->
+                        document3Ops.addAll(event.changeInfos.flatMap { it.operations })
+                    }
                 },
             )
 
@@ -373,9 +376,12 @@ class ClientTest {
             document2.updateAsync {
                 it["c2"] = 0
             }.await()
-            withTimeout(1_000L) {
+            withTimeout(1_000) {
                 // size should be 2 since it has local-change and remote-change
-                while (document1Events.size < 2 || document2Events.size < 2) {
+                while (document1Events.size < 2 ||
+                    document2Events.size < 2 ||
+                    document3Ops.size < 2
+                ) {
                     delay(50)
                 }
             }
@@ -393,10 +399,10 @@ class ClientTest {
             document2.updateAsync {
                 it["c2"] = 1
             }.await()
-            withTimeout(1_000L) {
+            withTimeout(1_000) {
                 while (document1Events.size < 3 ||
                     document2Events.size < 3 ||
-                    document3Events.size < 2
+                    document3Ops.size < 4
                 ) {
                     delay(50)
                 }
@@ -408,7 +414,7 @@ class ClientTest {
             // 04. c1 and c2 sync with push-pull mode.
             client1.resumeRemoteChanges(document1)
             client2.resumeRemoteChanges(document2)
-            withTimeout(1_000L) {
+            withTimeout(2_000) {
                 while (document1Events.size < 4 || document2Events.size < 4) {
                     delay(50)
                 }

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -376,7 +376,7 @@ class ClientTest {
             document2.updateAsync {
                 it["c2"] = 0
             }.await()
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 // size should be 2 since it has local-change and remote-change
                 while (document1Events.size < 2 ||
                     document2Events.size < 2 ||
@@ -399,7 +399,7 @@ class ClientTest {
             document2.updateAsync {
                 it["c2"] = 1
             }.await()
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Events.size < 3 ||
                     document2Events.size < 3 ||
                     document3Ops.size < 4

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
@@ -13,7 +13,14 @@ import dev.yorkie.document.json.JsonObject
 import dev.yorkie.document.json.JsonPrimitive
 import dev.yorkie.document.json.JsonText
 import dev.yorkie.document.operation.OperationInfo
-import dev.yorkie.document.operation.OperationInfo.*
+import dev.yorkie.document.operation.OperationInfo.AddOpInfo
+import dev.yorkie.document.operation.OperationInfo.EditOpInfo
+import dev.yorkie.document.operation.OperationInfo.IncreaseOpInfo
+import dev.yorkie.document.operation.OperationInfo.MoveOpInfo
+import dev.yorkie.document.operation.OperationInfo.RemoveOpInfo
+import dev.yorkie.document.operation.OperationInfo.SelectOpInfo
+import dev.yorkie.document.operation.OperationInfo.SetOpInfo
+import dev.yorkie.document.operation.OperationInfo.StyleOpInfo
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
@@ -276,7 +276,7 @@ class DocumentTest {
                 }
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document2Ops.size < 4) {
                     delay(50)
                 }
@@ -296,7 +296,7 @@ class DocumentTest {
                 }
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.size < 3) {
                     delay(50)
                 }
@@ -386,7 +386,7 @@ class DocumentTest {
                 }
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 // ops: counter, todos, todoOps: todos
                 while (document1Ops.size < 2 || document1TodosOps.isEmpty()) {
                     delay(50)
@@ -416,7 +416,7 @@ class DocumentTest {
                 it.getAs<JsonCounter>("counter").increase(10)
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.isEmpty() || document1CounterOps.isEmpty()) {
                     delay(50)
                 }
@@ -434,7 +434,7 @@ class DocumentTest {
                 it.getAs<JsonArray>("todos").put("todo3")
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.isEmpty() || document1TodosOps.isEmpty()) {
                     delay(50)
                 }
@@ -450,7 +450,7 @@ class DocumentTest {
                 it.getAs<JsonArray>("todos").put("todo4")
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.isEmpty()) {
                     delay(50)
                 }
@@ -465,7 +465,7 @@ class DocumentTest {
                 it.getAs<JsonCounter>("counter").increase(10)
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.isEmpty()) {
                     delay(50)
                 }
@@ -516,7 +516,7 @@ class DocumentTest {
                 }
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.size < 2 ||
                     document1TodosOps.isEmpty() ||
                     document1ObjOps.isEmpty()
@@ -561,7 +561,7 @@ class DocumentTest {
                 it.getAs<JsonObject>("obj").getAs<JsonObject>("c1")["name"] = "john"
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.isEmpty() || document1ObjOps.isEmpty()) {
                     delay(50)
                 }
@@ -576,7 +576,7 @@ class DocumentTest {
                 it.getAs<JsonArray>("todos").getAs<JsonObject>(0)?.set("completed", true)
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.isEmpty() || document1TodosOps.isEmpty()) {
                     delay(50)
                 }
@@ -595,7 +595,7 @@ class DocumentTest {
                 it.getAs<JsonArray>("todos").getAs<JsonObject>(0)?.set("text", "todo_1")
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.isEmpty()) {
                     delay(50)
                 }
@@ -610,7 +610,7 @@ class DocumentTest {
                 it.getAs<JsonObject>("obj").getAs<JsonObject>("c1")["age"] = 15
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.isEmpty()) {
                     delay(50)
                 }

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
@@ -364,7 +364,9 @@ class DocumentTest {
                 "counter" to launch(start = CoroutineStart.UNDISPATCHED) {
                     document1.events("$.counter").filterIsInstance<Event.RemoteChange>()
                         .collect {
-                            document1CounterOps.addAll(it.changeInfos.flatMap(ChangeInfo::operations))
+                            document1CounterOps.addAll(
+                                it.changeInfos.flatMap(ChangeInfo::operations),
+                            )
                         }
                 },
             )
@@ -508,9 +510,9 @@ class DocumentTest {
             }.await()
 
             withTimeout(1_000) {
-                while (document1Ops.size < 2
-                    || document1TodosOps.isEmpty()
-                    || document1ObjOps.isEmpty()
+                while (document1Ops.size < 2 ||
+                    document1TodosOps.isEmpty() ||
+                    document1ObjOps.isEmpty()
                 ) {
                     println(document1Ops)
                     delay(50)

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
@@ -1,9 +1,26 @@
 package dev.yorkie.core
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.yorkie.assertJsonContentEquals
 import dev.yorkie.document.Document
 import dev.yorkie.document.Document.DocumentStatus
+import dev.yorkie.document.Document.Event
+import dev.yorkie.document.Document.Event.ChangeInfo
+import dev.yorkie.document.crdt.TextWithAttributes
+import dev.yorkie.document.json.JsonArray
+import dev.yorkie.document.json.JsonCounter
+import dev.yorkie.document.json.JsonObject
+import dev.yorkie.document.json.JsonPrimitive
+import dev.yorkie.document.json.JsonText
+import dev.yorkie.document.operation.OperationInfo
+import dev.yorkie.document.operation.OperationInfo.*
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.UUID
@@ -196,6 +213,404 @@ class DocumentTest {
             }
 
             client.deactivateAsync().await()
+        }
+    }
+
+    @Test
+    fun test_document_event_stream() {
+        withTwoClientsAndDocuments { _, _, document1, document2, _ ->
+            val document1Ops = mutableListOf<OperationInfo>()
+            val document2Ops = mutableListOf<OperationInfo>()
+            val collectJobs = listOf(
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    document1.events.filterIsInstance<Event.RemoteChange>()
+                        .collect {
+                            document1Ops.addAll(it.changeInfos.flatMap(ChangeInfo::operations))
+                        }
+                },
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    document2.events.filterIsInstance<Event.RemoteChange>()
+                        .collect {
+                            document2Ops.addAll(it.changeInfos.flatMap(ChangeInfo::operations))
+                        }
+                },
+            )
+
+            document1.updateAsync {
+                it.setNewCounter("counter", 100)
+                it.setNewArray("todos").apply {
+                    put("todo1")
+                    put("todo2")
+                    put("todo3")
+                }
+                it.setNewText("content").edit(
+                    0,
+                    0,
+                    "hello world",
+                    mapOf(
+                        "italic" to "true",
+                    ),
+                )
+                it.setNewObject("obj").apply {
+                    set("name", "josh")
+                    set("age", 14)
+                    setNewArray("food").apply {
+                        put("apple")
+                        put("grape")
+                    }
+                    setNewObject("score").apply {
+                        set("english", 80)
+                        set("math", 90)
+                    }
+                    setNewObject("score").apply {
+                        set("science", 100)
+                    }
+                    remove("food")
+                }
+            }.await()
+
+            withTimeout(1_000) {
+                while (document2Ops.size < 4) {
+                    delay(50)
+                }
+            }
+
+            document2.updateAsync {
+                it.getAs<JsonCounter>("counter").increase(1)
+                it.getAs<JsonArray>("todos").apply {
+                    put("todo4")
+                    val prevItem = requireNotNull(getAs<JsonPrimitive>(1))
+                    val currItem = requireNotNull(getAs<JsonPrimitive>(0))
+                    moveAfter(prevItem.target.id, currItem.target.id)
+                }
+                it.getAs<JsonText>("content").apply {
+                    select(0, 5)
+                    style(0, 5, mapOf("bold" to "true"))
+                }
+            }.await()
+
+            withTimeout(1_000) {
+                while (document1Ops.size < 3) {
+                    delay(50)
+                }
+            }
+
+            assertJsonContentEquals(document1.toJson(), document2.toJson())
+            val expectedDocument1Ops = listOf(
+                IncreaseOpInfo(path = "$.counter", value = 1),
+                AddOpInfo(path = "$.todos", index = 3),
+                MoveOpInfo(path = "$.todos", index = 1, previousIndex = 0),
+                SelectOpInfo(path = "$.content", from = 0, to = 5),
+                StyleOpInfo(
+                    path = "$.content",
+                    from = 0,
+                    to = 5,
+                    attributes = mapOf("bold" to "true"),
+                ),
+            )
+            val expectedDocument2Ops = listOf(
+                SetOpInfo(path = "$", key = "counter"),
+                SetOpInfo(path = "$", key = "todos"),
+                AddOpInfo(path = "$.todos", index = 0),
+                AddOpInfo(path = "$.todos", index = 1),
+                AddOpInfo(path = "$.todos", index = 2),
+                SetOpInfo(path = "$", key = "content"),
+                EditOpInfo(
+                    from = 0,
+                    to = 0,
+                    value = TextWithAttributes("hello world" to mapOf("italic" to "true")),
+                    path = "$.content",
+                ),
+                SelectOpInfo(path = "$.content", from = 11, to = 11),
+                SetOpInfo(path = "$", key = "obj"),
+                SetOpInfo(path = "$.obj", key = "name"),
+                SetOpInfo(path = "$.obj", key = "age"),
+                SetOpInfo(path = "$.obj", key = "food"),
+                AddOpInfo(path = "$.obj.food", index = 0),
+                AddOpInfo(path = "$.obj.food", index = 1),
+                SetOpInfo(path = "$.obj", key = "score"),
+                SetOpInfo(path = "$.obj.score", key = "english"),
+                SetOpInfo(path = "$.obj.score", key = "math"),
+                SetOpInfo(path = "$.obj", key = "score"),
+                SetOpInfo(path = "$.obj.score", key = "science"),
+                RemoveOpInfo(path = "$.obj", key = "food", index = null),
+            )
+            assertEquals(expectedDocument1Ops, document1Ops)
+            assertEquals(expectedDocument2Ops, document2Ops)
+
+            collectJobs.forEach(Job::cancel)
+        }
+    }
+
+    @Test
+    fun test_document_event_stream_with_specific_topic() {
+        withTwoClientsAndDocuments { _, _, document1, document2, _ ->
+            val document1Ops = mutableListOf<OperationInfo>()
+            val document1TodosOps = mutableListOf<OperationInfo>()
+            val document1CounterOps = mutableListOf<OperationInfo>()
+            val collectJobs = mapOf(
+                "events" to launch(start = CoroutineStart.UNDISPATCHED) {
+                    document1.events.filterIsInstance<Event.RemoteChange>()
+                        .collect {
+                            document1Ops.addAll(it.changeInfos.flatMap(ChangeInfo::operations))
+                        }
+                },
+                "todos" to launch(start = CoroutineStart.UNDISPATCHED) {
+                    document1.events("$.todos").filterIsInstance<Event.RemoteChange>()
+                        .collect {
+                            document1TodosOps.addAll(it.changeInfos.flatMap(ChangeInfo::operations))
+                        }
+                },
+                "counter" to launch(start = CoroutineStart.UNDISPATCHED) {
+                    document1.events("$.counter").filterIsInstance<Event.RemoteChange>()
+                        .collect {
+                            document1CounterOps.addAll(it.changeInfos.flatMap(ChangeInfo::operations))
+                        }
+                },
+            )
+
+            document2.updateAsync {
+                it.setNewCounter("counter", 0)
+                it.setNewArray("todos").apply {
+                    put("todo1")
+                    put("todo2")
+                }
+            }.await()
+
+            withTimeout(1_000) {
+                // ops: counter, todos, todoOps: todos
+                while (document1Ops.size < 2 || document1TodosOps.isEmpty()) {
+                    delay(50)
+                }
+            }
+
+            assertEquals(
+                listOf(
+                    SetOpInfo(path = "$", key = "counter"),
+                    SetOpInfo(path = "$", key = "todos"),
+                    AddOpInfo(path = "$.todos", index = 0),
+                    AddOpInfo(path = "$.todos", index = 1),
+                ),
+                document1Ops,
+            )
+            assertEquals(
+                listOf<OperationInfo>(
+                    AddOpInfo(path = "$.todos", index = 0),
+                    AddOpInfo(path = "$.todos", index = 1),
+                ),
+                document1TodosOps,
+            )
+            document1Ops.clear()
+            document1TodosOps.clear()
+
+            document2.updateAsync {
+                it.getAs<JsonCounter>("counter").increase(10)
+            }.await()
+
+            withTimeout(1_000) {
+                while (document1Ops.isEmpty() || document1CounterOps.isEmpty()) {
+                    delay(50)
+                }
+            }
+
+            assertEquals(IncreaseOpInfo(path = "$.counter", value = 10), document1Ops.first())
+            assertEquals(
+                IncreaseOpInfo(path = "$.counter", value = 10),
+                document1CounterOps.first(),
+            )
+            document1Ops.clear()
+            document1CounterOps.clear()
+
+            document2.updateAsync {
+                it.getAs<JsonArray>("todos").put("todo3")
+            }.await()
+
+            withTimeout(1_000) {
+                while (document1Ops.isEmpty() || document1TodosOps.isEmpty()) {
+                    delay(50)
+                }
+            }
+
+            assertEquals(AddOpInfo(path = "$.todos", index = 2), document1Ops.first())
+            assertEquals(AddOpInfo(path = "$.todos", index = 2), document1TodosOps.first())
+            document1Ops.clear()
+            document1TodosOps.clear()
+
+            collectJobs["todos"]?.cancel()
+            document2.updateAsync {
+                it.getAs<JsonArray>("todos").put("todo4")
+            }.await()
+
+            withTimeout(1_000) {
+                while (document1Ops.isEmpty()) {
+                    delay(50)
+                }
+            }
+
+            assertEquals(AddOpInfo(path = "$.todos", index = 3), document1Ops.first())
+            assert(document1TodosOps.isEmpty())
+            document1Ops.clear()
+
+            collectJobs["counter"]?.cancel()
+            document2.updateAsync {
+                it.getAs<JsonCounter>("counter").increase(10)
+            }.await()
+
+            withTimeout(1_000) {
+                while (document1Ops.isEmpty()) {
+                    delay(50)
+                }
+            }
+
+            assertEquals(IncreaseOpInfo(path = "$.counter", value = 10), document1Ops.first())
+            assert(document1CounterOps.isEmpty())
+
+            collectJobs.values.forEach(Job::cancel)
+        }
+    }
+
+    @Test
+    fun test_document_event_stream_with_nested_topic() {
+        withTwoClientsAndDocuments { _, _, document1, document2, _ ->
+            val document1Ops = mutableListOf<OperationInfo>()
+            val document1TodosOps = mutableListOf<OperationInfo>()
+            val document1ObjOps = mutableListOf<OperationInfo>()
+            val collectJobs = mapOf(
+                "events" to launch(start = CoroutineStart.UNDISPATCHED) {
+                    document1.events.filterIsInstance<Event.RemoteChange>()
+                        .collect {
+                            document1Ops.addAll(it.changeInfos.flatMap(ChangeInfo::operations))
+                        }
+                },
+                "todos" to launch(start = CoroutineStart.UNDISPATCHED) {
+                    document1.events("$.todos.0").filterIsInstance<Event.RemoteChange>()
+                        .collect {
+                            document1TodosOps.addAll(it.changeInfos.flatMap(ChangeInfo::operations))
+                        }
+                },
+                "obj" to launch(start = CoroutineStart.UNDISPATCHED) {
+                    document1.events("$.obj.c1").filterIsInstance<Event.RemoteChange>()
+                        .collect {
+                            document1ObjOps.addAll(it.changeInfos.flatMap(ChangeInfo::operations))
+                        }
+                },
+            )
+
+            document2.updateAsync {
+                it.setNewArray("todos").putNewObject().apply {
+                    set("text", "todo1")
+                    set("completed", false)
+                }
+                it.setNewObject("obj").setNewObject("c1").apply {
+                    set("name", "josh")
+                    set("age", 14)
+                }
+            }.await()
+
+            withTimeout(1_000) {
+                while (document1Ops.size < 2
+                    || document1TodosOps.isEmpty()
+                    || document1ObjOps.isEmpty()
+                ) {
+                    println(document1Ops)
+                    delay(50)
+                }
+            }
+
+            assertEquals(
+                listOf(
+                    SetOpInfo(path = "$", key = "todos"),
+                    AddOpInfo(path = "$.todos", index = 0),
+                    SetOpInfo(path = "$.todos.0", key = "text"),
+                    SetOpInfo(path = "$.todos.0", key = "completed"),
+                    SetOpInfo(path = "$", key = "obj"),
+                    SetOpInfo(path = "$.obj", key = "c1"),
+                    SetOpInfo(path = "$.obj.c1", key = "name"),
+                    SetOpInfo(path = "$.obj.c1", key = "age"),
+                ),
+                document1Ops,
+            )
+            assertEquals(
+                listOf<OperationInfo>(
+                    SetOpInfo(path = "$.todos.0", key = "text"),
+                    SetOpInfo(path = "$.todos.0", key = "completed"),
+                ),
+                document1TodosOps,
+            )
+            assertEquals(
+                listOf<OperationInfo>(
+                    SetOpInfo(path = "$.obj.c1", key = "name"),
+                    SetOpInfo(path = "$.obj.c1", key = "age"),
+                ),
+                document1ObjOps,
+            )
+            document1Ops.clear()
+            document1TodosOps.clear()
+            document1ObjOps.clear()
+
+            document2.updateAsync {
+                it.getAs<JsonObject>("obj").getAs<JsonObject>("c1")["name"] = "john"
+            }.await()
+
+            withTimeout(1_000) {
+                while (document1Ops.isEmpty() || document1ObjOps.isEmpty()) {
+                    delay(50)
+                }
+            }
+
+            assertEquals(SetOpInfo(path = "$.obj.c1", key = "name"), document1Ops.first())
+            assertEquals(SetOpInfo(path = "$.obj.c1", key = "name"), document1ObjOps.first())
+            document1Ops.clear()
+            document1ObjOps.clear()
+
+            document2.updateAsync {
+                it.getAs<JsonArray>("todos").getAs<JsonObject>(0)?.set("completed", true)
+            }.await()
+
+            withTimeout(1_000) {
+                while (document1Ops.isEmpty() || document1TodosOps.isEmpty()) {
+                    delay(50)
+                }
+            }
+
+            assertEquals(SetOpInfo(path = "$.todos.0", key = "completed"), document1Ops.first())
+            assertEquals(
+                SetOpInfo(path = "$.todos.0", key = "completed"),
+                document1TodosOps.first(),
+            )
+            document1Ops.clear()
+            document1TodosOps.clear()
+
+            collectJobs["todos"]?.cancel()
+            document2.updateAsync {
+                it.getAs<JsonArray>("todos").getAs<JsonObject>(0)?.set("text", "todo_1")
+            }.await()
+
+            withTimeout(1_000) {
+                while (document1Ops.isEmpty()) {
+                    delay(50)
+                }
+            }
+
+            assertEquals(SetOpInfo(path = "$.todos.0", key = "text"), document1Ops.first())
+            assert(document1TodosOps.isEmpty())
+            document1Ops.clear()
+
+            collectJobs["obj"]?.cancel()
+            document2.updateAsync {
+                it.getAs<JsonObject>("obj").getAs<JsonObject>("c1")["age"] = 15
+            }.await()
+
+            withTimeout(1_000) {
+                while (document1Ops.isEmpty()) {
+                    delay(50)
+                }
+            }
+
+            assertEquals(SetOpInfo(path = "$.obj.c1", key = "age"), document1Ops.first())
+            assert(document1ObjOps.isEmpty())
+
+            collectJobs.values.forEach(Job::cancel)
         }
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/Change.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/Change.kt
@@ -1,6 +1,7 @@
 package dev.yorkie.document.change
 
 import dev.yorkie.document.crdt.CrdtRoot
+import dev.yorkie.document.operation.InternalOpInfo
 import dev.yorkie.document.operation.Operation
 import dev.yorkie.document.time.ActorID
 
@@ -20,8 +21,8 @@ public data class Change internal constructor(
         id = id.setActor(actorID)
     }
 
-    internal fun execute(root: CrdtRoot) {
-        operations.forEach {
+    internal fun execute(root: CrdtRoot): List<InternalOpInfo> {
+        return operations.flatMap {
             it.execute(root)
         }
     }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/Change.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/Change.kt
@@ -1,7 +1,7 @@
 package dev.yorkie.document.change
 
 import dev.yorkie.document.crdt.CrdtRoot
-import dev.yorkie.document.operation.InternalOpInfo
+import dev.yorkie.document.operation.OperationInfo
 import dev.yorkie.document.operation.Operation
 import dev.yorkie.document.time.ActorID
 
@@ -21,7 +21,7 @@ public data class Change internal constructor(
         id = id.setActor(actorID)
     }
 
-    internal fun execute(root: CrdtRoot): List<InternalOpInfo> {
+    internal fun execute(root: CrdtRoot): List<OperationInfo> {
         return operations.flatMap {
             it.execute(root)
         }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/Change.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/Change.kt
@@ -1,8 +1,8 @@
 package dev.yorkie.document.change
 
 import dev.yorkie.document.crdt.CrdtRoot
-import dev.yorkie.document.operation.OperationInfo
 import dev.yorkie.document.operation.Operation
+import dev.yorkie.document.operation.OperationInfo
 import dev.yorkie.document.time.ActorID
 
 /**

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtRoot.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtRoot.kt
@@ -49,11 +49,10 @@ internal class CrdtRoot(val rootObject: CrdtObject) {
         while (true) {
             val parent = pair.parent ?: break
             val currentCreatedAt = pair.element.createdAt
-            var subPath = parent.subPathOf(currentCreatedAt)
+            val subPath = parent.subPathOf(currentCreatedAt)
             if (subPath == null) {
                 YorkieLogger.e(TAG, "fail to find the given element: $currentCreatedAt")
             } else {
-                subPath = subPath.replace(Regex("/[\$.]/g"), "\\$&")
                 subPaths.add(0, subPath)
             }
             pair = elementPairMapByCreatedAt[parent.createdAt] ?: break

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonArray.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonArray.kt
@@ -7,6 +7,7 @@ import dev.yorkie.document.crdt.CrdtObject
 import dev.yorkie.document.crdt.CrdtPrimitive
 import dev.yorkie.document.crdt.ElementRht
 import dev.yorkie.document.operation.AddOperation
+import dev.yorkie.document.operation.MoveOperation
 import dev.yorkie.document.operation.RemoveOperation
 import dev.yorkie.document.time.TimeTicket
 import java.util.Date
@@ -120,6 +121,19 @@ public class JsonArray internal constructor(
         )
         context.registerRemovedElement(deleted)
         return deleted.toJsonElement(context)
+    }
+
+    public fun moveAfter(prevCreatedAt: TimeTicket, createdAt: TimeTicket) {
+        val executedAt = context.issueTimeTicket()
+        target.moveAfter(prevCreatedAt, createdAt, executedAt)
+        context.push(
+            MoveOperation(
+                parentCreatedAt = target.createdAt,
+                prevCreatedAt = prevCreatedAt,
+                createdAt = createdAt,
+                executedAt = executedAt,
+            ),
+        )
     }
 
     override fun contains(element: JsonElement): Boolean {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonElement.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonElement.kt
@@ -28,7 +28,6 @@ public abstract class JsonElement {
             CrdtCounter::class.java to JsonCounter::class.java,
         )
 
-        @Suppress("UNCHECKED_CAST")
         internal inline fun <reified T : JsonElement> CrdtElement.toJsonElement(
             context: ChangeContext,
         ): T {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonPrimitive.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonPrimitive.kt
@@ -2,7 +2,6 @@ package dev.yorkie.document.json
 
 import com.google.protobuf.ByteString
 import dev.yorkie.document.crdt.CrdtPrimitive
-import dev.yorkie.document.crdt.CrdtPrimitive.Type
 import java.util.Date
 
 /**

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonText.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonText.kt
@@ -43,7 +43,7 @@ public class JsonText internal constructor(
 
         val range = target.createRange(fromIndex, toIndex)
         val executedAt = context.issueTimeTicket()
-        val maxCreatedAtMapByActor = target.edit(range, content, executedAt, attributes)
+        val maxCreatedAtMapByActor = target.edit(range, content, executedAt, attributes).first
         context.push(
             EditOperation(
                 fromPos = range.first,

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
@@ -25,17 +25,16 @@ internal data class AddOperation(
     /**
      * Executes this [AddOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot): List<InternalOpInfo> {
+    override fun execute(root: CrdtRoot): List<OperationInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtArray) {
             val copiedValue = value.deepCopy()
             parentObject.insertAfter(prevCreatedAt, copiedValue)
             root.registerElement(copiedValue, parentObject)
             listOf(
-                InternalOpInfo(
-                    parentCreatedAt,
-                    OperationInfo.AddOpInfo(parentObject.subPathOf(effectedCreatedAt).toInt()),
-                ),
+                OperationInfo.AddOpInfo(parentObject.subPathOf(effectedCreatedAt).toInt()).apply {
+                    executedAt = parentCreatedAt
+                },
             )
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
@@ -25,15 +25,22 @@ internal data class AddOperation(
     /**
      * Executes this [AddOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot) {
+    override fun execute(root: CrdtRoot): List<InternalOpInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
-        if (parentObject is CrdtArray) {
+        return if (parentObject is CrdtArray) {
             val copiedValue = value.deepCopy()
             parentObject.insertAfter(prevCreatedAt, copiedValue)
             root.registerElement(copiedValue, parentObject)
+            listOf(
+                InternalOpInfo(
+                    parentCreatedAt,
+                    OperationInfo.AddOpInfo(parentObject.subPathOf(effectedCreatedAt).toInt()),
+                ),
+            )
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")
             YorkieLogger.e(TAG, "fail to execute, only array can execute add")
+            emptyList()
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/EditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/EditOperation.kt
@@ -29,7 +29,7 @@ internal data class EditOperation(
     override val effectedCreatedAt: TimeTicket
         get() = parentCreatedAt
 
-    override fun execute(root: CrdtRoot): List<InternalOpInfo> {
+    override fun execute(root: CrdtRoot): List<OperationInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtText) {
             val changes = parentObject.edit(
@@ -44,16 +44,15 @@ internal data class EditOperation(
             }
             changes.map { (type, _, from, to, content, attributes) ->
                 if (type == TextChangeType.Content) {
-                    InternalOpInfo(
-                        parentCreatedAt,
-                        OperationInfo.EditOpInfo(
-                            from,
-                            to,
-                            TextWithAttributes(content.orEmpty() to attributes.orEmpty()),
-                        ),
+                    OperationInfo.EditOpInfo(
+                        from,
+                        to,
+                        TextWithAttributes(content.orEmpty() to attributes.orEmpty()),
                     )
                 } else {
-                    InternalOpInfo(parentCreatedAt, OperationInfo.SelectOpInfo(from, to))
+                    OperationInfo.SelectOpInfo(from, to)
+                }.apply {
+                    executedAt = parentCreatedAt
                 }
             }
         } else {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/IncreaseOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/IncreaseOperation.kt
@@ -27,7 +27,7 @@ internal data class IncreaseOperation(
     /**
      * Executes this [IncreaseOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot): List<InternalOpInfo> {
+    override fun execute(root: CrdtRoot): List<OperationInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtCounter) {
             val copiedValue = value.deepCopy() as CrdtPrimitive
@@ -38,10 +38,9 @@ internal data class IncreaseOperation(
                 copiedValue.value as Long
             }
             listOf(
-                InternalOpInfo(
-                    effectedCreatedAt,
-                    OperationInfo.IncreaseOpInfo(increasedValue),
-                ),
+                OperationInfo.IncreaseOpInfo(increasedValue).apply {
+                    executedAt = effectedCreatedAt
+                },
             )
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
@@ -24,17 +24,16 @@ internal data class MoveOperation(
     /**
      * Executes this [MoveOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot): List<InternalOpInfo> {
+    override fun execute(root: CrdtRoot): List<OperationInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtArray) {
             val previousIndex = parentObject.subPathOf(createdAt).toInt()
             parentObject.moveAfter(prevCreatedAt, createdAt, executedAt)
             val index = parentObject.subPathOf(createdAt).toInt()
             listOf(
-                InternalOpInfo(
-                    parentCreatedAt,
-                    OperationInfo.MoveOpInfo(previousIndex = previousIndex, index = index),
-                ),
+                OperationInfo.MoveOpInfo(previousIndex = previousIndex, index = index).apply {
+                    executedAt = parentCreatedAt
+                },
             )
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
@@ -24,13 +24,22 @@ internal data class MoveOperation(
     /**
      * Executes this [MoveOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot) {
+    override fun execute(root: CrdtRoot): List<InternalOpInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
-        if (parentObject is CrdtArray) {
+        return if (parentObject is CrdtArray) {
+            val previousIndex = parentObject.subPathOf(createdAt).toInt()
             parentObject.moveAfter(prevCreatedAt, createdAt, executedAt)
+            val index = parentObject.subPathOf(createdAt).toInt()
+            listOf(
+                InternalOpInfo(
+                    parentCreatedAt,
+                    OperationInfo.MoveOpInfo(previousIndex = previousIndex, index = index),
+                ),
+            )
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")
             YorkieLogger.e(TAG, "fail to execute, only array can execute move")
+            emptyList()
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/Operation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/Operation.kt
@@ -22,7 +22,7 @@ internal abstract class Operation {
     /**
      * Executes this [Operation] on the given [root].
      */
-    abstract fun execute(root: CrdtRoot): List<InternalOpInfo>
+    abstract fun execute(root: CrdtRoot): List<OperationInfo>
 
     /**
      * Sets the given [ActorID] to this [Operation].

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/Operation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/Operation.kt
@@ -22,7 +22,7 @@ internal abstract class Operation {
     /**
      * Executes this [Operation] on the given [root].
      */
-    abstract fun execute(root: CrdtRoot)
+    abstract fun execute(root: CrdtRoot): List<InternalOpInfo>
 
     /**
      * Sets the given [ActorID] to this [Operation].

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/OperationInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/OperationInfo.kt
@@ -1,0 +1,63 @@
+package dev.yorkie.document.operation
+
+import dev.yorkie.document.crdt.TextWithAttributes
+import dev.yorkie.document.time.TimeTicket
+
+/**
+ * [OperationInfo] represents the information of an operation.
+ * It is used to inform to the user what kind of operation was executed.
+ */
+public sealed class OperationInfo {
+
+    public abstract var path: String
+
+    public data class AddOpInfo(val index: Int, override var path: String = INITIAL_PATH) :
+        OperationInfo()
+
+    public data class MoveOpInfo(
+        val previousIndex: Int,
+        val index: Int,
+        override var path: String = INITIAL_PATH,
+    ) : OperationInfo()
+
+    public data class SetOpInfo(val key: String, override var path: String = INITIAL_PATH) :
+        OperationInfo()
+
+    public data class RemoveOpInfo(
+        val key: String?,
+        val index: Int?,
+        override var path: String = INITIAL_PATH,
+    ) : OperationInfo()
+
+    public data class IncreaseOpInfo(val value: Number, override var path: String = INITIAL_PATH) :
+        OperationInfo()
+
+    public data class EditOpInfo(
+        val from: Int,
+        val to: Int,
+        val value: TextWithAttributes,
+        override var path: String = INITIAL_PATH,
+    ) : OperationInfo()
+
+    public data class StyleOpInfo(
+        val from: Int,
+        val to: Int,
+        val value: TextWithAttributes,
+        override var path: String = INITIAL_PATH,
+    ) : OperationInfo()
+
+    public data class SelectOpInfo(
+        val from: Int,
+        val to: Int,
+        override var path: String = INITIAL_PATH,
+    ) : OperationInfo()
+
+    companion object {
+        const val INITIAL_PATH = "initial path"
+    }
+}
+
+internal data class InternalOpInfo(
+    val element: TimeTicket,
+    val operationInfo: OperationInfo,
+)

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/OperationInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/OperationInfo.kt
@@ -11,6 +11,8 @@ public sealed class OperationInfo {
 
     public abstract var path: String
 
+    internal var executedAt: TimeTicket = TimeTicket.InitialTimeTicket
+
     public data class AddOpInfo(val index: Int, override var path: String = INITIAL_PATH) :
         OperationInfo()
 
@@ -42,7 +44,7 @@ public sealed class OperationInfo {
     public data class StyleOpInfo(
         val from: Int,
         val to: Int,
-        val value: TextWithAttributes,
+        val attributes: Map<String, String>,
         override var path: String = INITIAL_PATH,
     ) : OperationInfo()
 
@@ -53,11 +55,6 @@ public sealed class OperationInfo {
     ) : OperationInfo()
 
     companion object {
-        const val INITIAL_PATH = "initial path"
+        private const val INITIAL_PATH = "initial path"
     }
 }
-
-internal data class InternalOpInfo(
-    val element: TimeTicket,
-    val operationInfo: OperationInfo,
-)

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/RemoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/RemoveOperation.kt
@@ -24,7 +24,7 @@ internal data class RemoveOperation(
     /**
      * Executes this [RemoveOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot): List<InternalOpInfo> {
+    override fun execute(root: CrdtRoot): List<OperationInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtContainer) {
             val key = parentObject.subPathOf(createdAt)
@@ -32,10 +32,9 @@ internal data class RemoveOperation(
             root.registerRemovedElement(element)
             val index = if (parentObject is CrdtArray) key?.toInt() else null
             listOf(
-                InternalOpInfo(
-                    effectedCreatedAt,
-                    OperationInfo.RemoveOpInfo(key, index),
-                ),
+                OperationInfo.RemoveOpInfo(key, index).apply {
+                    executedAt = effectedCreatedAt
+                },
             )
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/SelectOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/SelectOperation.kt
@@ -20,13 +20,21 @@ internal data class SelectOperation(
     /**
      * Returns the created time of the effected element.
      */
-    override fun execute(root: CrdtRoot) {
+    override fun execute(root: CrdtRoot): List<InternalOpInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
-        if (parentObject is CrdtText) {
-            parentObject.select(RgaTreeSplitNodeRange(fromPos, toPos), executedAt)
+        return if (parentObject is CrdtText) {
+            val change = parentObject.select(RgaTreeSplitNodeRange(fromPos, toPos), executedAt)
+                ?: return emptyList()
+            listOf(
+                InternalOpInfo(
+                    parentCreatedAt,
+                    OperationInfo.SelectOpInfo(from = change.from, to = change.to),
+                ),
+            )
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")
             YorkieLogger.e(TAG, "fail to execute, only Text, RichText can execute select")
+            emptyList()
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/SelectOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/SelectOperation.kt
@@ -20,16 +20,15 @@ internal data class SelectOperation(
     /**
      * Returns the created time of the effected element.
      */
-    override fun execute(root: CrdtRoot): List<InternalOpInfo> {
+    override fun execute(root: CrdtRoot): List<OperationInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtText) {
             val change = parentObject.select(RgaTreeSplitNodeRange(fromPos, toPos), executedAt)
                 ?: return emptyList()
             listOf(
-                InternalOpInfo(
-                    parentCreatedAt,
-                    OperationInfo.SelectOpInfo(from = change.from, to = change.to),
-                ),
+                OperationInfo.SelectOpInfo(from = change.from, to = change.to).apply {
+                    executedAt = parentCreatedAt
+                },
             )
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
@@ -26,15 +26,17 @@ internal data class SetOperation(
     /**
      * Executes this [SetOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot) {
+    override fun execute(root: CrdtRoot): List<InternalOpInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
-        if (parentObject is CrdtObject) {
+        return if (parentObject is CrdtObject) {
             val copiedValue = value.deepCopy()
             parentObject[key] = copiedValue
             root.registerElement(copiedValue, parentObject)
+            listOf(InternalOpInfo(parentCreatedAt, OperationInfo.SetOpInfo(key)))
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")
             YorkieLogger.e(TAG, "fail to execute, only object can execute set")
+            emptyList()
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
@@ -26,13 +26,17 @@ internal data class SetOperation(
     /**
      * Executes this [SetOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot): List<InternalOpInfo> {
+    override fun execute(root: CrdtRoot): List<OperationInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtObject) {
             val copiedValue = value.deepCopy()
             parentObject[key] = copiedValue
             root.registerElement(copiedValue, parentObject)
-            listOf(InternalOpInfo(parentCreatedAt, OperationInfo.SetOpInfo(key)))
+            listOf(
+                OperationInfo.SetOpInfo(key).apply {
+                    executedAt = parentCreatedAt
+                },
+            )
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")
             YorkieLogger.e(TAG, "fail to execute, only object can execute set")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt
@@ -4,7 +4,6 @@ import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.crdt.CrdtText
 import dev.yorkie.document.crdt.RgaTreeSplitNodePos
 import dev.yorkie.document.crdt.RgaTreeSplitNodeRange
-import dev.yorkie.document.crdt.TextWithAttributes
 import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.util.YorkieLogger
 
@@ -19,20 +18,19 @@ internal data class StyleOperation(
     override val effectedCreatedAt: TimeTicket
         get() = parentCreatedAt
 
-    override fun execute(root: CrdtRoot): List<InternalOpInfo> {
+    override fun execute(root: CrdtRoot): List<OperationInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtText) {
             val changes =
                 parentObject.style(RgaTreeSplitNodeRange(fromPos, toPos), attributes, executedAt)
             changes.map {
-                InternalOpInfo(
-                    parentCreatedAt,
-                    OperationInfo.StyleOpInfo(
-                        it.from,
-                        it.to,
-                        TextWithAttributes(it.content.orEmpty() to it.attributes.orEmpty()),
-                    ),
-                )
+                OperationInfo.StyleOpInfo(
+                    it.from,
+                    it.to,
+                    it.attributes.orEmpty(),
+                ).apply {
+                    executedAt = parentCreatedAt
+                }
             }
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")

--- a/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
@@ -24,6 +24,7 @@ import dev.yorkie.document.operation.EditOperation
 import dev.yorkie.document.operation.IncreaseOperation
 import dev.yorkie.document.operation.MoveOperation
 import dev.yorkie.document.operation.Operation
+import dev.yorkie.document.operation.OperationInfo
 import dev.yorkie.document.operation.RemoveOperation
 import dev.yorkie.document.operation.SelectOperation
 import dev.yorkie.document.operation.SetOperation
@@ -371,9 +372,7 @@ class ConverterTest {
         override var executedAt: TimeTicket,
         override val effectedCreatedAt: TimeTicket,
     ) : Operation() {
-        override fun execute(root: CrdtRoot) {
-            println("should throw IllegalArgumentException")
-        }
+        override fun execute(root: CrdtRoot): List<OperationInfo> = emptyList()
     }
 
     private class TestCrdtElement(


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- provide a new API that allows users to subscribe to the document with a specific target path.
- improve the event value of Local/RemoteChange.

you can read the full description for these tasks from the following [link](https://github.com/yorkie-team/yorkie-js-sdk/pull/487#issue-1643050373).

#### Any background context you want to provide?
some previously written instrumentation tests are failing occasionally. I'll fix them in a separate PR.

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
related to https://github.com/yorkie-team/yorkie-js-sdk/pull/487, https://github.com/yorkie-team/yorkie-js-sdk/issues/445

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
