### PR TITLE
Implement new functions in JsonArray

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonArray.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonArray.kt
@@ -20,8 +20,6 @@ public class JsonArray internal constructor(
     internal val context: ChangeContext,
     override val target: CrdtArray,
 ) : JsonElement(), Collection<JsonElement> {
-    internal val id
-        get() = target.createdAt
 
     override val size: Int
         get() = target.length
@@ -44,45 +42,53 @@ public class JsonArray internal constructor(
         return target[createdAt]?.toJsonElement(context)
     }
 
-    public fun put(value: Boolean) = putPrimitive(value)
+    public fun put(value: Boolean, prevCreatedAt: TimeTicket? = null) =
+        putPrimitive(value, prevCreatedAt)
 
-    public fun put(value: Int) = putPrimitive(value)
+    public fun put(value: Int, prevCreatedAt: TimeTicket? = null) =
+        putPrimitive(value, prevCreatedAt)
 
-    public fun put(value: Long) = putPrimitive(value)
+    public fun put(value: Long, prevCreatedAt: TimeTicket? = null) =
+        putPrimitive(value, prevCreatedAt)
 
-    public fun put(value: Double) = putPrimitive(value)
+    public fun put(value: Double, prevCreatedAt: TimeTicket? = null) =
+        putPrimitive(value, prevCreatedAt)
 
-    public fun put(value: String) = putPrimitive(value)
+    public fun put(value: String, prevCreatedAt: TimeTicket? = null) =
+        putPrimitive(value, prevCreatedAt)
 
-    public fun put(value: ByteArray) = putPrimitive(value)
+    public fun put(value: ByteArray, prevCreatedAt: TimeTicket? = null) =
+        putPrimitive(value, prevCreatedAt)
 
-    public fun put(value: Date) = putPrimitive(value)
+    public fun put(value: Date, prevCreatedAt: TimeTicket? = null) =
+        putPrimitive(value, prevCreatedAt)
 
-    public fun put(value: JsonPrimitive) = putPrimitive(value)
+    public fun put(value: JsonPrimitive, prevCreatedAt: TimeTicket? = null) =
+        putPrimitive(value, prevCreatedAt)
 
-    private fun putPrimitive(value: Any) {
+    private fun putPrimitive(value: Any, prevCreatedAt: TimeTicket? = null) {
         val primitive = if (value is JsonPrimitive) {
             value.target
         } else {
             CrdtPrimitive(value, context.issueTimeTicket())
         }
-        putCrdtElement(primitive)
+        putCrdtElement(primitive, prevCreatedAt)
     }
 
-    public fun putNewObject(): JsonObject {
+    public fun putNewObject(prevCreatedAt: TimeTicket? = null): JsonObject {
         val obj = CrdtObject(context.issueTimeTicket(), rht = ElementRht())
-        putCrdtElement(obj)
+        putCrdtElement(obj, prevCreatedAt)
         return obj.toJsonElement(context)
     }
 
-    public fun putNewArray(): JsonArray {
+    public fun putNewArray(prevCreatedAt: TimeTicket? = null): JsonArray {
         val array = CrdtArray(context.issueTimeTicket())
-        putCrdtElement(array)
+        putCrdtElement(array, prevCreatedAt)
         return array.toJsonElement(context)
     }
 
-    private fun putCrdtElement(value: CrdtElement) {
-        val prevCreated = target.lastCreatedAt
+    private fun putCrdtElement(value: CrdtElement, prevCreatedAt: TimeTicket? = null) {
+        val prevCreated = prevCreatedAt ?: target.lastCreatedAt
         target.insertAfter(prevCreated, value)
         context.registerElement(value, target)
         context.push(
@@ -124,6 +130,22 @@ public class JsonArray internal constructor(
     }
 
     public fun moveAfter(prevCreatedAt: TimeTicket, createdAt: TimeTicket) {
+        moveInternal(prevCreatedAt, createdAt)
+    }
+
+    public fun moveBefore(nextCreatedAt: TimeTicket, createdAt: TimeTicket) {
+        moveInternal(target.getPrevCreatedAt(nextCreatedAt), createdAt)
+    }
+
+    public fun moveFront(createdAt: TimeTicket) {
+        moveInternal(target.head.createdAt, createdAt)
+    }
+
+    public fun moveLast(createdAt: TimeTicket) {
+        moveInternal(target.lastCreatedAt, createdAt)
+    }
+
+    private fun moveInternal(prevCreatedAt: TimeTicket, createdAt: TimeTicket) {
         val executedAt = context.issueTimeTicket()
         target.moveAfter(prevCreatedAt, createdAt, executedAt)
         context.push(

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonCounter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonCounter.kt
@@ -13,10 +13,8 @@ public class JsonCounter internal constructor(
     internal val context: ChangeContext,
     override val target: CrdtCounter,
 ) : JsonElement() {
-    public val id
-        get() = target.id
 
-    public val value
+    public val value: CounterValue
         get() = target.value
 
     public fun increase(value: Int): JsonCounter {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonElement.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonElement.kt
@@ -7,6 +7,7 @@ import dev.yorkie.document.crdt.CrdtElement
 import dev.yorkie.document.crdt.CrdtObject
 import dev.yorkie.document.crdt.CrdtPrimitive
 import dev.yorkie.document.crdt.CrdtText
+import dev.yorkie.document.time.TimeTicket
 
 /**
  * [JsonElement] is a wrapper for [CrdtElement] that provides users with an
@@ -14,6 +15,9 @@ import dev.yorkie.document.crdt.CrdtText
  */
 public abstract class JsonElement {
     internal abstract val target: CrdtElement
+
+    public val id: TimeTicket
+        get() = target.id
 
     public fun toJson() = target.toJson()
 
@@ -52,5 +56,13 @@ public abstract class JsonElement {
                 throw TypeCastException(e.message)
             }
         }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return target == (other as? JsonElement)?.target
+    }
+
+    override fun hashCode(): Int {
+        return target.hashCode()
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonObject.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonObject.kt
@@ -23,8 +23,6 @@ public class JsonObject internal constructor(
     internal val context: ChangeContext,
     override val target: CrdtObject,
 ) : JsonElement() {
-    public val id
-        get() = target.createdAt
 
     public val keys: List<String>
         get() = target.keys

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonText.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonText.kt
@@ -7,7 +7,6 @@ import dev.yorkie.document.crdt.TextWithAttributes
 import dev.yorkie.document.operation.EditOperation
 import dev.yorkie.document.operation.SelectOperation
 import dev.yorkie.document.operation.StyleOperation
-import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.util.YorkieLogger
 
 /**
@@ -17,9 +16,6 @@ public class JsonText internal constructor(
     internal val context: ChangeContext,
     override val target: CrdtText,
 ) : JsonElement() {
-
-    public val id: TimeTicket
-        get() = target.id
 
     public val values: List<TextWithAttributes>
         get() = target.values

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonArrayTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonArrayTest.kt
@@ -119,7 +119,7 @@ class JsonArrayTest {
         assertEquals("[1,2,3]", target.toJson())
 
         val firstElement = requireNotNull(target.getAs<JsonPrimitive>(0))
-        val lastElement =  requireNotNull(target.getAs<JsonPrimitive>(2))
+        val lastElement = requireNotNull(target.getAs<JsonPrimitive>(2))
         target.moveAfter(lastElement.id, firstElement.id)
         assertEquals("[2,3,1]", target.toJson())
     }
@@ -134,7 +134,7 @@ class JsonArrayTest {
         assertEquals("[1,2,3]", target.toJson())
 
         val firstElement = requireNotNull(target.getAs<JsonPrimitive>(0))
-        val lastElement =  requireNotNull(target.getAs<JsonPrimitive>(2))
+        val lastElement = requireNotNull(target.getAs<JsonPrimitive>(2))
         target.moveBefore(lastElement.id, firstElement.id)
         assertEquals("[2,1,3]", target.toJson())
     }
@@ -148,7 +148,7 @@ class JsonArrayTest {
         }
         assertEquals("[1,2,3]", target.toJson())
 
-        val lastElement =  requireNotNull(target.getAs<JsonPrimitive>(2))
+        val lastElement = requireNotNull(target.getAs<JsonPrimitive>(2))
         target.moveFront(lastElement.id)
         assertEquals("[3,1,2]", target.toJson())
     }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonArrayTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonArrayTest.kt
@@ -1,0 +1,203 @@
+package dev.yorkie.document.json
+
+import dev.yorkie.document.change.ChangeContext
+import dev.yorkie.document.change.ChangeID
+import dev.yorkie.document.crdt.CrdtArray
+import dev.yorkie.document.crdt.CrdtObject
+import dev.yorkie.document.crdt.CrdtPrimitive
+import dev.yorkie.document.crdt.CrdtRoot
+import dev.yorkie.document.crdt.ElementRht
+import dev.yorkie.document.time.TimeTicket
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+import java.util.Date
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class JsonArrayTest {
+
+    private lateinit var target: JsonArray
+
+    @Before
+    fun setUp() {
+        val obj = CrdtObject(TimeTicket.InitialTimeTicket, rht = ElementRht())
+        val array = CrdtArray(TimeTicket.InitialTimeTicket)
+        target = JsonArray(
+            ChangeContext(
+                ChangeID.InitialChangeID,
+                CrdtRoot(obj),
+                null,
+            ),
+            array,
+        )
+    }
+
+    @Test
+    fun `should put values and elements`() {
+        val jsonPrimitive = JsonPrimitive(CrdtPrimitive("json", TimeTicket.InitialTimeTicket))
+        target.apply {
+            put(false)
+            put(0)
+            put(1L)
+            put(2.0)
+            put("string")
+            put("byte array".toByteArray())
+            put(Date(1_000))
+            put(jsonPrimitive)
+            putNewArray().put(1)
+            putNewObject().setNewArray("array")
+        }
+        assertTrue(jsonPrimitive in target)
+        assertEquals(
+            """[false,0,1,2.0,"string","byte array",1000,"json",[1],{"array":[]}]""",
+            target.toJson(),
+        )
+    }
+
+    @Test
+    fun `should put values and elements with prevCreatedAt`() {
+        val inserted = listOf(
+            target.putNewArray(),
+            target.putNewObject().apply {
+                set("k1", "v1")
+            },
+        )
+        assertEquals("""[[],{"k1":"v1"}]""", target.toJson())
+        assertTrue(target.containsAll(inserted))
+
+        val array = assertIs<JsonArray>(inserted.first())
+        target.put(1, array.id)
+        assertEquals("""[[],1,{"k1":"v1"}]""", target.toJson())
+
+        val obj = assertIs<JsonObject>(inserted.last())
+        target.put(false, obj.id)
+        assertEquals("""[[],1,{"k1":"v1"},false]""", target.toJson())
+    }
+
+    @Test
+    fun `should remove elements using index`() {
+        target.apply {
+            put(0)
+            putNewArray().put("value")
+        }
+        assertEquals("""[0,["value"]]""", target.toJson())
+
+        assertIs<JsonPrimitive>(target.removeAt(0))
+        assertEquals("""[["value"]]""", target.toJson())
+
+        assertNull(target.removeAt(3))
+        assertEquals("""[["value"]]""", target.toJson())
+
+        assertIs<JsonArray>(target.removeAt(0))
+        assertTrue(target.isEmpty())
+    }
+
+    @Test
+    fun `should remove elements using TimeTicket`() {
+        val obj = target.putNewObject()
+        assertIs<JsonObject>(target.last())
+        assertTrue(target.isNotEmpty())
+
+        target.remove(obj.target.createdAt)
+        assertTrue(target.isEmpty())
+
+        assertThrows(NoSuchElementException::class.java) {
+            target.remove(TimeTicket.MaxTimeTicket)
+        }
+    }
+
+    @Test
+    fun `should handle moveAfter`() {
+        target.apply {
+            put(1)
+            put(2)
+            put(3)
+        }
+        assertEquals("[1,2,3]", target.toJson())
+
+        val firstElement = requireNotNull(target.getAs<JsonPrimitive>(0))
+        val lastElement =  requireNotNull(target.getAs<JsonPrimitive>(2))
+        target.moveAfter(lastElement.id, firstElement.id)
+        assertEquals("[2,3,1]", target.toJson())
+    }
+
+    @Test
+    fun `should handle moveBefore`() {
+        target.apply {
+            put(1)
+            put(2)
+            put(3)
+        }
+        assertEquals("[1,2,3]", target.toJson())
+
+        val firstElement = requireNotNull(target.getAs<JsonPrimitive>(0))
+        val lastElement =  requireNotNull(target.getAs<JsonPrimitive>(2))
+        target.moveBefore(lastElement.id, firstElement.id)
+        assertEquals("[2,1,3]", target.toJson())
+    }
+
+    @Test
+    fun `should handle moveFront`() {
+        target.apply {
+            put(1)
+            put(2)
+            put(3)
+        }
+        assertEquals("[1,2,3]", target.toJson())
+
+        val lastElement =  requireNotNull(target.getAs<JsonPrimitive>(2))
+        target.moveFront(lastElement.id)
+        assertEquals("[3,1,2]", target.toJson())
+    }
+
+    @Test
+    fun `should handle moveLast`() {
+        target.apply {
+            put(1)
+            put(2)
+            put(3)
+        }
+        assertEquals("[1,2,3]", target.toJson())
+
+        val firstElement = requireNotNull(target.getAs<JsonPrimitive>(0))
+        target.moveLast(firstElement.id)
+        assertEquals("[2,3,1]", target.toJson())
+    }
+
+    @Test
+    fun `should return null when index for get function does not exist`() {
+        assertNull(target[0])
+    }
+
+    @Test
+    fun `should return null when index for getAs function does not exist`() {
+        assertNull(target.getAs(0))
+    }
+
+    @Test
+    fun `should return null when TimeTicket for get function does not exist`() {
+        assertNull(target[TimeTicket.MaxTimeTicket])
+    }
+
+    @Test
+    fun `should return null when TimeTicket for getAs function does not exist`() {
+        assertNull(target.getAs(TimeTicket.MaxTimeTicket))
+    }
+
+    @Test
+    fun `should return requested type with getAs`() {
+        target.put(0)
+        val get = assertIs<JsonPrimitive>(target[0])
+        assertEquals(0, get.value)
+
+        val getAs = assertIs<JsonPrimitive>(target.getAs<JsonPrimitive>(0))
+        assertEquals(0, getAs.value)
+
+        assertThrows(TypeCastException::class.java) {
+            target.getAs<JsonArray>(0)
+        }
+    }
+}

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonCounterTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonCounterTest.kt
@@ -3,12 +3,10 @@ package dev.yorkie.document.json
 import dev.yorkie.assertJsonContentEquals
 import dev.yorkie.document.Document
 import dev.yorkie.document.crdt.CrdtCounter.CounterType
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import kotlin.test.assertEquals
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class JsonCounterTest {
     private val document = Document(Document.Key(""))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Some public functions of `JsonArray` exist in JS and iOS SDK, but not in the Android SDK. These functions include:
1. `insertAfter()`, `insertBefore()`
2. `moveAfter()`, `moveBefore()`, `moveFirst()`, `moveLast()`
3. [`splice()`](https://github.com/yorkie-team/yorkie-js-sdk/blob/72ab98e0abaaa2795025af8baeac99415276733a/src/document/json/array.ts#L556)

Regarding the insert functions (1), it is kind of tricky to implement them as separate functions in the Android SDK, so I implemented the same feature of `insertAfter()` by modifying the `put` methods. I guess `insertAfter()` can cover the expected behaviors of `insertBefore()`, so I did not implement it.

The move functions (2) are implemented the same way as in other SDKs. 

As for `splice()`, it is a JavaScript method and seems unnecessary for Kotlin. (I am considering adding `replace()` instead of `splice()`, but maybe it would be better to keep it until it is actually necessary).

+) All the `JsonElement`s have `id`, so I defined `id` property in `JsonElement` instead of implementing it in each of its child class.

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
