### PR TITLE
Add Presence for Client.Options

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
       - run: ./gradlew dokkaHtml
       - uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/JsonTestUtils.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/JsonTestUtils.kt
@@ -6,7 +6,7 @@ import com.google.gson.Gson
 import com.google.gson.JsonObject
 import org.junit.Assert.assertEquals
 
-private val gson = Gson()
+internal val gson = Gson()
 
 fun assertJsonContentEquals(expected: String, actual: String) {
     val expectedJson = gson.fromJson(expected, JsonObject::class.java)

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -13,8 +13,6 @@ import dev.yorkie.document.change.CheckPoint
 import dev.yorkie.document.json.JsonCounter
 import dev.yorkie.document.json.JsonPrimitive
 import dev.yorkie.document.operation.OperationInfo
-import dev.yorkie.document.operation.RemoveOperation
-import dev.yorkie.document.operation.SetOperation
 import dev.yorkie.gson
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -15,6 +15,7 @@ import dev.yorkie.document.json.JsonCounter
 import dev.yorkie.document.json.JsonPrimitive
 import dev.yorkie.document.operation.RemoveOperation
 import dev.yorkie.document.operation.SetOperation
+import dev.yorkie.gson
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -477,6 +478,60 @@ class ClientTest {
 
             client.detachAsync(document).await()
             client.deactivateAsync().await()
+        }
+    }
+
+    @Test
+    fun test_access_peer_presence() {
+        runBlocking {
+            data class Cursor(val x: Int, val y: Int)
+
+            val serializedCursor = gson.toJson(Cursor(1, 1))
+
+            val client1 = createClient(presence = Presence(mapOf("name" to "a")))
+            val client2 = createClient(
+                presence = Presence(mapOf("name" to "b", "cursor" to serializedCursor)),
+            )
+            val client1Events = mutableListOf<Client.Event>()
+            val client1EventsJob = launch(start = CoroutineStart.UNDISPATCHED) {
+                client1.events.collect(client1Events::add)
+            }
+
+            client1.activateAsync().await()
+            client2.activateAsync().await()
+
+            val documentKey = UUID.randomUUID().toString().toDocKey()
+            val document1 = Document(documentKey)
+            val document2 = Document(documentKey)
+
+            client1.attachAsync(document1).await()
+            withTimeout(2_000) {
+                // initialized
+                while (client1Events.isEmpty()) {
+                    delay(50)
+                }
+            }
+            assertEquals(
+                null,
+                client1.peerStatusByDoc(documentKey).first()[client2.requireClientId()]?.data,
+            )
+
+            client2.attachAsync(document2).await()
+            withTimeout(2_000) {
+                client1.peerStatusByDoc(documentKey).first {
+                    it[client2.requireClientId()]?.data != null
+                }
+            }
+            assertEquals(
+                mapOf("name" to "b", "cursor" to serializedCursor),
+                client1.peerStatusByDoc(documentKey).first()[client2.requireClientId()]?.data,
+            )
+
+            client1EventsJob.cancel()
+            client1.detachAsync(document1).await()
+            client2.detachAsync(document2).await()
+            client1.deactivateAsync().await()
+            client2.deactivateAsync().await()
         }
     }
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
@@ -6,11 +6,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 import java.util.UUID
 
-fun createClient() = Client(
+fun createClient(presence: Presence? = null) = Client(
     InstrumentationRegistry.getInstrumentation().targetContext,
     "10.0.2.2",
     8080,
     usePlainText = true,
+    options = Client.Options(presence = presence)
 )
 
 fun String.toDocKey(): Document.Key {

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
@@ -11,7 +11,7 @@ fun createClient(presence: Presence? = null) = Client(
     "10.0.2.2",
     8080,
     usePlainText = true,
-    options = Client.Options(presence = presence)
+    options = Client.Options(presence = presence),
 )
 
 fun String.toDocKey(): Document.Key {

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -93,7 +93,7 @@ public class Client @VisibleForTesting internal constructor(
     private val _peerStatus = MutableStateFlow(emptyMap<Document.Key, Peers>())
     public val peerStatus = _peerStatus.asStateFlow()
 
-    public var presenceInfo = options.presence ?: PresenceInfo(0, emptyMap())
+    public var presenceInfo = PresenceInfo(0, options.presence?.value.orEmpty())
         private set
 
     private val service by lazy {
@@ -737,7 +737,7 @@ public class Client @VisibleForTesting internal constructor(
          * If the [Client] attaches a [Document], the [PresenceInfo] is sent to the other peers
          * attached to the [Document].
          */
-        public val presence: PresenceInfo? = null,
+        public val presence: Presence? = null,
         /**
          * API key of the project used to identify the project.
          */

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Peers.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Peers.kt
@@ -24,6 +24,9 @@ public class Peers private constructor(
 }
 
 public data class PresenceInfo(
-    public val clock: Int,
+    internal val clock: Int,
     public val data: Map<String, String>,
 )
+
+@JvmInline
+public value class Presence(val value: Map<String, String>)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Currently, users set `Client.Options.presence` using `PresenceInfo` directly, but I think it is not advisable for users to manipulate or access `PresenceInfo.clock` directly. (iOS, JS SDKs are not exposing it to users.)
To address this, I have made `clock` property internally visible only and added `Presence` value class.
I also added a test on accessing peer presences based on [this PR](https://github.com/yorkie-team/yorkie-js-sdk/pull/493).

#### Any background context you want to provide?


#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
