### PR TITLE
Add tests for GC and IndexTree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,6 @@ jobs:
           disable-animations: true
           script: |
             adb shell pm list packages | grep dev.yorkie.test && adb uninstall dev.yorkie.test || true;
-            adb logcat *:E &
             ./gradlew yorkie:createDebugAndroidTestCoverageReport
       - uses: actions/upload-artifact@v3
         with:

--- a/examples/texteditor/src/main/java/com/example/texteditor/EditorViewModel.kt
+++ b/examples/texteditor/src/main/java/com/example/texteditor/EditorViewModel.kt
@@ -66,8 +66,6 @@ class EditorViewModel(private val client: Client) : ViewModel(), YorkieEditText.
     }
 
     private suspend fun emitTextOpInfos(changeInfo: Document.Event.ChangeInfo) {
-        if (changeInfo.actorID == client.requireClientId()) return
-
         changeInfo.operations.filterIsInstance<OperationInfo.TextOpInfo>()
             .forEach { opInfo ->
                 _textOpInfos.emit(changeInfo.actorID to opInfo)

--- a/yorkie/proto/src/main/proto/yorkie/v1/resources.proto
+++ b/yorkie/proto/src/main/proto/yorkie/v1/resources.proto
@@ -47,7 +47,7 @@ message Change {
 }
 
 message ChangeID {
-  uint64 client_seq = 1;
+  uint32 client_seq = 1;
   int64 server_seq = 2 [jstype = JS_STRING];
   int64 lamport = 3 [jstype = JS_STRING];
   bytes actor_id = 4;
@@ -292,7 +292,7 @@ message Client {
 
 message Checkpoint {
   int64 server_seq = 1 [jstype = JS_STRING];
-  uint64 client_seq = 2;
+  uint32 client_seq = 2;
 }
 
 message TextNodePos {
@@ -303,7 +303,7 @@ message TextNodePos {
 
 message TimeTicket {
   int64 lamport = 1 [jstype = JS_STRING];
-  uint64 delimiter = 2;
+  uint32 delimiter = 2;
   bytes actor_id = 3;
 }
 

--- a/yorkie/proto/src/main/proto/yorkie/v1/resources.proto
+++ b/yorkie/proto/src/main/proto/yorkie/v1/resources.proto
@@ -47,7 +47,7 @@ message Change {
 }
 
 message ChangeID {
-  uint32 client_seq = 1;
+  uint64 client_seq = 1;
   int64 server_seq = 2 [jstype = JS_STRING];
   int64 lamport = 3 [jstype = JS_STRING];
   bytes actor_id = 4;
@@ -292,7 +292,7 @@ message Client {
 
 message Checkpoint {
   int64 server_seq = 1 [jstype = JS_STRING];
-  uint32 client_seq = 2;
+  uint64 client_seq = 2;
 }
 
 message TextNodePos {
@@ -303,7 +303,7 @@ message TextNodePos {
 
 message TimeTicket {
   int64 lamport = 1 [jstype = JS_STRING];
-  uint32 delimiter = 2;
+  uint64 delimiter = 2;
   bytes actor_id = 3;
 }
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -446,9 +446,9 @@ class ClientTest {
                 it.setNewCounter("counter", 0)
             }.await()
 
-            assertEquals(CheckPoint(0, 0), document.checkPoint)
+            assertEquals(CheckPoint(0, 0u), document.checkPoint)
             client.syncAsync().await()
-            assertEquals(CheckPoint(1, 1), document.checkPoint)
+            assertEquals(CheckPoint(1, 1u), document.checkPoint)
 
             // 03. cli update the document with increasing the counter(0 -> 1)
             //     and sync with push-only mode: CP(1, 1) -> CP(2, 1)
@@ -460,7 +460,7 @@ class ClientTest {
             assertEquals(1, changePack.changes.size)
 
             client.syncAsync(document, Client.SyncMode.PushOnly).await()
-            assertEquals(CheckPoint(1, 2), document.checkPoint)
+            assertEquals(CheckPoint(1, 2u), document.checkPoint)
 
             // 04. cli update the document with increasing the counter(1 -> 2)
             //     and sync with push-pull mode. CP(2, 1) -> CP(3, 3)
@@ -475,7 +475,7 @@ class ClientTest {
 
             client.syncAsync().await()
 
-            assertEquals(CheckPoint(3, 3), document.checkPoint)
+            assertEquals(CheckPoint(3, 3u), document.checkPoint)
             assertEquals(2, document.getRoot().getAs<JsonCounter>("counter").value)
 
             client.detachAsync(document).await()

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/GCTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/GCTest.kt
@@ -1,0 +1,434 @@
+package dev.yorkie.core
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.yorkie.assertJsonContentEquals
+import dev.yorkie.document.Document
+import dev.yorkie.document.crdt.CrdtTreeNode
+import dev.yorkie.document.json.JsonText
+import dev.yorkie.document.json.JsonTree
+import dev.yorkie.document.json.JsonTree.TextNode
+import dev.yorkie.document.json.TreeBuilder.element
+import dev.yorkie.document.json.TreeBuilder.text
+import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.util.IndexTreeNode
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.UUID
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class GCTest {
+
+    @Test
+    fun test_gc() {
+        runBlocking {
+            val documentKey = UUID.randomUUID().toString().toDocKey()
+            val document = Document(documentKey)
+            assertEquals("{}", document.toJson())
+
+            document.updateAsync {
+                it["1"] = 1
+                it.setNewArray("2").apply {
+                    put(1)
+                    put(2)
+                    put(3)
+                }
+                it["3"] = 3
+            }.await()
+            assertJsonContentEquals("""{"1":1,"2":[1,2,3],"3":3}""", document.toJson())
+
+            document.updateAsync {
+                it.remove("2")
+            }.await()
+            assertJsonContentEquals("""{"1":1,"3":3}""", document.toJson())
+            assertEquals(4, document.garbageLength)
+            assertEquals(4, document.garbageCollect(TimeTicket.MaxTimeTicket))
+            assertEquals(0, document.garbageLength)
+        }
+    }
+
+    @Test
+    fun test_gc_with_text() {
+        runBlocking {
+            val documentKey = UUID.randomUUID().toString().toDocKey()
+            val document = Document(documentKey)
+            assertEquals("{}", document.toJson())
+
+            document.updateAsync {
+                it.setNewText("text").apply {
+                    edit(0, 0, "ABCD")
+                    edit(0, 2, "12")
+                }
+            }.await()
+
+            assertJsonContentEquals(
+                """{"text":[{"val":"12"},{"val":"CD"}]}""",
+                document.toJson(),
+            )
+            assertEquals(1, document.garbageLength)
+            assertEquals(1, document.garbageCollect(TimeTicket.MaxTimeTicket))
+            assertEquals(0, document.garbageLength)
+        }
+    }
+
+    @Test
+    fun test_gc_with_text_with_attributes() {
+        runBlocking {
+            val documentKey = UUID.randomUUID().toString().toDocKey()
+            val document = Document(documentKey)
+            assertEquals("{}", document.toJson())
+
+            document.updateAsync {
+                it.setNewText("text").apply {
+                    edit(0, 0, "Hello world", mapOf("b" to "1"))
+                    edit(6, 11, "mario")
+                }
+            }.await()
+            assertJsonContentEquals(
+                """{"text":[{"attrs":{"b":"1"},"val":"Hello "},{"val":"mario"}]}""",
+                document.toJson(),
+            )
+            assertEquals(1, document.garbageLength)
+
+            document.updateAsync {
+                val text = it.getAs<JsonText>("text")
+                text.edit(0, 5, "Hi", mapOf("b" to "1"))
+                text.edit(3, 4, "j")
+                text.edit(4, 8, "ane", mapOf("b" to "1"))
+            }.await()
+            assertJsonContentEquals(
+                """{"text":[{"attrs":{"b":"1"},"val":"Hi"},{"attrs":{"b":"1"},"val":" "},
+                    |{"val":"j"},{"attrs":{"b":"1"},"val":"ane"}]}""".trimMargin(),
+                document.toJson(),
+            )
+            assertEquals(4, document.garbageLength)
+            assertEquals(4, document.garbageCollect(TimeTicket.MaxTimeTicket))
+            assertEquals(0, document.garbageLength)
+        }
+    }
+
+    @Test
+    fun test_gc_with_tree() {
+        runBlocking {
+            val documentKey = UUID.randomUUID().toString().toDocKey()
+            val document = Document(documentKey)
+            assertEquals("{}", document.toJson())
+
+            document.updateAsync {
+                it.setNewTree(
+                    "t",
+                    element("doc") {
+                        element("p") {
+                            element("tn") {
+                                text { "a" }
+                                text { "b" }
+                            }
+                            element("tn") {
+                                text { "cd" }
+                            }
+                        }
+                    },
+                ).apply {
+                    editByPath(listOf(0, 0, 0), listOf(0, 0, 2), TextNode("gh"))
+                }
+            }.await()
+            assertEquals(
+                "<doc><p><tn>gh</tn><tn>cd</tn></p></doc>",
+                document.getRoot().getAs<JsonTree>("t").toXml(),
+            )
+
+            // [text(a), text(b)]
+            var nodeLengthBeforeGC =
+                getNodeLength(document.getRoot().getAs<JsonTree>("t").indexTree.root)
+            assertEquals(2, document.garbageLength)
+            assertEquals(2, document.garbageCollect(TimeTicket.MaxTimeTicket))
+            assertEquals(0, document.garbageLength)
+            var nodeLengthAfterGC =
+                getNodeLength(document.getRoot().getAs<JsonTree>("t").indexTree.root)
+            assertEquals(2, nodeLengthBeforeGC - nodeLengthAfterGC)
+
+            document.updateAsync {
+                it.getAs<JsonTree>("t").editByPath(listOf(0, 0, 0), listOf(0, 0, 2), text { "cv" })
+            }.await()
+            assertEquals(
+                "<doc><p><tn>cv</tn><tn>cd</tn></p></doc>",
+                document.getRoot().getAs<JsonTree>("t").toXml(),
+            )
+
+            // [text(gh)]
+            nodeLengthBeforeGC =
+                getNodeLength(document.getRoot().getAs<JsonTree>("t").indexTree.root)
+            assertEquals(1, document.garbageLength)
+            assertEquals(1, document.garbageCollect(TimeTicket.MaxTimeTicket))
+            assertEquals(0, document.garbageLength)
+            nodeLengthAfterGC =
+                getNodeLength(document.getRoot().getAs<JsonTree>("t").indexTree.root)
+            assertEquals(1, nodeLengthBeforeGC - nodeLengthAfterGC)
+
+            document.updateAsync {
+                it.getAs<JsonTree>("t").editByPath(
+                    listOf(0),
+                    listOf(1),
+                    element("p") { element("tn") { text { "ab" } } },
+                )
+            }.await()
+            assertEquals(
+                "<doc><p><tn>ab</tn></p></doc>",
+                document.getRoot().getAs<JsonTree>("t").toXml(),
+            )
+
+            // [p, tn, tn, text(cv), text(cd)]
+            nodeLengthBeforeGC =
+                getNodeLength(document.getRoot().getAs<JsonTree>("t").indexTree.root)
+
+            assertEquals(5, document.garbageLength)
+            assertEquals(5, document.garbageCollect(TimeTicket.MaxTimeTicket))
+            assertEquals(0, document.garbageLength)
+            nodeLengthAfterGC =
+                getNodeLength(document.getRoot().getAs<JsonTree>("t").indexTree.root)
+            assertEquals(5, nodeLengthBeforeGC - nodeLengthAfterGC)
+        }
+    }
+
+    @Test
+    fun test_gc_with_tree_for_multi_client() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, _ ->
+            document1.updateAsync {
+                it.setNewTree(
+                    "t",
+                    element("doc") {
+                        element("p") {
+                            element("tn") {
+                                text { "a" }
+                                text { "b" }
+                            }
+                            element("tn") {
+                                text { "cd" }
+                            }
+                        }
+                    },
+                )
+            }.await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(0, document2.garbageLength)
+
+            // (0, 0) -> (1, 0): syncedseqs:(0, 0)
+            client1.syncAsync().await()
+
+            // (1, 0) -> (1, 1): syncedseqs:(0, 0)
+            client2.syncAsync().await()
+
+            document2.updateAsync {
+                it.getAs<JsonTree>("t").editByPath(
+                    listOf(0, 0, 0),
+                    listOf(0, 0, 2),
+                    text { "gh" },
+                )
+            }.await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(2, document2.garbageLength)
+
+            // (1, 1) -> (1, 2): syncedseqs:(0, 1)
+            client2.syncAsync().await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(2, document2.garbageLength)
+
+            // (1, 2) -> (2, 2): syncedseqs:(1, 1)
+            client1.syncAsync().await()
+            assertEquals(2, document1.garbageLength)
+            assertEquals(2, document2.garbageLength)
+
+            // (2, 2) -> (2, 2): syncedseqs:(1, 2)
+            client2.syncAsync().await()
+            assertEquals(2, document1.garbageLength)
+            assertEquals(2, document2.garbageLength)
+
+            // (2, 2) -> (2, 2): syncedseqs:(2, 2): meet GC condition
+            client1.syncAsync().await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(2, document2.garbageLength)
+
+            // (2, 2) -> (2, 2): syncedseqs:(2, 2): meet GC condition
+            client2.syncAsync().await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(0, document2.garbageLength)
+        }
+    }
+
+    @Test
+    fun test_gc_with_container_type_for_multi_client() {
+        repeat(30) {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, _ ->
+            document1.updateAsync {
+                it["1"] = 1
+                it.setNewArray("2").apply {
+                    put(1)
+                    put(2)
+                    put(3)
+                }
+                it["3"] = 3
+            }.await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(0, document2.garbageLength)
+
+            // (0, 0) -> (1, 0): syncedseqs:(0, 0)
+            client1.syncAsync().await()
+
+            // (1, 0) -> (1, 1): syncedseqs:(0, 0)
+            client2.syncAsync().await()
+
+            document2.updateAsync {
+                it.remove("2")
+            }.await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(4, document2.garbageLength)
+
+            // (1, 1) -> (1, 2): syncedseqs:(0, 1)
+            client2.syncAsync().await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(4, document2.garbageLength)
+
+            // (1, 2) -> (2, 2): syncedseqs:(1, 1)
+            client1.syncAsync().await()
+            assertEquals(4, document1.garbageLength)
+            assertEquals(4, document2.garbageLength)
+
+            // (2, 2) -> (2, 2): syncedseqs:(1, 2)
+            client2.syncAsync().await()
+            assertEquals(4, document1.garbageLength)
+            assertEquals(4, document2.garbageLength)
+
+            // (2, 2) -> (2, 2): syncedseqs:(2, 2): meet GC condition
+            client1.syncAsync().await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(4, document2.garbageLength)
+
+            // (2, 2) -> (2, 2): syncedseqs:(2, 2): meet GC condition
+            client2.syncAsync().await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(0, document2.garbageLength)
+        }}
+    }
+
+    @Test
+    fun test_gc_with_text_for_multi_client() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, _ ->
+            document1.updateAsync {
+                it.setNewText("text").edit(0, 0, "Hello World")
+                it.setNewText("textWithAttr").edit(0, 0, "Hello World")
+            }.await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(0, document2.garbageLength)
+
+            // (0, 0) -> (1, 0): syncedseqs:(0, 0)
+            client1.syncAsync().await()
+
+            // (1, 0) -> (1, 1): syncedseqs:(0, 0)
+            client2.syncAsync().await()
+
+            document2.updateAsync {
+                it.getAs<JsonText>("text").apply {
+                    edit(0, 1, "a")
+                    edit(1, 2, "b")
+                }
+                it.getAs<JsonText>("textWithAttr").edit(
+                    0,
+                    1,
+                    "a",
+                    mapOf("b" to "1"),
+                )
+            }.await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(3, document2.garbageLength)
+
+            // (1, 1) -> (1, 2): syncedseqs:(0, 1)
+            client2.syncAsync().await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(3, document2.garbageLength)
+
+            // (1, 2) -> (2, 2): syncedseqs:(1, 1)
+            client1.syncAsync().await()
+            assertEquals(3, document1.garbageLength)
+            assertEquals(3, document2.garbageLength)
+
+            // (2, 2) -> (2, 2): syncedseqs:(1, 2)
+            client2.syncAsync().await()
+            assertEquals(3, document1.garbageLength)
+            assertEquals(3, document2.garbageLength)
+
+            // (2, 2) -> (2, 2): syncedseqs:(2, 2): meet GC condition
+            client1.syncAsync().await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(3, document2.garbageLength)
+
+            // (2, 2) -> (2, 2): syncedseqs:(2, 2): meet GC condition
+            client2.syncAsync().await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(0, document2.garbageLength)
+        }
+    }
+
+    @Test
+    fun test_gc_with_detached_document() {
+        withTwoClientsAndDocuments(detachDocuments = false) { client1, client2, document1, document2, _ ->
+            document1.updateAsync {
+                it["1"] = 1
+                it.setNewArray("2").apply {
+                    put(1)
+                    put(2)
+                    put(3)
+                }
+                it["3"] = 3
+                it.setNewText("4").edit(0, 0, "hi")
+                it.setNewText("5").edit(0, 0, "hi")
+            }.await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(0, document2.garbageLength)
+
+            // (0, 0) -> (1, 0): syncedseqs:(0, 0)
+            client1.syncAsync().await()
+
+            // (1, 0) -> (1, 1): syncedseqs:(0, 0)
+            client2.syncAsync().await()
+
+            document1.updateAsync {
+                it.remove("2")
+                it.getAs<JsonText>("4").edit(0, 1, "h")
+                it.getAs<JsonText>("5").edit(
+                    0,
+                    1,
+                    "h",
+                    mapOf("b" to "1"),
+                )
+            }.await()
+            assertEquals(6, document1.garbageLength)
+            assertEquals(0, document2.garbageLength)
+
+            // (1, 1) -> (2, 1): syncedseqs:(1, 0)
+            client1.syncAsync().await()
+            assertEquals(6, document1.garbageLength)
+            assertEquals(0, document2.garbageLength)
+
+            client2.detachAsync(document2).await()
+
+            // (2, 1) -> (2, 2): syncedseqs:(1, x)
+            client2.syncAsync().await()
+            assertEquals(6, document1.garbageLength)
+            assertEquals(6, document2.garbageLength)
+
+            // (2, 2) -> (2, 2): syncedseqs:(2, x): meet GC condition
+            client1.syncAsync().await()
+            assertEquals(0, document1.garbageLength)
+            assertEquals(6, document2.garbageLength)
+
+            client1.detachAsync(document1).await()
+        }
+    }
+
+    private fun getNodeLength(root: IndexTreeNode<CrdtTreeNode>): Int {
+        return root.allChildren.fold(root.allChildren.size) { acc, child ->
+            acc + getNodeLength(child)
+        }
+    }
+}

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/GCTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/GCTest.kt
@@ -99,7 +99,8 @@ class GCTest {
             }.await()
             assertJsonContentEquals(
                 """{"text":[{"attrs":{"b":"1"},"val":"Hi"},{"attrs":{"b":"1"},"val":" "},
-                    |{"val":"j"},{"attrs":{"b":"1"},"val":"ane"}]}""".trimMargin(),
+                    |{"val":"j"},{"attrs":{"b":"1"},"val":"ane"}]}
+                """.trimMargin(),
                 document.toJson(),
             )
             assertEquals(4, document.garbageLength)

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
@@ -7,7 +7,6 @@ import dev.yorkie.document.Document
 import dev.yorkie.document.json.TreeBuilder.element
 import dev.yorkie.document.json.TreeBuilder.text
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.test.assertEquals
@@ -17,122 +16,116 @@ class JsonTreeTest {
 
     @Test
     fun test_tree_sync_between_replicas() {
-        runBlocking {
-            withTwoClientsAndDocuments(realTimeSync = false) { c1, c2, d1, d2, _ ->
-                updateAndSync(
-                    Updater(c1, d1) { root ->
-                        root.setNewTree(
-                            "t",
-                            element("doc") {
-                                element("p") {
-                                    text { "hello" }
-                                }
-                            },
-                        )
-                    },
-                    Updater(c2, d2),
-                )
-                assertTreesXmlEquals("<doc><p>hello</p></doc>", d1, d2)
-
-                updateAndSync(
-                    Updater(c1, d1) { root ->
-                        root.rootTree().edit(
-                            7,
-                            7,
+        withTwoClientsAndDocuments(realTimeSync = false) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                Updater(c1, d1) { root ->
+                    root.setNewTree(
+                        "t",
+                        element("doc") {
                             element("p") {
-                                text { "yorkie" }
-                            },
-                        )
-                    },
-                    Updater(c2, d2),
-                )
-                assertTreesXmlEquals("<doc><p>hello</p><p>yorkie</p></doc>", d1, d2)
-            }
+                                text { "hello" }
+                            }
+                        },
+                    )
+                },
+                Updater(c2, d2),
+            )
+            assertTreesXmlEquals("<doc><p>hello</p></doc>", d1, d2)
+
+            updateAndSync(
+                Updater(c1, d1) { root ->
+                    root.rootTree().edit(
+                        7,
+                        7,
+                        element("p") {
+                            text { "yorkie" }
+                        },
+                    )
+                },
+                Updater(c2, d2),
+            )
+            assertTreesXmlEquals("<doc><p>hello</p><p>yorkie</p></doc>", d1, d2)
         }
     }
 
     @Test
     fun test_inserting_text_to_same_position_concurrently() {
-        runBlocking {
-            withTwoClientsAndDocuments(realTimeSync = false) { c1, c2, d1, d2, _ ->
-                updateAndSync(
-                    Updater(c1, d1) { root ->
-                        root.setNewTree(
-                            "t",
-                            element("r") {
-                                element("p") {
-                                    text { "12" }
-                                }
-                            },
-                        )
-                    },
-                    Updater(c2, d2),
-                )
-                assertTreesXmlEquals("<r><p>12</p></r>", d1, d2)
+        withTwoClientsAndDocuments(realTimeSync = false) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                Updater(c1, d1) { root ->
+                    root.setNewTree(
+                        "t",
+                        element("r") {
+                            element("p") {
+                                text { "12" }
+                            }
+                        },
+                    )
+                },
+                Updater(c2, d2),
+            )
+            assertTreesXmlEquals("<r><p>12</p></r>", d1, d2)
 
-                // TODO: add inserting on the leftmost after tree is fixed
+            // TODO: add inserting on the leftmost after tree is fixed
 
-                updateAndSync(
-                    Updater(c1, d1) { root ->
-                        root.rootTree().edit(2, 2, text { "A" })
-                    },
-                    Updater(c2, d2) { root ->
-                        root.rootTree().edit(2, 2, text { "B" })
-                    },
-                ) {
-                    assertEquals("<r><p>1A2</p></r>", d1.getRoot().rootTree().toXml())
-                    assertEquals("<r><p>1B2</p></r>", d2.getRoot().rootTree().toXml())
-                }
-                assertTreesXmlEquals("<r><p>1BA2</p></r>", d1, d2)
-
-                updateAndSync(
-                    Updater(c1, d1) { root ->
-                        root.rootTree().edit(5, 5, text { "C" })
-                    },
-                    Updater(c2, d2) { root ->
-                        root.rootTree().edit(5, 5, text { "D" })
-                    },
-                ) {
-                    assertEquals("<r><p>1BA2C</p></r>", d1.getRoot().rootTree().toXml())
-                    assertEquals("<r><p>1BA2D</p></r>", d2.getRoot().rootTree().toXml())
-                }
-                assertTreesXmlEquals("<r><p>1BA2DC</p></r>", d1, d2)
+            updateAndSync(
+                Updater(c1, d1) { root ->
+                    root.rootTree().edit(2, 2, text { "A" })
+                },
+                Updater(c2, d2) { root ->
+                    root.rootTree().edit(2, 2, text { "B" })
+                },
+            ) {
+                assertEquals("<r><p>1A2</p></r>", d1.getRoot().rootTree().toXml())
+                assertEquals("<r><p>1B2</p></r>", d2.getRoot().rootTree().toXml())
             }
+            assertTreesXmlEquals("<r><p>1BA2</p></r>", d1, d2)
+
+            updateAndSync(
+                Updater(c1, d1) { root ->
+                    root.rootTree().edit(5, 5, text { "C" })
+                },
+                Updater(c2, d2) { root ->
+                    root.rootTree().edit(5, 5, text { "D" })
+                },
+            ) {
+                assertEquals("<r><p>1BA2C</p></r>", d1.getRoot().rootTree().toXml())
+                assertEquals("<r><p>1BA2D</p></r>", d2.getRoot().rootTree().toXml())
+            }
+            assertTreesXmlEquals("<r><p>1BA2DC</p></r>", d1, d2)
         }
     }
 
     @Test
     fun test_tree_with_attributes_between_replicas() {
-        runBlocking {
-            withTwoClientsAndDocuments(realTimeSync = false) { c1, c2, d1, d2, _ ->
-                updateAndSync(
-                    Updater(c1, d1) { root ->
-                        root.setNewTree(
-                            "t",
-                            element("doc") {
-                                element("p") {
-                                    text { "hello" }
-                                    attr { "italic" to true }
-                                }
-                            },
-                        )
-                    },
-                    Updater(c2, d2),
-                )
-                assertTreesXmlEquals("""<doc><p italic="true">hello</p></doc>""", d1, d2)
+        withTwoClientsAndDocuments(realTimeSync = false) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                Updater(c1, d1) { root ->
+                    root.setNewTree(
+                        "t",
+                        element("doc") {
+                            element("p") {
+                                text { "hello" }
+                                attr { "italic" to true }
+                            }
+                        },
+                    )
+                },
+                Updater(c2, d2),
+            )
+            assertTreesXmlEquals("""<doc><p italic="true">hello</p></doc>""", d1, d2)
 
-                updateAndSync(
-                    Updater(c1, d1) { root ->
-                        root.rootTree().style(6, 7, mapOf("bold" to "true"))
-                    },
-                    Updater(c2, d2),
-                )
-                assertTreesXmlEquals(
-                    """<doc><p italic="true" bold="true">hello</p></doc>""",
-                    d1,
-                    d2,
-                )
-            }
+            updateAndSync(
+                Updater(c1, d1) { root ->
+                    root.rootTree().style(6, 7, mapOf("bold" to "true"))
+                },
+                Updater(c2, d2),
+            )
+            assertTreesXmlEquals(
+                """<doc><p italic="true" bold="true">hello</p></doc>""",
+                d1,
+                d2,
+            )
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/api/ChangeConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/ChangeConverter.kt
@@ -41,7 +41,7 @@ internal fun List<Change>.toPBChanges(): List<PBChange> {
 
 internal fun PBChangeID.toChangeID(): ChangeID {
     return ChangeID(
-        clientSeq,
+        clientSeq.toUInt(),
         lamport,
         actorId.toActorID(),
     )
@@ -50,21 +50,21 @@ internal fun PBChangeID.toChangeID(): ChangeID {
 internal fun ChangeID.toPBChangeID(): PBChangeID {
     val changeID = this
     return changeID {
-        clientSeq = changeID.clientSeq
+        clientSeq = changeID.clientSeq.toInt()
         lamport = changeID.lamport
         actorId = changeID.actor.toByteString()
     }
 }
 
 internal fun PBCheckPoint.toCheckPoint(): CheckPoint {
-    return CheckPoint(serverSeq, clientSeq)
+    return CheckPoint(serverSeq, clientSeq.toUInt())
 }
 
 internal fun CheckPoint.toPBCheckPoint(): PBCheckPoint {
     val checkPoint = this
     return checkpoint {
         serverSeq = checkPoint.serverSeq
-        clientSeq = checkPoint.clientSeq
+        clientSeq = checkPoint.clientSeq.toInt()
     }
 }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/api/TimeConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/TimeConverter.kt
@@ -12,7 +12,7 @@ internal typealias PBTimeTicket = dev.yorkie.api.v1.TimeTicket
 internal fun PBTimeTicket.toTimeTicket(): TimeTicket {
     return TimeTicket(
         lamport = lamport,
-        delimiter = delimiter,
+        delimiter = delimiter.toUInt(),
         actorID = actorId.toActorID(),
     )
 }
@@ -21,7 +21,7 @@ internal fun TimeTicket.toPBTimeTicket(): PBTimeTicket {
     val timeTicket = this
     return timeTicket {
         lamport = timeTicket.lamport
-        delimiter = timeTicket.delimiter
+        delimiter = timeTicket.delimiter.toInt()
         actorId = timeTicket.actorID.toByteString()
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -63,6 +63,9 @@ public class Document(public val key: Key) {
     public var status = DocumentStatus.Detached
         internal set
 
+    internal val garbageLength: Int
+        get() = root.getGarbageLength()
+
     /**
      * Executes the given [updater] to update this document.
      */
@@ -262,7 +265,7 @@ public class Document(public val key: Key) {
     /**
      * Deletes elements that were removed before the given time.
      */
-    private fun garbageCollect(ticket: TimeTicket): Int {
+    internal fun garbageCollect(ticket: TimeTicket): Int {
         clone?.garbageCollect(ticket)
         return root.garbageCollect(ticket)
     }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/ChangeContext.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/ChangeContext.kt
@@ -17,7 +17,7 @@ internal data class ChangeContext(
     val root: CrdtRoot,
     val message: String? = null,
     private val _operations: MutableList<Operation> = mutableListOf(),
-    private var delimiter: Long = TimeTicket.INITIAL_DELIMITER,
+    private var delimiter: UInt = TimeTicket.INITIAL_DELIMITER,
 ) {
     val operations: List<Operation>
         get() = _operations.toList()

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/ChangeContext.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/ChangeContext.kt
@@ -17,7 +17,7 @@ internal data class ChangeContext(
     val root: CrdtRoot,
     val message: String? = null,
     private val _operations: MutableList<Operation> = mutableListOf(),
-    private var delimiter: Int = TimeTicket.INITIAL_DELIMITER,
+    private var delimiter: Long = TimeTicket.INITIAL_DELIMITER,
 ) {
     val operations: List<Operation>
         get() = _operations.toList()

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/ChangeID.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/ChangeID.kt
@@ -8,7 +8,7 @@ import dev.yorkie.document.time.TimeTicket
  * Identifies the Change.
  */
 internal data class ChangeID(
-    val clientSeq: Int,
+    val clientSeq: Long,
     val lamport: Long,
     val actor: ActorID,
 ) {
@@ -33,7 +33,7 @@ internal data class ChangeID(
     /**
      * Creates a ticket of the given delimiter.
      */
-    fun createTimeTicket(delimiter: Int): TimeTicket {
+    fun createTimeTicket(delimiter: Long): TimeTicket {
         return TimeTicket(lamport, delimiter, actor)
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/ChangeID.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/ChangeID.kt
@@ -8,7 +8,7 @@ import dev.yorkie.document.time.TimeTicket
  * Identifies the Change.
  */
 internal data class ChangeID(
-    val clientSeq: Long,
+    val clientSeq: UInt,
     val lamport: Long,
     val actor: ActorID,
 ) {
@@ -16,7 +16,7 @@ internal data class ChangeID(
     /**
      * Creates a next ID of this ID.
      */
-    fun next() = copy(clientSeq = clientSeq + 1, lamport = lamport + 1)
+    fun next() = copy(clientSeq = clientSeq + 1u, lamport = lamport + 1)
 
     /**
      * Syncs lamport timestamp with the given ID.
@@ -33,7 +33,7 @@ internal data class ChangeID(
     /**
      * Creates a ticket of the given delimiter.
      */
-    fun createTimeTicket(delimiter: Long): TimeTicket {
+    fun createTimeTicket(delimiter: UInt): TimeTicket {
         return TimeTicket(lamport, delimiter, actor)
     }
 
@@ -47,6 +47,6 @@ internal data class ChangeID(
          * Represents the initial state ID.
          * Usually this is used to represent a state where nothing has been edited.
          */
-        val InitialChangeID = ChangeID(0, 0, INITIAL_ACTOR_ID)
+        val InitialChangeID = ChangeID(0u, 0, INITIAL_ACTOR_ID)
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/CheckPoint.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/CheckPoint.kt
@@ -8,7 +8,7 @@ import kotlin.math.max
  */
 internal data class CheckPoint(
     val serverSeq: Long,
-    val clientSeq: Int,
+    val clientSeq: Long,
 ) {
 
     /**

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/CheckPoint.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/CheckPoint.kt
@@ -8,7 +8,7 @@ import kotlin.math.max
  */
 internal data class CheckPoint(
     val serverSeq: Long,
-    val clientSeq: Long,
+    val clientSeq: UInt,
 ) {
 
     /**
@@ -18,7 +18,7 @@ internal data class CheckPoint(
         return if (increase == 0) {
             this
         } else {
-            copy(clientSeq = clientSeq + increase)
+            copy(clientSeq = clientSeq + increase.toUInt())
         }
     }
 
@@ -37,6 +37,6 @@ internal data class CheckPoint(
     }
 
     companion object {
-        val InitialCheckPoint = CheckPoint(0, 0)
+        val InitialCheckPoint = CheckPoint(0, 0u)
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -343,7 +343,7 @@ internal class CrdtTree(
     override fun deleteRemovedNodesBefore(executedAt: TimeTicket): Int {
         val nodesToRemoved = removedNodeMap.filterValues { node ->
             node.removedAt != null && node.removedAt <= executedAt
-        }.values.toMutableSet()
+        }.values.toMutableList()
 
         indexTree.traverseAll { node, _ ->
             if (node in nodesToRemoved) {
@@ -617,7 +617,7 @@ internal data class CrdtTreeNode private constructor(
     @Suppress("FunctionName")
     companion object {
 
-        fun CrdtTreeText(pos: CrdtTreePos, value: String? = null): CrdtTreeNode {
+        fun CrdtTreeText(pos: CrdtTreePos, value: String): CrdtTreeNode {
             return CrdtTreeNode(pos, DEFAULT_TEXT_TYPE, value)
         }
 
@@ -632,7 +632,7 @@ internal data class CrdtTreeNode private constructor(
 
 /**
  * [CrdtTreePos] represents a position in the tree. It indicates the virtual
- * location in the tree, so whether the node is splitted or not, we can find
+ * location in the tree, so whether the node is split or not, we can find
  * the adjacent node to pos by calling `map.floorEntry()`.
  */
 public data class CrdtTreePos(

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -70,7 +70,6 @@ internal class CrdtTree(
     ): List<TreeChange> {
         val (_, toRight) = findTreePos(range.second, executedAt)
         val (_, fromRight) = findTreePos(range.first, executedAt)
-        // TODO(7hong13): need to check toPath - range.second? first?
         val changes = listOf(
             TreeChange(
                 type = TreeChangeType.Style.type,

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -341,23 +341,18 @@ internal class CrdtTree(
      * Physically deletes nodes that have been removed.
      */
     override fun deleteRemovedNodesBefore(executedAt: TimeTicket): Int {
-        val nodesToRemoved = removedNodeMap.filterValues { node ->
+        val nodesToBeRemoved = removedNodeMap.filterValues { node ->
             node.removedAt != null && node.removedAt <= executedAt
-        }.values.toMutableList()
+        }.values.toMutableSet()
 
-        indexTree.traverseAll { node, _ ->
-            if (node in nodesToRemoved) {
-                node.parent?.removeChild(node) ?: nodesToRemoved.remove(node)
-            }
-        }
-
-        nodesToRemoved.forEach { node ->
+        nodesToBeRemoved.forEach { node ->
+            node.parent?.removeChild(node)
             nodeMapByPos.remove(node.pos)
             delete(node)
             removedNodeMap.remove(node.createdAt to node.pos.offset)
         }
 
-        return nodesToRemoved.size
+        return nodesToBeRemoved.size
     }
 
     /**

--- a/yorkie/src/main/kotlin/dev/yorkie/document/time/TimeTicket.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/time/TimeTicket.kt
@@ -8,7 +8,7 @@ import dev.yorkie.document.time.ActorID.Companion.MAX_ACTOR_ID
  */
 public data class TimeTicket(
     public val lamport: Long,
-    public val delimiter: Long,
+    public val delimiter: UInt,
     public val actorID: ActorID,
 ) : Comparable<TimeTicket> {
 
@@ -24,8 +24,8 @@ public data class TimeTicket(
     }
 
     companion object {
-        internal const val INITIAL_DELIMITER = 0L
-        internal const val MAX_DELIMITER = Long.MAX_VALUE
+        internal const val INITIAL_DELIMITER = 0u
+        internal const val MAX_DELIMITER = UInt.MAX_VALUE
         internal const val MAX_LAMPORT = Long.MAX_VALUE
 
         private val NullTimeTicket = TimeTicket(

--- a/yorkie/src/main/kotlin/dev/yorkie/document/time/TimeTicket.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/time/TimeTicket.kt
@@ -8,7 +8,7 @@ import dev.yorkie.document.time.ActorID.Companion.MAX_ACTOR_ID
  */
 public data class TimeTicket(
     public val lamport: Long,
-    public val delimiter: Int,
+    public val delimiter: Long,
     public val actorID: ActorID,
 ) : Comparable<TimeTicket> {
 
@@ -24,8 +24,8 @@ public data class TimeTicket(
     }
 
     companion object {
-        internal const val INITIAL_DELIMITER = 0
-        internal const val MAX_DELIMITER = Int.MAX_VALUE
+        internal const val INITIAL_DELIMITER = 0L
+        internal const val MAX_DELIMITER = Long.MAX_VALUE
         internal const val MAX_LAMPORT = Long.MAX_VALUE
 
         private val NullTimeTicket = TimeTicket(

--- a/yorkie/src/main/kotlin/dev/yorkie/util/IndexTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/IndexTree.kt
@@ -1,5 +1,7 @@
 package dev.yorkie.util
 
+import com.google.common.annotations.VisibleForTesting
+
 /**
  * About `index`, `path`, `size` and `TreePos` in crdt.IndexTree.
  *
@@ -123,24 +125,6 @@ internal class IndexTree<T : IndexTreeNode<T>>(val root: T) {
      */
     fun traverse(action: ((T, Int) -> Unit)) {
         traverse(root, 0, action)
-    }
-
-    /**
-     * Traverses the whole tree (including tombstones) with postorder traversal.
-     */
-    fun traverseAll(action: ((T, Int) -> Unit)) {
-        traverseAllInternal(root, 0, action)
-    }
-
-    private fun traverseAllInternal(
-        node: T,
-        depth: Int = 0,
-        action: ((T, Int) -> Unit),
-    ) {
-        node.allChildren.forEach { child ->
-            traverseAllInternal(child, depth + 1, action)
-        }
-        action.invoke(node, depth)
     }
 
     /**
@@ -435,6 +419,7 @@ internal abstract class IndexTreeNode<T : IndexTreeNode<T>>(children: MutableLis
     /**
      * Returns the children of the node including tombstones.
      */
+    @VisibleForTesting
     val allChildren: List<T>
         get() = _children.toList()
 

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -462,7 +462,7 @@ class ClientTest {
     companion object {
         private val InitialEmptyChangePack = ChangePack(
             NORMAL_DOCUMENT_KEY,
-            CheckPoint(0, 0),
+            CheckPoint.InitialCheckPoint,
             emptyList(),
             null,
             null,

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTextTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTextTest.kt
@@ -51,7 +51,7 @@ class CrdtTextTest {
     @Test
     fun `should handle select operations`() {
         target.edit(target.createRange(0, 0), "ABCD", TimeTicket.InitialTimeTicket)
-        val executedAt = TimeTicket(1L, 1, ActorID.INITIAL_ACTOR_ID)
+        val executedAt = TimeTicket(1L, 1u, ActorID.INITIAL_ACTOR_ID)
         assertNull(target.select(target.createRange(1, 3), TimeTicket.InitialTimeTicket))
         val textChange = target.select(target.createRange(2, 4), executedAt)
         assertEquals(TextChangeType.Selection, textChange?.type)

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTreeTest.kt
@@ -139,7 +139,7 @@ class CrdtTreeTest {
         // 02. delete b, c and first paragraph.
         //       0   1 2 3    4
         // <root> <p> a d </p> </root>
-        target.editByIndex(2 to 6, CrdtTreeText(issuePos()), issueTime())
+        target.editByIndex(2 to 6, null, issueTime())
         assertEquals("<root><p>ad</p></root>", target.toXml())
 
         // 03. insert a new text node at the start of the first paragraph.

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/ElementRhtTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/ElementRhtTest.kt
@@ -54,19 +54,19 @@ class ElementRhtTest {
         val elementRht1 = ElementRht<CrdtPrimitive>()
         elementRht1["test1"] = CrdtPrimitive(1, generateTimeTicket(1, 1, "1"))
 
-        (2..3L).forEach { index ->
+        (2..3).forEach { index ->
             elementRht1["test1"] = CrdtPrimitive(
                 index,
-                generateTimeTicket(index, index, "2"),
+                generateTimeTicket(index.toLong(), index, "2"),
             )
         }
 
         val elementRht2 = ElementRht<CrdtPrimitive>()
         elementRht2["test1"] = CrdtPrimitive(1, generateTimeTicket(1, 1, "1"))
-        (3 downTo 2L).forEach { index ->
+        (3 downTo 2).forEach { index ->
             elementRht2["test1"] = CrdtPrimitive(
                 index,
-                generateTimeTicket(index, index, "3"),
+                generateTimeTicket(index.toLong(), index, "3"),
             )
         }
 
@@ -190,9 +190,10 @@ class ElementRhtTest {
     fun `Verity the getKeyOfQueue() using sequence`() {
         val elementRht = ElementRht<CrdtPrimitive>()
         val list = mutableListOf<String>()
-        for (i in 0..100000L) {
+        for (i in 0..100000) {
             val key = "test$i"
-            elementRht[key] = CrdtPrimitive("value$i", generateTimeTicket(i, i, "11"))
+            elementRht[key] =
+                CrdtPrimitive("value$i", generateTimeTicket(i.toLong(), i, "11"))
             list.add(key)
         }
 
@@ -207,10 +208,10 @@ class ElementRhtTest {
 
     private fun generateTimeTicket(
         lamport: Long,
-        delimiter: Long,
+        delimiter: Int,
         actorID: String,
     ): TimeTicket {
-        return TimeTicket(lamport, delimiter, ActorID(actorID))
+        return TimeTicket(lamport, delimiter.toUInt(), ActorID(actorID))
     }
 
     private fun ElementRht<CrdtPrimitive>.getStructureAsString() = buildString {

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/ElementRhtTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/ElementRhtTest.kt
@@ -54,24 +54,24 @@ class ElementRhtTest {
         val elementRht1 = ElementRht<CrdtPrimitive>()
         elementRht1["test1"] = CrdtPrimitive(1, generateTimeTicket(1, 1, "1"))
 
-        (2..3).forEach { index ->
+        (2..3L).forEach { index ->
             elementRht1["test1"] = CrdtPrimitive(
                 index,
-                generateTimeTicket(index.toLong(), index, "2"),
+                generateTimeTicket(index, index, "2"),
             )
         }
 
         val elementRht2 = ElementRht<CrdtPrimitive>()
         elementRht2["test1"] = CrdtPrimitive(1, generateTimeTicket(1, 1, "1"))
-        (3 downTo 2).forEach { index ->
+        (3 downTo 2L).forEach { index ->
             elementRht2["test1"] = CrdtPrimitive(
                 index,
-                generateTimeTicket(index.toLong(), index, "3"),
+                generateTimeTicket(index, index, "3"),
             )
         }
 
-        val value1 = elementRht1["test1"].value as Int
-        val value2 = elementRht2["test1"].value as Int
+        val value1 = elementRht1["test1"].value
+        val value2 = elementRht2["test1"].value
 
         assertEquals(value1, value2)
     }
@@ -190,9 +190,9 @@ class ElementRhtTest {
     fun `Verity the getKeyOfQueue() using sequence`() {
         val elementRht = ElementRht<CrdtPrimitive>()
         val list = mutableListOf<String>()
-        for (i in 0..100000) {
+        for (i in 0..100000L) {
             val key = "test$i"
-            elementRht[key] = CrdtPrimitive("value$i", generateTimeTicket(i.toLong(), i, "11"))
+            elementRht[key] = CrdtPrimitive("value$i", generateTimeTicket(i, i, "11"))
             list.add(key)
         }
 
@@ -207,7 +207,7 @@ class ElementRhtTest {
 
     private fun generateTimeTicket(
         lamport: Long,
-        delimiter: Int,
+        delimiter: Long,
         actorID: String,
     ): TimeTicket {
         return TimeTicket(lamport, delimiter, ActorID(actorID))

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
@@ -349,9 +349,8 @@ class JsonTreeTest {
             it.tree().edit(1, 1, TextNode("X"))
             assertEquals("<doc><p>Xab</p></doc>", it.tree().toXml())
 
-            it.tree().style(0, 0, mapOf("a" to "b"))
+            it.tree().style(4, 5, mapOf("a" to "b"))
         }.await()
-
         assertContentEquals(
             listOf(
                 TreeEditOpInfo(
@@ -363,10 +362,10 @@ class JsonTreeTest {
                     "$.t",
                 ),
                 TreeStyleOpInfo(
-                    0,
-                    0,
-                    listOf(0, -7), // TODO: need to check if these are the actual right values???
-                    listOf(0, -7),
+                    4,
+                    5,
+                    listOf(0),
+                    listOf(0),
                     mapOf("a" to "b"),
                     "$.t",
                 ),
@@ -440,7 +439,7 @@ class JsonTreeTest {
                 ),
                 TreeStyleOpInfo(
                     6,
-                    7, // TODO: need to check if these are the actual right values???
+                    7,
                     listOf(0, 0, 0),
                     listOf(0, 0, 0),
                     mapOf("a" to "b"),

--- a/yorkie/src/test/kotlin/dev/yorkie/util/IndexTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/util/IndexTreeTest.kt
@@ -3,12 +3,13 @@ package dev.yorkie.util
 import dev.yorkie.document.crdt.CrdtTreeNode
 import dev.yorkie.document.crdt.CrdtTreePos.Companion.InitialCrdtTreePos
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class IndexTreeTest {
 
     @Test
-    fun `should find position from the offsets`() {
+    fun `should find treePos from the offsets`() {
         //    0   1 2 3 4 5 6    7   8 9  10 11 12 13    14
         // <r> <p> h e l l o </p> <p> w  o  r  l  d  </p>  </r>
         val tree = createIndexTree(
@@ -37,6 +38,15 @@ class IndexTreeTest {
     }
 
     @Test
+    fun `should throw IllegalArgumentException when trying to find treePos with invalid index`() {
+        val tree = createIndexTree(DefaultRootNode)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            tree.findTreePos(tree.size + 1)
+        }
+    }
+
+    @Test
     fun `should find right node from the given offset in postorder traversal`() {
         //       0   1 2 3    4   5 6 7    8
         // <root> <p> a b </p> <p> c d </p> </root>
@@ -47,6 +57,8 @@ class IndexTreeTest {
                 createElementNode("p", createTextNode("cd")),
             ),
         )
+
+        // postorder traversal: "ab", <b>, "cd", <p>, <root>
         assertEquals("text", tree.findPostorderRight(tree.findTreePos(0))?.type)
         assertEquals("text", tree.findPostorderRight(tree.findTreePos(1))?.type)
         assertEquals("p", tree.findPostorderRight(tree.findTreePos(3))?.type)
@@ -54,6 +66,27 @@ class IndexTreeTest {
         assertEquals("text", tree.findPostorderRight(tree.findTreePos(5))?.type)
         assertEquals("p", tree.findPostorderRight(tree.findTreePos(7))?.type)
         assertEquals("root", tree.findPostorderRight(tree.findTreePos(8))?.type)
+    }
+
+    @Test
+    fun `should find common ancestor of two given nodes`() {
+        val tree = createIndexTree(
+            createElementNode(
+                "root",
+                createElementNode(
+                    "p",
+                    createElementNode("b", createTextNode("ab")),
+                    createElementNode("b", createTextNode("cd")),
+                ),
+            ),
+        )
+
+        val nodeAB = tree.findTreePos(3, true).node
+        val nodeCD = tree.findTreePos(7, true).node
+
+        assertEquals("text.ab", nodeAB.toDiagnostic())
+        assertEquals("text.cd", nodeCD.toDiagnostic())
+        assertEquals("p", findCommonAncestor(nodeAB, nodeCD)?.type)
     }
 
     @Test
@@ -79,7 +112,24 @@ class IndexTreeTest {
     }
 
     @Test
-    fun `should convert index to pos`() {
+    fun `should throw IllegalArgumentException when traversing nodes within invalid ranges`() {
+        val tree = createIndexTree(DefaultRootNode)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            tree.nodesBetween(tree.size, 0)
+        }
+
+        assertThrows(IllegalArgumentException::class.java) {
+            tree.nodesBetween(tree.size + 1, tree.size + 2)
+        }
+
+        assertThrows(IllegalArgumentException::class.java) {
+            tree.nodesBetween(tree.size, tree.size + 1)
+        }
+    }
+
+    @Test
+    fun `should convert index to treePos and vice versa`() {
         //       0   1 2 3 4    5   6 7 8 9 10 11 12  13  14 15 16  17 18 19 20   21
         // <root> <p> a b c </p> <p> c d e f  g  h </p> <p> i  j   k  l  m  n  </p>  </root>
         val tree = createIndexTree(
@@ -103,6 +153,72 @@ class IndexTreeTest {
         for (i in 0 until tree.root.size) {
             val pos = tree.findTreePos(i, true)
             assertEquals(i, tree.indexOf(pos))
+        }
+    }
+
+    @Test
+    fun `should find treePos from given path`() {
+        //       0   1 2 3    4   5 6 7 8    9   10 11 12   13
+        // <root> <p> a b </p> <p> c d e </p> <p>  f  g  </p>  </root>
+        val tree = createIndexTree(
+            createElementNode(
+                "root",
+                createElementNode("p", createTextNode("a"), createTextNode("b")),
+                createElementNode("p", createTextNode("cde")),
+                createElementNode("p", createTextNode("fg")),
+            ),
+        )
+
+        var pos = tree.pathToTreePos(listOf(0))
+        assertEquals("root" to 0, pos.node.toDiagnostic() to pos.offset)
+
+        pos = tree.pathToTreePos(listOf(0, 0))
+        assertEquals("text.a" to 0, pos.node.toDiagnostic() to pos.offset)
+
+        pos = tree.pathToTreePos(listOf(0, 1))
+        assertEquals("text.a" to 1, pos.node.toDiagnostic() to pos.offset)
+
+        pos = tree.pathToTreePos(listOf(0, 2))
+        assertEquals("text.b" to 1, pos.node.toDiagnostic() to pos.offset)
+
+        pos = tree.pathToTreePos(listOf(1))
+        assertEquals("root" to 1, pos.node.toDiagnostic() to pos.offset)
+
+        pos = tree.pathToTreePos(listOf(1, 0))
+        assertEquals("text.cde" to 0, pos.node.toDiagnostic() to pos.offset)
+
+        pos = tree.pathToTreePos(listOf(1, 1))
+        assertEquals("text.cde" to 1, pos.node.toDiagnostic() to pos.offset)
+
+        pos = tree.pathToTreePos(listOf(1, 2))
+        assertEquals("text.cde" to 2, pos.node.toDiagnostic() to pos.offset)
+
+        pos = tree.pathToTreePos(listOf(1, 3))
+        assertEquals("text.cde" to 3, pos.node.toDiagnostic() to pos.offset)
+
+        pos = tree.pathToTreePos(listOf(2))
+        assertEquals("root" to 2, pos.node.toDiagnostic() to pos.offset)
+
+        pos = tree.pathToTreePos(listOf(2, 0))
+        assertEquals("text.fg" to 0, pos.node.toDiagnostic() to pos.offset)
+
+        pos = tree.pathToTreePos(listOf(2, 1))
+        assertEquals("text.fg" to 1, pos.node.toDiagnostic() to pos.offset)
+
+        pos = tree.pathToTreePos(listOf(2, 2))
+        assertEquals("text.fg" to 2, pos.node.toDiagnostic() to pos.offset)
+    }
+
+    @Test
+    fun `should throw IllegalArgumentException for unacceptable paths`() {
+        val tree = createIndexTree(DefaultRootNode)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            tree.pathToTreePos(emptyList())
+        }
+
+        assertThrows(IllegalArgumentException::class.java) {
+            tree.pathToTreePos(listOf(tree.size + 1))
         }
     }
 
@@ -185,7 +301,7 @@ class IndexTreeTest {
     }
 
     @Test
-    fun `should find index from given path`() {
+    fun `should find index from given path and vice versa`() {
         val tree = createIndexTree(
             createElementNode(
                 "root",
@@ -280,16 +396,24 @@ class IndexTreeTest {
         }
     }
 
-    private fun createElementNode(type: String, vararg childNode: CrdtTreeNode): CrdtTreeNode {
-        return CrdtTreeNode(InitialCrdtTreePos, type, _children = childNode.toMutableList())
-    }
-
-    private fun createTextNode(value: String) =
-        CrdtTreeNode(InitialCrdtTreePos, "text", _value = value)
-
     private fun IndexTree<CrdtTreeNode>.nodesBetween(from: Int, to: Int) = buildList {
         nodesBetween(from, to) { node ->
             add(node.toDiagnostic())
         }
+    }
+
+    companion object {
+        private fun createElementNode(type: String, vararg childNode: CrdtTreeNode): CrdtTreeNode {
+            return CrdtTreeNode(InitialCrdtTreePos, type, _children = childNode.toMutableList())
+        }
+
+        private fun createTextNode(value: String) =
+            CrdtTreeNode(InitialCrdtTreePos, "text", _value = value)
+
+        private val DefaultRootNode = createElementNode(
+            "root",
+            createElementNode("p", createTextNode("ab")),
+            createElementNode("p", createTextNode("cd")),
+        )
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- Added more tests for IndexTree.
- Added integration tests for GC.
- Changed protobuf data type of `client_seq` and `delimiter` from `uint32` to `uint64`. (cc. @hackerwins )
    - [Protobuf uses a Java int for the Protobuf type uint32](https://protobuf.dev/programming-guides/proto2/#scalar). It causes issues when the server sends a `delimiter` or `client_seq` larger than `Int.MAX_VALUE`. I replaced all `uint32` with `uint64`, which is converted to a long in Java, so that we can properly express all `uint32` values.
- Removed unnecessary codes from GC in [967de53](https://github.com/yorkie-team/yorkie-android-sdk/pull/123/commits/967de5315de1d4f564bf99c8b208f52064e7bc7c)
    - https://github.com/yorkie-team/yorkie-js-sdk/pull/568

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
