### PR TITLE
Fix PresenceInfo inconsistency and test failures

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -95,7 +95,7 @@ class ClientTest {
                 it["k1"] = "v1"
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (client2Events.none { it is DocumentSynced }) {
                     delay(50)
                 }
@@ -377,7 +377,7 @@ class ClientTest {
             document2.updateAsync {
                 it["c2"] = 0
             }.await()
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 // size should be 2 since it has local-change and remote-change
                 while (document1Events.size < 2 || document2Events.size < 2) {
                     delay(50)
@@ -397,7 +397,7 @@ class ClientTest {
             document2.updateAsync {
                 it["c2"] = 1
             }.await()
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Events.size < 3 ||
                     document2Events.size < 3 ||
                     document3Events.size < 2
@@ -412,7 +412,7 @@ class ClientTest {
             // 04. c1 and c2 sync with push-pull mode.
             client1.resumeRemoteChanges(document1)
             client2.resumeRemoteChanges(document2)
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Events.size < 4 || document2Events.size < 4) {
                     delay(50)
                 }

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -95,7 +95,7 @@ class ClientTest {
                 it["k1"] = "v1"
             }.await()
 
-            withTimeout(1_000L) {
+            withTimeout(1_000) {
                 while (client2Events.none { it is DocumentSynced }) {
                     delay(50)
                 }
@@ -377,7 +377,7 @@ class ClientTest {
             document2.updateAsync {
                 it["c2"] = 0
             }.await()
-            withTimeout(1_000L) {
+            withTimeout(1_000) {
                 // size should be 2 since it has local-change and remote-change
                 while (document1Events.size < 2 || document2Events.size < 2) {
                     delay(50)
@@ -397,7 +397,7 @@ class ClientTest {
             document2.updateAsync {
                 it["c2"] = 1
             }.await()
-            withTimeout(1_000L) {
+            withTimeout(1_000) {
                 while (document1Events.size < 3 ||
                     document2Events.size < 3 ||
                     document3Events.size < 2
@@ -412,7 +412,7 @@ class ClientTest {
             // 04. c1 and c2 sync with push-pull mode.
             client1.resumeRemoteChanges(document1)
             client2.resumeRemoteChanges(document2)
-            withTimeout(1_000L) {
+            withTimeout(1_000) {
                 while (document1Events.size < 4 || document2Events.size < 4) {
                     delay(50)
                 }

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
@@ -276,7 +276,7 @@ class DocumentTest {
                 }
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document2Ops.size < 4) {
                     delay(50)
                 }
@@ -296,7 +296,7 @@ class DocumentTest {
                 }
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.size < 3) {
                     delay(50)
                 }
@@ -386,7 +386,7 @@ class DocumentTest {
                 }
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 // ops: counter, todos, todoOps: todos
                 while (document1Ops.size < 2 || document1TodosOps.isEmpty()) {
                     delay(50)
@@ -416,7 +416,7 @@ class DocumentTest {
                 it.getAs<JsonCounter>("counter").increase(10)
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.isEmpty() || document1CounterOps.isEmpty()) {
                     delay(50)
                 }
@@ -434,7 +434,7 @@ class DocumentTest {
                 it.getAs<JsonArray>("todos").put("todo3")
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.isEmpty() || document1TodosOps.isEmpty()) {
                     delay(50)
                 }
@@ -450,7 +450,7 @@ class DocumentTest {
                 it.getAs<JsonArray>("todos").put("todo4")
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.isEmpty()) {
                     delay(50)
                 }
@@ -465,7 +465,7 @@ class DocumentTest {
                 it.getAs<JsonCounter>("counter").increase(10)
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.isEmpty()) {
                     delay(50)
                 }
@@ -516,7 +516,7 @@ class DocumentTest {
                 }
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.size < 2 ||
                     document1TodosOps.isEmpty() ||
                     document1ObjOps.isEmpty()
@@ -561,7 +561,7 @@ class DocumentTest {
                 it.getAs<JsonObject>("obj").getAs<JsonObject>("c1")["name"] = "john"
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.isEmpty() || document1ObjOps.isEmpty()) {
                     delay(50)
                 }
@@ -576,7 +576,7 @@ class DocumentTest {
                 it.getAs<JsonArray>("todos").getAs<JsonObject>(0)?.set("completed", true)
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.isEmpty() || document1TodosOps.isEmpty()) {
                     delay(50)
                 }
@@ -595,7 +595,7 @@ class DocumentTest {
                 it.getAs<JsonArray>("todos").getAs<JsonObject>(0)?.set("text", "todo_1")
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.isEmpty()) {
                     delay(50)
                 }
@@ -610,7 +610,7 @@ class DocumentTest {
                 it.getAs<JsonObject>("obj").getAs<JsonObject>("c1")["age"] = 15
             }.await()
 
-            withTimeout(1_000) {
+            withTimeout(2_000) {
                 while (document1Ops.isEmpty()) {
                     delay(50)
                 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR is to resolve instrumentation tests failures.
- fix `realTimeAttachments()` returning outdated presenceInfo by modifying it to use only the document key instead.
- adjust timeout limits for certain tests due to occasional delays in server response.

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
