### PR TITLE
Replace Text.onChanges() with Document event stream subscription

### DIFF
--- a/examples/kanban/src/main/java/com/example/kanbanapp/KanbanBoardViewModel.kt
+++ b/examples/kanban/src/main/java/com/example/kanbanapp/KanbanBoardViewModel.kt
@@ -32,13 +32,13 @@ class KanbanBoardViewModel(private val client: Client) : ViewModel() {
         viewModelScope.launch {
             client.events.collect {
                 if (it is Client.Event.DocumentSynced) {
-                    try {
-                        updateDocument(it.result.document.getRoot().getAs(DOCUMENT_LIST_KEY))
-                    } catch (e: Exception) {
-                        document.updateAsync { jsonObject ->
-                            jsonObject.setNewArray(DOCUMENT_LIST_KEY)
-                        }.await()
-                    }
+                    it.result.document.getRoot().getAsOrNull<JsonArray>(DOCUMENT_LIST_KEY)
+                        ?.let(::updateDocument)
+                        ?: run {
+                            document.updateAsync { root ->
+                                root.setNewArray(DOCUMENT_LIST_KEY)
+                            }.await()
+                        }
                 }
             }
         }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TextInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TextInfo.kt
@@ -4,11 +4,7 @@ import dev.yorkie.document.json.escapeString
 import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket
 
-/**
- * The value passed as an argument to [CrdtText.onChanges].
- * [CrdtText.onChanges] is called when the [CrdtText] is modified.
- */
-public data class TextChange(
+internal data class TextChange(
     val type: TextChangeType,
     val actor: ActorID,
     val from: Int,
@@ -20,7 +16,7 @@ public data class TextChange(
 /**
  * The type of [TextChange].
  */
-public enum class TextChangeType {
+internal enum class TextChangeType {
     Content, Selection, Style
 }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/OperationInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/OperationInfo.kt
@@ -13,6 +13,8 @@ public sealed class OperationInfo {
 
     internal var executedAt: TimeTicket = TimeTicket.InitialTimeTicket
 
+    public interface TextOpInfo
+
     public data class AddOpInfo(val index: Int, override var path: String = INITIAL_PATH) :
         OperationInfo()
 
@@ -39,20 +41,20 @@ public sealed class OperationInfo {
         val to: Int,
         val value: TextWithAttributes,
         override var path: String = INITIAL_PATH,
-    ) : OperationInfo()
+    ) : OperationInfo(), TextOpInfo
 
     public data class StyleOpInfo(
         val from: Int,
         val to: Int,
         val attributes: Map<String, String>,
         override var path: String = INITIAL_PATH,
-    ) : OperationInfo()
+    ) : OperationInfo(), TextOpInfo
 
     public data class SelectOpInfo(
         val from: Int,
         val to: Int,
         override var path: String = INITIAL_PATH,
-    ) : OperationInfo()
+    ) : OperationInfo(), TextOpInfo
 
     companion object {
         private const val INITIAL_PATH = "initial path"

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTextTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTextTest.kt
@@ -5,6 +5,7 @@ import dev.yorkie.document.time.TimeTicket
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class CrdtTextTest {
     private lateinit var target: CrdtText
@@ -50,14 +51,10 @@ class CrdtTextTest {
     @Test
     fun `should handle select operations`() {
         target.edit(target.createRange(0, 0), "ABCD", TimeTicket.InitialTimeTicket)
-        target.onChanges { changes ->
-            if (changes.first().type == TextChangeType.Selection) {
-                assertEquals(changes.first().from, 2)
-                assertEquals(changes.first().to, 4)
-            }
-        }
         val executedAt = TimeTicket(1L, 1, ActorID.INITIAL_ACTOR_ID)
-        target.select(target.createRange(1, 3), TimeTicket.InitialTimeTicket)
-        target.select(target.createRange(2, 4), executedAt)
+        assertNull(target.select(target.createRange(1, 3), TimeTicket.InitialTimeTicket))
+        val textChange = target.select(target.createRange(2, 4), executedAt)
+        assertEquals(TextChangeType.Selection, textChange?.type)
+        assertEquals(2 to 4, textChange?.from to textChange?.to)
     }
 }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTextTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTextTest.kt
@@ -7,11 +7,11 @@ import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.crdt.CrdtText
 import dev.yorkie.document.crdt.ElementRht
 import dev.yorkie.document.crdt.RgaTreeSplit
-import dev.yorkie.document.crdt.TextChangeType
 import dev.yorkie.document.time.TimeTicket
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class JsonTextTest {
@@ -126,15 +126,24 @@ class JsonTextTest {
     }
 
     @Test
-    fun `should handle select operations`() {
-        target.edit(0, 0, "ABCD")
-        target.onChanges { changes ->
-            if (changes.first().type == TextChangeType.Selection) {
-                assertEquals(changes.first().from, 2)
-                assertEquals(changes.first().to, 4)
-            }
-        }
-        target.select(2, 4)
+    fun `should return false when index range is invalid with edit`() {
+        assertTrue(target.edit(0, 0, "ABC"))
+        assertFalse(target.edit(5, 0, "D"))
+        assertFalse(target.edit(5, 7, "E"))
+    }
+
+    @Test
+    fun `should return false when index range is invalid with style`() {
+        assertTrue(target.style(0, 0, emptyMap()))
+        assertFalse(target.style(5, 0, emptyMap()))
+        assertFalse(target.style(5, 7, emptyMap()))
+    }
+
+    @Test
+    fun `should return false when index range is invalid with select`() {
+        assertTrue(target.select(0, 0))
+        assertFalse(target.select(5, 0))
+        assertFalse(target.select(5, 7))
     }
 
     @Test


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- Replace `Text.onChanges()` with Document event stream subscription.
- Make `TextChange` internal since it is not exposed to users anymore.
- Prevent `JsonText` from throwing internally caused exceptions in the SDK.
- Add `TextOpInfo` interface for convenience.

#### Any background context you want to provide?

#### What are the relevant tickets?
https://github.com/yorkie-team/yorkie-js-sdk/pull/519

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
