### PR TITLE
Allow user to configure Channel

### DIFF
--- a/yorkie/build.gradle.kts
+++ b/yorkie/build.gradle.kts
@@ -191,7 +191,7 @@ protobuf {
 dependencies {
     protobuf(project(":yorkie:proto"))
 
-    implementation(libs.bundles.grpc)
+    api(libs.bundles.grpc)
     implementation(libs.kotlinx.coroutines)
     implementation(libs.apache.commons.collections)
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
@@ -12,9 +12,10 @@ fun createClient(presence: Presence? = null) = Client(
     InstrumentationRegistry.getInstrumentation().targetContext,
     "10.0.2.2",
     8080,
-    usePlainText = true,
     options = Client.Options(presence = presence),
-)
+) {
+    it.usePlaintext()
+}
 
 fun String.toDocKey(): Document.Key {
     return Document.Key(

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -118,10 +118,10 @@ public class Client @VisibleForTesting internal constructor(
         rpcHost: String,
         rpcPort: Int,
         options: Options = Options(),
-        usePlainText: Boolean = false,
+        buildChannel: (AndroidChannelBuilder) -> AndroidChannelBuilder = { it },
     ) : this(
         channel = AndroidChannelBuilder.forAddress(rpcHost, rpcPort)
-            .run { if (usePlainText) usePlaintext() else this }
+            .let(buildChannel)
             .context(context.applicationContext)
             .build(),
         options = options,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Allows user to configure Channel.
There was no way to configure Channel which could be problematic when users need custom values for `maxInboundMessageSize` and etc.

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
