### PR TITLE
Update TreeEdit protobuf model and improve JsonTree functionality

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
   yorkie:
-    image: 'yorkieteam/yorkie:0.4.4'
+    image: 'yorkieteam/yorkie:0.4.5'
     container_name: 'yorkie'
     command: [
       'server',

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
   yorkie:
-    image: 'yorkieteam/yorkie:latest'
+    image: 'yorkieteam/yorkie:0.4.4'
     container_name: 'yorkie'
     command: [
       'server',

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
   yorkie:
-    image: 'yorkieteam/yorkie:0.4.5'
+    image: 'yorkieteam/yorkie:latest'
     container_name: 'yorkie'
     command: [
       'server',

--- a/yorkie/proto/src/main/proto/yorkie/v1/resources.proto
+++ b/yorkie/proto/src/main/proto/yorkie/v1/resources.proto
@@ -108,7 +108,7 @@ message Operation {
     TimeTicket parent_created_at = 1;
     TreePos from = 2;
     TreePos to = 3;
-    repeated TreeNode content = 4;
+    repeated TreeNodes contents = 4;
     TimeTicket executed_at = 5;
   }
   message TreeStyle {
@@ -231,6 +231,10 @@ message TreeNode {
   TreePos ins_prev_pos = 5;
   int32 depth = 6;
   map<string, NodeAttr> attributes = 7;
+}
+
+message TreeNodes {
+  repeated TreeNode content = 1;
 }
 
 message TreePos {

--- a/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
@@ -322,10 +322,9 @@ internal fun List<CrdtTreeNode>.toPBTreeNodesWhenEdit(): List<PBTreeNodes> {
 }
 
 internal fun List<PBTreeNodes>.toCrdtTreeNodesWhenEdit(): List<CrdtTreeNode>? {
-    return takeIf { it.isNotEmpty() }
-        ?.mapNotNull {
-            it.contentList.toCrdtTreeRootNode()
-        }
+    return mapNotNull {
+        it.contentList.toCrdtTreeRootNode()
+    }.ifEmpty { null }
 }
 
 internal fun CrdtTreePos.toPBTreePos(): PBTreePos {

--- a/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
@@ -19,6 +19,7 @@ import dev.yorkie.api.v1.textNode
 import dev.yorkie.api.v1.textNodeID
 import dev.yorkie.api.v1.textNodePos
 import dev.yorkie.api.v1.treeNode
+import dev.yorkie.api.v1.treeNodes
 import dev.yorkie.api.v1.treePos
 import dev.yorkie.document.crdt.CrdtArray
 import dev.yorkie.document.crdt.CrdtCounter
@@ -61,6 +62,7 @@ internal typealias PBTextNode = dev.yorkie.api.v1.TextNode
 internal typealias PBTree = dev.yorkie.api.v1.JSONElement.Tree
 internal typealias PBTreeNode = dev.yorkie.api.v1.TreeNode
 internal typealias PBTreePos = dev.yorkie.api.v1.TreePos
+internal typealias PBTreeNodes = dev.yorkie.api.v1.TreeNodes
 
 internal fun ByteString.toCrdtObject(): CrdtObject {
     return PBJsonElement.parseFrom(this).jsonObject.toCrdtObject()
@@ -309,6 +311,21 @@ internal fun CrdtTreeNode.toPBTreeNodes(): List<PBTreeNode> {
             add(pbTreeNode)
         }
     }
+}
+
+internal fun List<CrdtTreeNode>.toPBTreeNodesWhenEdit(): List<PBTreeNodes> {
+    return map {
+        treeNodes {
+            content.addAll(it.toPBTreeNodes())
+        }
+    }
+}
+
+internal fun List<PBTreeNodes>.toCrdtTreeNodesWhenEdit(): List<CrdtTreeNode>? {
+    return takeIf { it.isNotEmpty() }
+        ?.mapNotNull {
+            it.contentList.toCrdtTreeRootNode()
+        }
 }
 
 internal fun CrdtTreePos.toPBTreePos(): PBTreePos {

--- a/yorkie/src/main/kotlin/dev/yorkie/api/OperationConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/OperationConverter.kt
@@ -96,7 +96,7 @@ internal fun List<PBOperation>.toOperations(): List<Operation> {
                 parentCreatedAt = it.treeEdit.parentCreatedAt.toTimeTicket(),
                 fromPos = it.treeEdit.from.toCrdtTreePos(),
                 toPos = it.treeEdit.to.toCrdtTreePos(),
-                content = it.treeEdit.contentList.toCrdtTreeRootNode(),
+                contents = it.treeEdit.contentsList.toCrdtTreeNodesWhenEdit(),
                 executedAt = it.treeEdit.executedAt.toTimeTicket(),
             )
 
@@ -214,7 +214,7 @@ internal fun Operation.toPBOperation(): PBOperation {
                     from = operation.fromPos.toPBTreePos()
                     to = operation.toPos.toPBTreePos()
                     executedAt = operation.executedAt.toPBTimeTicket()
-                    content.addAll(operation.content?.toPBTreeNodes().orEmpty())
+                    contents.addAll(operation.contents?.toPBTreeNodesWhenEdit().orEmpty())
                 }
             }
         }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TreeInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TreeInfo.kt
@@ -46,7 +46,7 @@ internal data class TreeChange(
     val to: Int,
     val fromPath: List<Int>,
     val toPath: List<Int>,
-    val value: TreeNode? = null,
+    val value: List<TreeNode>? = null,
     val attributes: Map<String, String>? = null,
 )
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonTree.kt
@@ -123,7 +123,7 @@ public class JsonTree internal constructor(
         val ticket = context.lastTimeTicket
         target.edit(
             fromPos to toPos,
-            crdtNodes.takeIf { it.isNotEmpty() }?.map { it.deepCopy() },
+            crdtNodes.map { it.deepCopy() }.ifEmpty { null },
             ticket,
         )
 
@@ -132,7 +132,7 @@ public class JsonTree internal constructor(
                 target.createdAt,
                 fromPos,
                 toPos,
-                crdtNodes.takeIf { it.isNotEmpty() },
+                crdtNodes.ifEmpty { null },
                 ticket,
             ),
         )

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/OperationInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/OperationInfo.kt
@@ -62,7 +62,7 @@ public sealed class OperationInfo {
         val to: Int,
         val fromPath: List<Int>,
         val toPath: List<Int>,
-        val node: TreeNode?,
+        val nodes: List<TreeNode>?,
         override var path: String = INITIAL_PATH,
     ) : OperationInfo()
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
@@ -14,7 +14,7 @@ internal data class TreeEditOperation(
     override val parentCreatedAt: TimeTicket,
     val fromPos: CrdtTreePos,
     val toPos: CrdtTreePos,
-    val content: CrdtTreeNode?,
+    val contents: List<CrdtTreeNode>?,
     override var executedAt: TimeTicket,
 ) : Operation() {
     override val effectedCreatedAt = parentCreatedAt
@@ -29,7 +29,8 @@ internal data class TreeEditOperation(
             YorkieLogger.e(TAG, "fail to execute, only Tree can execute edit")
             return emptyList()
         }
-        val changes = tree.edit(fromPos to toPos, content?.deepCopy(), executedAt)
+        val changes =
+            tree.edit(fromPos to toPos, contents?.map(CrdtTreeNode::deepCopy), executedAt)
 
         if (fromPos.createdAt != toPos.createdAt || fromPos.offset != toPos.offset) {
             root.registerElementHasRemovedNodes(tree)

--- a/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
@@ -238,7 +238,7 @@ class ConverterTest {
             InitialTimeTicket,
             CrdtTreePos(InitialTimeTicket, 5),
             CrdtTreePos(InitialTimeTicket, 10),
-            CrdtTreeText(CrdtTreePos(InitialTimeTicket, 0), "hi"),
+            listOf(CrdtTreeText(CrdtTreePos(InitialTimeTicket, 0), "hi")),
             InitialTimeTicket,
         )
         val treeStyleOperation = TreeStyleOperation(

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTreeTest.kt
@@ -61,14 +61,14 @@ class CrdtTreeTest {
 
         //           1
         // <root> <p> </p> </root>
-        target.editByIndex(0 to 0, CrdtTreeElement(issuePos(), "p"), issueTime())
+        target.editByIndex(0 to 0, CrdtTreeElement(issuePos(), "p").toList(), issueTime())
         assertEquals("<root><p></p></root>", target.toXml())
         assertEquals(listOf("p", "root"), target.toList())
         assertEquals(2, target.root.size)
 
         //           1
         // <root> <p> h e l l o </p> </root>
-        target.editByIndex(1 to 1, CrdtTreeText(issuePos(), "hello"), issueTime())
+        target.editByIndex(1 to 1, CrdtTreeText(issuePos(), "hello").toList(), issueTime())
         assertEquals("<root><p>hello</p></root>", target.toXml())
         assertEquals(listOf("text.hello", "p", "root"), target.toList())
         assertEquals(7, target.root.size)
@@ -78,14 +78,14 @@ class CrdtTreeTest {
         val p = CrdtTreeElement(issuePos(), "p").apply {
             insertAt(0, CrdtTreeText(issuePos(), "world"))
         }
-        target.editByIndex(7 to 7, p, issueTime())
+        target.editByIndex(7 to 7, p.toList(), issueTime())
         assertEquals("<root><p>hello</p><p>world</p></root>", target.toXml())
         assertEquals(listOf("text.hello", "p", "text.world", "p", "root"), target.toList())
         assertEquals(14, target.root.size)
 
         //       0   1 2 3 4 5 6 7    8   9 10 11 12 13 14    15
         // <root> <p> h e l l o ! </p> <p> w  o  r  l  d  </p>  </root>
-        target.editByIndex(6 to 6, CrdtTreeText(issuePos(), "!"), issueTime())
+        target.editByIndex(6 to 6, CrdtTreeText(issuePos(), "!").toList(), issueTime())
         assertEquals("<root><p>hello!</p><p>world</p></root>", target.toXml())
         assertEquals(
             listOf("text.hello", "text.!", "p", "text.world", "p", "root"),
@@ -93,7 +93,7 @@ class CrdtTreeTest {
         )
         assertEquals(15, target.root.size)
 
-        target.editByIndex(6 to 6, CrdtTreeText(issuePos(), "~"), issueTime())
+        target.editByIndex(6 to 6, CrdtTreeText(issuePos(), "~").toList(), issueTime())
         assertEquals("<root><p>hello~!</p><p>world</p></root>", target.toXml())
         assertEquals(
             listOf("text.hello", "text.~", "text.!", "p", "text.world", "p", "root"),
@@ -107,10 +107,10 @@ class CrdtTreeTest {
         // 01. Create a tree with 2 paragraphs.
         //       0   1 2 3    4   5 6 7    8
         // <root> <p> a b </p> <p> c d </p> </root>
-        target.editByIndex(0 to 0, CrdtTreeElement(issuePos(), "p"), issueTime())
-        target.editByIndex(1 to 1, CrdtTreeText(issuePos(), "ab"), issueTime())
-        target.editByIndex(4 to 4, CrdtTreeElement(issuePos(), "p"), issueTime())
-        target.editByIndex(5 to 5, CrdtTreeText(issuePos(), "cd"), issueTime())
+        target.editByIndex(0 to 0, CrdtTreeElement(issuePos(), "p").toList(), issueTime())
+        target.editByIndex(1 to 1, CrdtTreeText(issuePos(), "ab").toList(), issueTime())
+        target.editByIndex(4 to 4, CrdtTreeElement(issuePos(), "p").toList(), issueTime())
+        target.editByIndex(5 to 5, CrdtTreeText(issuePos(), "cd").toList(), issueTime())
         assertEquals("<root><p>ab</p><p>cd</p></root>", target.toXml())
         assertEquals(listOf("text.ab", "p", "text.cd", "p", "root"), target.toList())
         assertEquals(8, target.root.size)
@@ -129,10 +129,10 @@ class CrdtTreeTest {
         // 01. Create a tree with 2 paragraphs.
         //       0   1 2 3    4   5 6 7    8
         // <root> <p> a b </p> <p> c d </p> </root>
-        target.editByIndex(0 to 0, CrdtTreeElement(issuePos(), "p"), issueTime())
-        target.editByIndex(1 to 1, CrdtTreeText(issuePos(), "ab"), issueTime())
-        target.editByIndex(4 to 4, CrdtTreeElement(issuePos(), "p"), issueTime())
-        target.editByIndex(5 to 5, CrdtTreeText(issuePos(), "cd"), issueTime())
+        target.editByIndex(0 to 0, CrdtTreeElement(issuePos(), "p").toList(), issueTime())
+        target.editByIndex(1 to 1, CrdtTreeText(issuePos(), "ab").toList(), issueTime())
+        target.editByIndex(4 to 4, CrdtTreeElement(issuePos(), "p").toList(), issueTime())
+        target.editByIndex(5 to 5, CrdtTreeText(issuePos(), "cd").toList(), issueTime())
         assertEquals("<root><p>ab</p><p>cd</p></root>", target.toXml())
         assertEquals(listOf("text.ab", "p", "text.cd", "p", "root"), target.toList())
 
@@ -143,7 +143,7 @@ class CrdtTreeTest {
         assertEquals("<root><p>ad</p></root>", target.toXml())
 
         // 03. insert a new text node at the start of the first paragraph.
-        target.editByIndex(1 to 1, CrdtTreeText(issuePos(), "@"), issueTime())
+        target.editByIndex(1 to 1, CrdtTreeText(issuePos(), "@").toList(), issueTime())
         assertEquals("<root><p>@ad</p></root>", target.toXml())
     }
 
@@ -151,10 +151,10 @@ class CrdtTreeTest {
     fun `should merge and edit different levels with editByIndex`() {
         fun initializeTree() {
             setUp()
-            target.editByIndex(0 to 0, CrdtTreeElement(issuePos(), "p"), issueTime())
-            target.editByIndex(1 to 1, CrdtTreeElement(issuePos(), "b"), issueTime())
-            target.editByIndex(2 to 2, CrdtTreeElement(issuePos(), "i"), issueTime())
-            target.editByIndex(3 to 3, CrdtTreeText(issuePos(), "ab"), issueTime())
+            target.editByIndex(0 to 0, CrdtTreeElement(issuePos(), "p").toList(), issueTime())
+            target.editByIndex(1 to 1, CrdtTreeElement(issuePos(), "b").toList(), issueTime())
+            target.editByIndex(2 to 2, CrdtTreeElement(issuePos(), "i").toList(), issueTime())
+            target.editByIndex(3 to 3, CrdtTreeText(issuePos(), "ab").toList(), issueTime())
             assertEquals("<root><p><b><i>ab</i></b></p></root>", target.toXml())
         }
 
@@ -192,13 +192,13 @@ class CrdtTreeTest {
 
         // 07. edit between text and element node in same hierarchy.
         setUp()
-        target.editByIndex(0 to 0, CrdtTreeElement(issuePos(), "p"), issueTime())
-        target.editByIndex(1 to 1, CrdtTreeText(issuePos(), "ab"), issueTime())
-        target.editByIndex(4 to 4, CrdtTreeElement(issuePos(), "p"), issueTime())
-        target.editByIndex(5 to 5, CrdtTreeElement(issuePos(), "b"), issueTime())
-        target.editByIndex(6 to 6, CrdtTreeText(issuePos(), "cd"), issueTime())
-        target.editByIndex(10 to 10, CrdtTreeElement(issuePos(), "p"), issueTime())
-        target.editByIndex(11 to 11, CrdtTreeText(issuePos(), "ef"), issueTime())
+        target.editByIndex(0 to 0, CrdtTreeElement(issuePos(), "p").toList(), issueTime())
+        target.editByIndex(1 to 1, CrdtTreeText(issuePos(), "ab").toList(), issueTime())
+        target.editByIndex(4 to 4, CrdtTreeElement(issuePos(), "p").toList(), issueTime())
+        target.editByIndex(5 to 5, CrdtTreeElement(issuePos(), "b").toList(), issueTime())
+        target.editByIndex(6 to 6, CrdtTreeText(issuePos(), "cd").toList(), issueTime())
+        target.editByIndex(10 to 10, CrdtTreeElement(issuePos(), "p").toList(), issueTime())
+        target.editByIndex(11 to 11, CrdtTreeText(issuePos(), "ef").toList(), issueTime())
         assertEquals("<root><p>ab</p><p><b>cd</b></p><p>ef</p></root>", target.toXml())
 
         target.editByIndex(9 to 10, null, issueTime())
@@ -209,10 +209,10 @@ class CrdtTreeTest {
     fun `should get correct index from CrdtTreePos`() {
         //     0  1  2   3 4 5    6   7   8
         // <root><p><b><i> a b </i></b></p></root>
-        target.editByIndex(0 to 0, CrdtTreeElement(issuePos(), "p"), issueTime())
-        target.editByIndex(1 to 1, CrdtTreeElement(issuePos(), "b"), issueTime())
-        target.editByIndex(2 to 2, CrdtTreeElement(issuePos(), "i"), issueTime())
-        target.editByIndex(3 to 3, CrdtTreeText(issuePos(), "ab"), issueTime())
+        target.editByIndex(0 to 0, CrdtTreeElement(issuePos(), "p").toList(), issueTime())
+        target.editByIndex(1 to 1, CrdtTreeElement(issuePos(), "b").toList(), issueTime())
+        target.editByIndex(2 to 2, CrdtTreeElement(issuePos(), "i").toList(), issueTime())
+        target.editByIndex(3 to 3, CrdtTreeText(issuePos(), "ab").toList(), issueTime())
         assertEquals("<root><p><b><i>ab</i></b></p></root>", target.toXml())
 
         var (from, to) = target.pathToPosRange(listOf(0))
@@ -254,6 +254,8 @@ class CrdtTreeTest {
             node.type
         }
     }
+
+    private fun CrdtTreeNode.toList() = listOf(this)
 
     companion object {
 

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
@@ -346,7 +346,7 @@ class JsonTreeTest {
                     1,
                     listOf(0, 0),
                     listOf(0, 0),
-                    TreeNode("text", value = "X"),
+                    listOf(TreeNode("text", value = "X")),
                     "$.t",
                 ),
                 TreeStyleOpInfo(
@@ -412,7 +412,7 @@ class JsonTreeTest {
                     4,
                     listOf(0, 0, 0, 1),
                     listOf(0, 0, 0, 1),
-                    TreeNode("text", value = "X"),
+                    listOf(TreeNode("text", value = "X")),
                     "$.t",
                 ),
                 TreeStyleOpInfo(


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- updated TreeEdit protobuf model and related code.
- fixed misbehaviors of `JsonTree`.
- added `pathToIndex()` in `JsonTree`.

#### Any background context you want to provide?
some tests will fail in the CI due to its downgraded server version, but I checked they work fine in the latest server.

#### What are the relevant tickets?
- https://github.com/yorkie-team/yorkie-js-sdk/pull/570
- https://github.com/yorkie-team/yorkie-js-sdk/pull/576
- https://github.com/yorkie-team/yorkie-js-sdk/pull/567

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
