### PR TITLE
Prevent usage of `.` in JsonObject key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
           disable-animations: true
           script: |
             adb shell pm list packages | grep dev.yorkie.test && adb uninstall dev.yorkie.test || true;
+            adb logcat *:E &
             ./gradlew yorkie:createDebugAndroidTestCoverageReport
       - uses: actions/upload-artifact@v3
         with:

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - yorkie
   yorkie:
-    image: 'yorkieteam/yorkie:latest'
+    image: 'yorkieteam/yorkie:0.4.4'
     container_name: 'yorkie'
     command: [
       'server',

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
   yorkie:
-    image: 'yorkieteam/yorkie:latest'
+    image: 'yorkieteam/yorkie:0.4.4'
     container_name: 'yorkie'
     command: [
       'server',

--- a/examples/kanban/build.gradle.kts
+++ b/examples/kanban/build.gradle.kts
@@ -72,5 +72,5 @@ dependencies {
     testImplementation(libs.androidx.test.monitor)
     testImplementation(libs.androidx.test.junit)
 
-    androidTestImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.test.junit)
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -11,6 +11,7 @@ import dev.yorkie.document.change.CheckPoint
 import dev.yorkie.document.crdt.CrdtObject
 import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.crdt.ElementRht
+import dev.yorkie.document.json.JsonArray
 import dev.yorkie.document.json.JsonElement
 import dev.yorkie.document.json.JsonObject
 import dev.yorkie.document.operation.OperationInfo
@@ -153,11 +154,15 @@ public class Document(public val key: Key) {
             "the path must start with \"$\""
         }
         val paths = path.split(".").drop(1)
-        var value = getRoot()
-        paths.dropLast(1).forEach { key ->
-            value = value[key] as? JsonObject ?: return null
+        var value: JsonElement? = getRoot()
+        paths.forEach { key ->
+            value = when (value) {
+                is JsonObject -> (value as JsonObject).getOrNull(key)
+                is JsonArray -> (value as JsonArray)[key.toInt()]
+                else -> return null
+            }
         }
-        return value.getOrNull(paths.last())
+        return value
     }
 
     /**

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonObject.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonObject.kt
@@ -117,6 +117,9 @@ public class JsonObject internal constructor(
     }
 
     private fun setAndRegister(key: String, element: CrdtElement) {
+        require(!key.contains(".")) {
+            """key must not contain the "."."""
+        }
         val removed = target.set(key, element)
         context.registerElement(element, target)
         removed?.let(context::registerRemovedElement)

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonObjectTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonObjectTest.kt
@@ -45,6 +45,21 @@ class JsonObjectTest {
     }
 
     @Test
+    fun `should throw when setting a key containing delimiter`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            target["."] = "dot"
+        }
+
+        assertThrows(IllegalArgumentException::class.java) {
+            target["$..hello"] = "world"
+        }
+
+        assertThrows(IllegalArgumentException::class.java) {
+            target.setNewObject("")["."] = "dot"
+        }
+    }
+
+    @Test
     fun `should return null when accessing a key not added with getAsOrNull function`() {
         assertNull(target.getAsOrNull<JsonPrimitive>("k1"))
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- I added a restriction on JsonObject key not to contain the delimiter `.`.
- `getValueByPath()` was not functioning correctly, so I fixed it.

#### Any background context you want to provide?

#### What are the relevant tickets?
related to https://github.com/yorkie-team/yorkie-js-sdk/pull/569, https://github.com/yorkie-team/yorkie-ios-sdk/pull/86

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
