### PR TITLE
Add JsonSerializable `XXStruct` classes

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
@@ -17,7 +17,6 @@ import dev.yorkie.document.operation.OperationInfo.EditOpInfo
 import dev.yorkie.document.operation.OperationInfo.IncreaseOpInfo
 import dev.yorkie.document.operation.OperationInfo.MoveOpInfo
 import dev.yorkie.document.operation.OperationInfo.RemoveOpInfo
-import dev.yorkie.document.operation.OperationInfo.SelectOpInfo
 import dev.yorkie.document.operation.OperationInfo.SetOpInfo
 import dev.yorkie.document.operation.OperationInfo.StyleOpInfo
 import kotlinx.coroutines.CoroutineStart
@@ -289,10 +288,7 @@ class DocumentTest {
                     val currItem = requireNotNull(getAs<JsonPrimitive>(0))
                     moveAfter(prevItem.target.id, currItem.target.id)
                 }
-                it.getAs<JsonText>("content").apply {
-                    select(0, 5)
-                    style(0, 5, mapOf("bold" to "true"))
-                }
+                it.getAs<JsonText>("content").style(0, 5, mapOf("bold" to "true"))
             }.await()
 
             withTimeout(2_000) {
@@ -306,7 +302,6 @@ class DocumentTest {
                 IncreaseOpInfo(path = "$.counter", value = 1),
                 AddOpInfo(path = "$.todos", index = 3),
                 MoveOpInfo(path = "$.todos", index = 1, previousIndex = 0),
-                SelectOpInfo(path = "$.content", from = 0, to = 5),
                 StyleOpInfo(
                     path = "$.content",
                     from = 0,
@@ -327,7 +322,6 @@ class DocumentTest {
                     value = TextWithAttributes("hello world" to mapOf("italic" to "true")),
                     path = "$.content",
                 ),
-                SelectOpInfo(path = "$.content", from = 11, to = 11),
                 SetOpInfo(path = "$", key = "obj"),
                 SetOpInfo(path = "$.obj", key = "name"),
                 SetOpInfo(path = "$.obj", key = "age"),

--- a/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
@@ -38,7 +38,7 @@ import dev.yorkie.document.crdt.RgaTreeList
 import dev.yorkie.document.crdt.RgaTreeSplit
 import dev.yorkie.document.crdt.RgaTreeSplitNode
 import dev.yorkie.document.crdt.RgaTreeSplitNodeID
-import dev.yorkie.document.crdt.RgaTreeSplitNodePos
+import dev.yorkie.document.crdt.RgaTreeSplitPos
 import dev.yorkie.document.crdt.Rht
 import dev.yorkie.document.crdt.TextValue
 import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
@@ -347,7 +347,7 @@ internal fun RgaTreeSplit<TextValue>.toPBTextNodes(): List<PBTextNode> {
     }
 }
 
-internal fun RgaTreeSplitNodePos.toPBTextNodePos(): PBTextNodePos {
+internal fun RgaTreeSplitPos.toPBTextNodePos(): PBTextNodePos {
     return textNodePos {
         createdAt = this@toPBTextNodePos.id.createdAt.toPBTimeTicket()
         offset = this@toPBTextNodePos.id.offset
@@ -355,8 +355,8 @@ internal fun RgaTreeSplitNodePos.toPBTextNodePos(): PBTextNodePos {
     }
 }
 
-internal fun PBTextNodePos.toRgaTreeSplitNodePos(): RgaTreeSplitNodePos {
-    return RgaTreeSplitNodePos(
+internal fun PBTextNodePos.toRgaTreeSplitNodePos(): RgaTreeSplitPos {
+    return RgaTreeSplitPos(
         id = RgaTreeSplitNodeID(createdAt.toTimeTicket(), offset),
         relativeOffSet = relativeOffset,
     )

--- a/yorkie/src/main/kotlin/dev/yorkie/document/JsonSerializableStruct.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/JsonSerializableStruct.kt
@@ -1,0 +1,74 @@
+package dev.yorkie.document
+
+import dev.yorkie.document.crdt.CrdtTreePos
+import dev.yorkie.document.crdt.RgaTreeSplitNodeID
+import dev.yorkie.document.crdt.RgaTreeSplitPos
+import dev.yorkie.document.time.ActorID
+import dev.yorkie.document.time.TimeTicket
+
+internal interface JsonSerializable<I, O : JsonSerializable.Struct<I>> {
+
+    interface Struct<I> {
+
+        fun toOriginal(): I
+    }
+
+    fun toStruct(): O
+}
+
+/**
+* [CrdtTreePosStruct] represents the structure of [CrdtTreePos].
+* It is used to serialize and deserialize the CRDTTreePos.
+*/
+public data class CrdtTreePosStruct(
+    val createdAt: TimeTicketStruct,
+    val offset: Int,
+) : JsonSerializable.Struct<CrdtTreePos> {
+
+    override fun toOriginal(): CrdtTreePos {
+        return CrdtTreePos(createdAt.toOriginal(), offset)
+    }
+}
+
+/**
+ * [RgaTreeSplitPosStruct] is a structure represents the meta data of the node pos.
+ * It is used to serialize and deserialize the node pos.
+ */
+public data class RgaTreeSplitPosStruct(
+    val id: RgaTreeSplitNodeIDStruct,
+    val relativeOffset: Int,
+) : JsonSerializable.Struct<RgaTreeSplitPos> {
+
+    override fun toOriginal(): RgaTreeSplitPos {
+        return RgaTreeSplitPos(id.toOriginal(), relativeOffset)
+    }
+}
+
+/**
+ * [RgaTreeSplitNodeIDStruct] is a structure represents the meta data of the node id.
+ * It is used to serialize and deserialize the node id.
+ */
+public data class RgaTreeSplitNodeIDStruct(
+    val createdAt: TimeTicketStruct,
+    val offset: Int,
+) : JsonSerializable.Struct<RgaTreeSplitNodeID> {
+
+    override fun toOriginal(): RgaTreeSplitNodeID {
+        return RgaTreeSplitNodeID(createdAt.toOriginal(), offset)
+    }
+}
+
+/**
+ * [TimeTicketStruct] is a structure represents the meta data of the ticket.
+ * It is used to serialize and deserialize the ticket.
+ */
+public data class TimeTicketStruct(
+    val lamport: String,
+    val delimiter: UInt,
+    val actorID: ActorID,
+) : JsonSerializable.Struct<TimeTicket> {
+
+    override fun toOriginal(): TimeTicket {
+        return TimeTicket(lamport.toLong(), delimiter, actorID)
+    }
+}

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -1,7 +1,9 @@
 package dev.yorkie.document.crdt
 
-import com.google.common.annotations.VisibleForTesting
+import dev.yorkie.document.CrdtTreePosStruct
+import dev.yorkie.document.JsonSerializable
 import dev.yorkie.document.crdt.CrdtTreeNode.Companion.CrdtTreeElement
+import dev.yorkie.document.json.TreePosStructRange
 import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
 import dev.yorkie.document.time.TimeTicket.Companion.compareTo
@@ -11,7 +13,7 @@ import dev.yorkie.util.TreePos
 import dev.yorkie.util.traverse
 import java.util.TreeMap
 
-public typealias TreeRange = Pair<CrdtTreePos, CrdtTreePos>
+public typealias TreePosRange = Pair<CrdtTreePos, CrdtTreePos>
 
 internal class CrdtTree(
     val root: CrdtTreeNode,
@@ -65,7 +67,7 @@ internal class CrdtTree(
      * Applies the given [attributes] of the given [range].
      */
     fun style(
-        range: TreeRange,
+        range: TreePosRange,
         attributes: Map<String, String>?,
         executedAt: TimeTicket,
     ): List<TreeChange> {
@@ -139,7 +141,7 @@ internal class CrdtTree(
      * If the [content] is null, the [range] will be removed.
      */
     fun edit(
-        range: TreeRange,
+        range: TreePosRange,
         content: CrdtTreeNode?,
         executedAt: TimeTicket,
     ): List<TreeChange> {
@@ -387,15 +389,14 @@ internal class CrdtTree(
     /**
      * Converts the given [pos] to the index of the tree.
      */
-    @VisibleForTesting
     fun toIndex(pos: CrdtTreePos): Int {
         return toTreePos(pos)?.let(indexTree::indexOf) ?: -1
     }
 
     /**
-     * Finds the range of pos from given [path].
+     * Converts the given path of the node to the range of the position.
      */
-    fun pathToPosRange(path: List<Int>): TreeRange {
+    fun pathToPosRange(path: List<Int>): TreePosRange {
         val index = pathToIndex(path)
         val (parentNode, offset) = pathToTreePos(path)
 
@@ -445,9 +446,10 @@ internal class CrdtTree(
     }
 
     /**
-     * Returns [TreeRange] based on the given index range.
+     * Returns the position range from the given [range].
      */
-    fun createRange(fromIndex: Int, toIndex: Int): TreeRange {
+    fun indexRangeToPosRange(range: Pair<Int, Int>): TreePosRange {
+        val (fromIndex, toIndex) = range
         val fromPos = findPos(fromIndex)
         return if (fromIndex == toIndex) {
             fromPos to fromPos
@@ -457,16 +459,24 @@ internal class CrdtTree(
     }
 
     /**
-     * Returns a pair of integer offsets of the tree.
+     * Converts the [range] into [TreePosStructRange].
      */
-    fun rangeToIndex(range: TreeRange): Pair<Int, Int> {
-        return toIndex(range.first) to toIndex(range.second)
+    fun indexRangeToPosStructRange(range: Pair<Int, Int>): TreePosStructRange {
+        val (fromPos, toPos) = indexRangeToPosRange(range)
+        return fromPos.toStruct() to toPos.toStruct()
     }
 
     /**
      * Returns a pair of integer offsets of the tree.
      */
-    fun rangeToPath(range: TreeRange): Pair<List<Int>, List<Int>> {
+    fun rangeToIndex(range: TreePosRange): Pair<Int, Int> {
+        return toIndex(range.first) to toIndex(range.second)
+    }
+
+    /**
+     * Converts the given position [range] to the path range.
+     */
+    fun posRangeToPathRange(range: TreePosRange): Pair<List<Int>, List<Int>> {
         val fromPath = indexTree.indexToPath(toIndex(range.first))
         val toPath = indexTree.indexToPath(toIndex(range.second))
         return fromPath to toPath
@@ -640,10 +650,14 @@ public data class CrdtTreePos(
      * The distance from the beginning of the node when the node is split.
      */
     val offset: Int,
-) : Comparable<CrdtTreePos> {
+) : Comparable<CrdtTreePos>, JsonSerializable<CrdtTreePos, CrdtTreePosStruct> {
 
     override fun compareTo(other: CrdtTreePos): Int {
         return compareValuesBy(this, other, { it.createdAt }, { it.offset })
+    }
+
+    override fun toStruct(): CrdtTreePosStruct {
+        return CrdtTreePosStruct(createdAt.toStruct(), offset)
     }
 
     companion object {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TextInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TextInfo.kt
@@ -24,8 +24,8 @@ internal enum class TextChangeType {
  * Represents the selection of text range in the editor.
  */
 internal data class Selection(
-    val from: RgaTreeSplitNodePos,
-    val to: RgaTreeSplitNodePos,
+    val from: RgaTreeSplitPos,
+    val to: RgaTreeSplitPos,
     val executedAt: TimeTicket,
 )
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonTree.kt
@@ -7,12 +7,15 @@ import dev.yorkie.document.crdt.CrdtTreeNode.Companion.CrdtTreeElement
 import dev.yorkie.document.crdt.CrdtTreeNode.Companion.CrdtTreeText
 import dev.yorkie.document.crdt.CrdtTreePos
 import dev.yorkie.document.crdt.Rht
-import dev.yorkie.document.crdt.TreeRange
+import dev.yorkie.document.crdt.TreePosRange
 import dev.yorkie.document.json.JsonTree.TreeNode
 import dev.yorkie.document.operation.TreeEditOperation
 import dev.yorkie.document.operation.TreeStyleOperation
 import dev.yorkie.util.IndexTreeNode.Companion.DEFAULT_ROOT_TYPE
 import dev.yorkie.util.IndexTreeNode.Companion.DEFAULT_TEXT_TYPE
+import dev.yorkie.document.CrdtTreePosStruct as TreePosStruct
+
+public typealias TreePosStructRange = Pair<TreePosStruct, TreePosStruct>
 
 /**
  * [JsonTree] is a CRDT-based tree structure that is used to represent the document
@@ -52,7 +55,7 @@ public class JsonTree internal constructor(
     }
 
     private fun styleByRange(
-        range: TreeRange,
+        range: TreePosRange,
         attributes: Map<String, String>,
     ) {
         val ticket = context.issueTimeTicket()
@@ -136,29 +139,36 @@ public class JsonTree internal constructor(
     public fun indexToPath(index: Int): List<Int> = target.indexToPath(index)
 
     /**
-     * Returns pair of CRDTTreePos of the given integer offsets.
+     * Converts the path [range] into the [TreePosStructRange].
      */
-    public fun createRange(
-        fromIndex: Int,
-        toIndex: Int,
-    ): TreeRange = target.createRange(fromIndex, toIndex)
-
-    /**
-     * Returns a pair of [CrdtTreeNode] of the given integer offsets.
-     */
-    public fun createRangeByPath(fromPath: List<Int>, toPath: List<Int>): TreeRange {
-        return createRange(target.pathToIndex(fromPath), target.pathToIndex(toPath))
+    public fun pathRangeToPosRange(range: Pair<List<Int>, List<Int>>): TreePosStructRange {
+        val indexRange = target.pathToIndex(range.first) to target.pathToIndex(range.second)
+        val posRange = target.indexRangeToPosRange(indexRange)
+        return posRange.first.toStruct() to posRange.second.toStruct()
     }
 
     /**
-     * Returns the integer offsets of the given [range].
+     * Converts the index [range] into the [TreePosStructRange].
      */
-    public fun rangeToIndex(range: TreeRange): Pair<Int, Int> = target.rangeToIndex(range)
+    public fun indexRangeToPosRange(range: Pair<Int, Int>): TreePosStructRange {
+        return target.indexRangeToPosStructRange(range)
+    }
 
     /**
-     *  Returns the path of the given [range].
+     * Converts the position [range] into the index range.
      */
-    public fun rangeToPath(range: TreeRange): Pair<List<Int>, List<Int>> = target.rangeToPath(range)
+    public fun posRangeToIndexRange(range: TreePosStructRange): Pair<Int, Int> {
+        val posRange = range.first.toOriginal() to range.second.toOriginal()
+        return target.toIndex(posRange.first) to target.toIndex(posRange.second)
+    }
+
+    /**
+     *  Converts the position [range] into the path range.
+     */
+    public fun posRangeToPathRange(range: TreePosStructRange): Pair<List<Int>, List<Int>> {
+        val posRange = range.first.toOriginal() to range.second.toOriginal()
+        return target.posRangeToPathRange(posRange)
+    }
 
     override fun isEmpty(): Boolean = target.isEmpty()
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/EditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/EditOperation.kt
@@ -2,8 +2,8 @@ package dev.yorkie.document.operation
 
 import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.crdt.CrdtText
-import dev.yorkie.document.crdt.RgaTreeSplitNodePos
-import dev.yorkie.document.crdt.RgaTreeSplitNodeRange
+import dev.yorkie.document.crdt.RgaTreeSplitPos
+import dev.yorkie.document.crdt.RgaTreeSplitPosRange
 import dev.yorkie.document.crdt.TextChangeType
 import dev.yorkie.document.crdt.TextWithAttributes
 import dev.yorkie.document.time.ActorID
@@ -14,8 +14,8 @@ import dev.yorkie.util.YorkieLogger
  * [EditOperation] is an operations representing editing rich text.
  */
 internal data class EditOperation(
-    val fromPos: RgaTreeSplitNodePos,
-    val toPos: RgaTreeSplitNodePos,
+    val fromPos: RgaTreeSplitPos,
+    val toPos: RgaTreeSplitPos,
     val maxCreatedAtMapByActor: Map<ActorID, TimeTicket>,
     val content: String,
     override val parentCreatedAt: TimeTicket,
@@ -33,7 +33,7 @@ internal data class EditOperation(
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtText) {
             val changes = parentObject.edit(
-                RgaTreeSplitNodeRange(fromPos, toPos),
+                RgaTreeSplitPosRange(fromPos, toPos),
                 content,
                 executedAt,
                 attributes,

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/SelectOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/SelectOperation.kt
@@ -2,14 +2,14 @@ package dev.yorkie.document.operation
 
 import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.crdt.CrdtText
-import dev.yorkie.document.crdt.RgaTreeSplitNodePos
-import dev.yorkie.document.crdt.RgaTreeSplitNodeRange
+import dev.yorkie.document.crdt.RgaTreeSplitPos
+import dev.yorkie.document.crdt.RgaTreeSplitPosRange
 import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.util.YorkieLogger
 
 internal data class SelectOperation(
-    val fromPos: RgaTreeSplitNodePos,
-    val toPos: RgaTreeSplitNodePos,
+    val fromPos: RgaTreeSplitPos,
+    val toPos: RgaTreeSplitPos,
     override val parentCreatedAt: TimeTicket,
     override var executedAt: TimeTicket,
 ) : Operation() {
@@ -23,7 +23,7 @@ internal data class SelectOperation(
     override fun execute(root: CrdtRoot): List<OperationInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtText) {
-            val change = parentObject.select(RgaTreeSplitNodeRange(fromPos, toPos), executedAt)
+            val change = parentObject.select(RgaTreeSplitPosRange(fromPos, toPos), executedAt)
                 ?: return emptyList()
             listOf(
                 OperationInfo.SelectOpInfo(from = change.from, to = change.to).apply {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt
@@ -2,14 +2,14 @@ package dev.yorkie.document.operation
 
 import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.crdt.CrdtText
-import dev.yorkie.document.crdt.RgaTreeSplitNodePos
-import dev.yorkie.document.crdt.RgaTreeSplitNodeRange
+import dev.yorkie.document.crdt.RgaTreeSplitPos
+import dev.yorkie.document.crdt.RgaTreeSplitPosRange
 import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.util.YorkieLogger
 
 internal data class StyleOperation(
-    val fromPos: RgaTreeSplitNodePos,
-    val toPos: RgaTreeSplitNodePos,
+    val fromPos: RgaTreeSplitPos,
+    val toPos: RgaTreeSplitPos,
     val attributes: Map<String, String>,
     override val parentCreatedAt: TimeTicket,
     override var executedAt: TimeTicket,
@@ -22,7 +22,7 @@ internal data class StyleOperation(
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtText) {
             val changes =
-                parentObject.style(RgaTreeSplitNodeRange(fromPos, toPos), attributes, executedAt)
+                parentObject.style(RgaTreeSplitPosRange(fromPos, toPos), attributes, executedAt)
             changes.map {
                 OperationInfo.StyleOpInfo(
                     it.from,

--- a/yorkie/src/main/kotlin/dev/yorkie/document/time/TimeTicket.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/time/TimeTicket.kt
@@ -1,5 +1,7 @@
 package dev.yorkie.document.time
 
+import dev.yorkie.document.JsonSerializable
+import dev.yorkie.document.TimeTicketStruct
 import dev.yorkie.document.time.ActorID.Companion.INITIAL_ACTOR_ID
 import dev.yorkie.document.time.ActorID.Companion.MAX_ACTOR_ID
 
@@ -10,7 +12,7 @@ public data class TimeTicket(
     public val lamport: Long,
     public val delimiter: UInt,
     public val actorID: ActorID,
-) : Comparable<TimeTicket> {
+) : Comparable<TimeTicket>, JsonSerializable<TimeTicket, TimeTicketStruct> {
 
     /**
      * Creates a new instance of [TimeTicket] with the given [ActorID].
@@ -23,10 +25,14 @@ public data class TimeTicket(
             ?: delimiter.compareTo(other.delimiter)
     }
 
+    override fun toStruct(): TimeTicketStruct {
+        return TimeTicketStruct(lamport.toString(), delimiter, actorID)
+    }
+
     companion object {
         internal const val INITIAL_DELIMITER = 0u
         internal const val MAX_DELIMITER = UInt.MAX_VALUE
-        internal const val MAX_LAMPORT = Long.MAX_VALUE
+        private const val MAX_LAMPORT = Long.MAX_VALUE
 
         private val NullTimeTicket = TimeTicket(
             Long.MIN_VALUE,

--- a/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
@@ -22,7 +22,7 @@ import dev.yorkie.document.crdt.ElementRht
 import dev.yorkie.document.crdt.RgaTreeList
 import dev.yorkie.document.crdt.RgaTreeSplit
 import dev.yorkie.document.crdt.RgaTreeSplitNodeID
-import dev.yorkie.document.crdt.RgaTreeSplitNodePos
+import dev.yorkie.document.crdt.RgaTreeSplitPos
 import dev.yorkie.document.operation.AddOperation
 import dev.yorkie.document.operation.EditOperation
 import dev.yorkie.document.operation.IncreaseOperation
@@ -199,7 +199,7 @@ class ConverterTest {
             InitialTimeTicket,
             InitialTimeTicket,
         )
-        val nodePos = RgaTreeSplitNodePos(
+        val nodePos = RgaTreeSplitPos(
             RgaTreeSplitNodeID(InitialTimeTicket, 0),
             0,
         )
@@ -322,7 +322,7 @@ class ConverterTest {
     @Test
     fun `should convert CrdtText`() {
         val crdtText = CrdtText(RgaTreeSplit(), InitialTimeTicket).apply {
-            edit(createRange(0, 0), "Text", InitialTimeTicket)
+            edit(indexRangeToPosRange(0, 0), "Text", InitialTimeTicket)
         }
         val converted = crdtText.toPBText().toCrdtElement()
         assertEquals(crdtText.toJson(), converted.toJson())

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtArrayTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtArrayTest.kt
@@ -32,13 +32,13 @@ class CrdtArrayTest {
         assertEquals(crdtElements.size, target.length)
 
         target.remove(timeTickets[1], timeTickets[2])
-        assertEquals("ACDEFG", target.getStructureAsString())
+        assertEquals("ACDEFG", target.toTestString())
         target.remove(timeTickets[2], timeTickets[3])
-        assertEquals("ADEFG", target.getStructureAsString())
+        assertEquals("ADEFG", target.toTestString())
         target.remove(timeTickets[3], timeTickets[4])
-        assertEquals("AEFG", target.getStructureAsString())
+        assertEquals("AEFG", target.toTestString())
         target.remove(timeTickets[6], timeTickets[5])
-        assertEquals("AEFG", target.getStructureAsString())
+        assertEquals("AEFG", target.toTestString())
 
         assertEquals(crdtElements.size - 3, target.length)
     }
@@ -52,13 +52,13 @@ class CrdtArrayTest {
 
         target.delete(crdtElements[0])
         assertEquals(crdtElements.size - 1, target.length)
-        assertEquals("BCDEFG", target.getStructureAsString())
+        assertEquals("BCDEFG", target.toTestString())
         target.delete(crdtElements[1])
         assertEquals(crdtElements.size - 2, target.length)
-        assertEquals("CDEFG", target.getStructureAsString())
+        assertEquals("CDEFG", target.toTestString())
         target.delete(crdtElements[2])
         assertEquals(crdtElements.size - 3, target.length)
-        assertEquals("DEFG", target.getStructureAsString())
+        assertEquals("DEFG", target.toTestString())
     }
 
     @Test
@@ -69,15 +69,15 @@ class CrdtArrayTest {
         assertEquals(crdtElements.size, target.length)
 
         target.removeByIndex(0, timeTickets[2])
-        assertEquals("BCDEFG", target.getStructureAsString())
+        assertEquals("BCDEFG", target.toTestString())
         target.removeByIndex(0, timeTickets[3])
-        assertEquals("CDEFG", target.getStructureAsString())
+        assertEquals("CDEFG", target.toTestString())
         target.removeByIndex(0, timeTickets[4])
-        assertEquals("DEFG", target.getStructureAsString())
+        assertEquals("DEFG", target.toTestString())
         target.removeByIndex(0, timeTickets[5])
-        assertEquals("EFG", target.getStructureAsString())
+        assertEquals("EFG", target.toTestString())
         target.removeByIndex(crdtElements.size, timeTickets[6])
-        assertEquals("EFG", target.getStructureAsString())
+        assertEquals("EFG", target.toTestString())
 
         assertEquals(crdtElements.size - 4, target.length)
     }
@@ -90,7 +90,7 @@ class CrdtArrayTest {
         assertEquals(crdtElements.size, target.length)
 
         target.insertAfter(timeTickets[0], CrdtPrimitive(1, createTimeTicket()))
-        assertEquals("AHBCDEFG", target.getStructureAsString())
+        assertEquals("AHBCDEFG", target.toTestString())
     }
 
     @Test
@@ -101,7 +101,7 @@ class CrdtArrayTest {
         assertEquals(crdtElements.size, target.length)
 
         target.moveAfter(timeTickets[5], timeTickets[4], createTimeTicket())
-        assertEquals("ABCDFEG", target.getStructureAsString())
+        assertEquals("ABCDFEG", target.toTestString())
         assertEquals(crdtElements.size, target.length)
     }
 
@@ -113,13 +113,13 @@ class CrdtArrayTest {
         val sampleTarget2 = createSampleCrdtArray().apply {
             insertAfter(last.createdAt, crdtElements[0])
         }
-        assertEquals(sampleTarget1.getStructureAsString(), sampleTarget2.getStructureAsString())
+        assertEquals(sampleTarget1.toTestString(), sampleTarget2.toTestString())
 
         sampleTarget1.insertAfter(timeTickets[0], crdtElements[1])
         sampleTarget1.insertAfter(timeTickets[0], crdtElements[2])
         sampleTarget2.insertAfter(timeTickets[0], crdtElements[2])
         sampleTarget2.insertAfter(timeTickets[0], crdtElements[1])
-        assertEquals(sampleTarget1.getStructureAsString(), sampleTarget2.getStructureAsString())
+        assertEquals(sampleTarget1.toTestString(), sampleTarget2.toTestString())
     }
 
     @Test
@@ -132,13 +132,13 @@ class CrdtArrayTest {
                 .map { CrdtPrimitive(1, it) }
                 .forEach { insertAfter(last.createdAt, it) }
         }
-        assertEquals(sampleTarget1.getStructureAsString(), sampleTarget2.getStructureAsString())
+        assertEquals(sampleTarget1.toTestString(), sampleTarget2.toTestString())
 
         sampleTarget1.moveAfter(timeTickets[3], timeTickets[1], timeTickets[1])
         sampleTarget1.moveAfter(timeTickets[3], timeTickets[2], timeTickets[2])
         sampleTarget2.moveAfter(timeTickets[3], timeTickets[2], timeTickets[2])
         sampleTarget2.moveAfter(timeTickets[3], timeTickets[1], timeTickets[1])
-        assertEquals(sampleTarget1.getStructureAsString(), sampleTarget2.getStructureAsString())
+        assertEquals(sampleTarget1.toTestString(), sampleTarget2.toTestString())
     }
 
     @Test
@@ -185,7 +185,7 @@ class CrdtArrayTest {
         return CrdtArray(TimeTicket.InitialTimeTicket)
     }
 
-    private fun CrdtArray.getStructureAsString() = buildString {
-        this@getStructureAsString.forEach { append(it.createdAt.actorID.value) }
+    private fun CrdtArray.toTestString() = buildString {
+        this@toTestString.forEach { append(it.createdAt.actorID.value) }
     }
 }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtObjectTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtObjectTest.kt
@@ -31,15 +31,15 @@ class CrdtObjectTest {
         assertEquals(0, target.keys.size)
 
         target["A"] = CrdtPrimitive(0, timeTickets[0])
-        assertEquals("A0", getStructureAsString())
+        assertEquals("A0", getTestString())
         target["B"] = CrdtPrimitive(1, timeTickets[1])
-        assertEquals("A0B1", getStructureAsString())
+        assertEquals("A0B1", getTestString())
         target["C"] = CrdtPrimitive(2, timeTickets[2])
-        assertEquals("A0B1C2", getStructureAsString())
+        assertEquals("A0B1C2", getTestString())
         target["D"] = CrdtPrimitive(3, timeTickets[3])
-        assertEquals("A0B1C2D3", getStructureAsString())
+        assertEquals("A0B1C2D3", getTestString())
         target["E"] = CrdtPrimitive(4, timeTickets[4])
-        assertEquals("A0B1C2D3E4", getStructureAsString())
+        assertEquals("A0B1C2D3E4", getTestString())
     }
 
     @Test
@@ -59,9 +59,9 @@ class CrdtObjectTest {
         assertEquals(5, target.memberNodes.size)
 
         target.delete(crdtElements[0])
-        assertEquals("B1C2D3E4", getStructureAsString())
+        assertEquals("B1C2D3E4", getTestString())
         target.delete(crdtElements[3])
-        assertEquals("B1C2E4", getStructureAsString())
+        assertEquals("B1C2E4", getTestString())
         target.delete(CrdtPrimitive(100, TimeTicket.InitialTimeTicket))
     }
 
@@ -71,9 +71,9 @@ class CrdtObjectTest {
         assertEquals(5, target.memberNodes.size)
 
         target.remove(timeTickets[0], timeTickets[1])
-        assertEquals("B1C2D3E4", getStructureAsString())
+        assertEquals("B1C2D3E4", getTestString())
         target.remove(timeTickets[2], timeTickets[1])
-        assertEquals("B1C2D3E4", getStructureAsString())
+        assertEquals("B1C2D3E4", getTestString())
         assertThrows(NoSuchElementException::class.java) {
             target.remove(TimeTicket.InitialTimeTicket, TimeTicket.InitialTimeTicket)
         }
@@ -85,9 +85,9 @@ class CrdtObjectTest {
         assertEquals(5, target.memberNodes.size)
 
         target.removeByKey(actorIDs[0], timeTickets[1])
-        assertEquals("B1C2D3E4", getStructureAsString())
+        assertEquals("B1C2D3E4", getTestString())
         target.removeByKey(actorIDs[2], timeTickets[1])
-        assertEquals("B1C2D3E4", getStructureAsString())
+        assertEquals("B1C2D3E4", getTestString())
         assertThrows(NoSuchElementException::class.java) {
             target.removeByKey("F", TimeTicket.InitialTimeTicket)
         }
@@ -125,7 +125,7 @@ class CrdtObjectTest {
         }
     }
 
-    private fun getStructureAsString() = buildString {
+    private fun getTestString() = buildString {
         target.forEach { append(it.first + (it.second as CrdtPrimitive).value) }
     }
 }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTextTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTextTest.kt
@@ -5,7 +5,6 @@ import dev.yorkie.document.time.TimeTicket
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 class CrdtTextTest {
     private lateinit var target: CrdtText
@@ -18,7 +17,7 @@ class CrdtTextTest {
     @Test
     fun `should handle edit operations with attributes`() {
         target.edit(
-            target.createRange(0, 0),
+            target.indexRangeToPosRange(0, 0),
             "ABCD",
             TimeTicket.InitialTimeTicket,
             mapOf("b" to "1"),
@@ -28,7 +27,7 @@ class CrdtTextTest {
             target.toJson(),
         )
 
-        target.edit(target.createRange(3, 3), "\n", TimeTicket.InitialTimeTicket)
+        target.edit(target.indexRangeToPosRange(3, 3), "\n", TimeTicket.InitialTimeTicket)
         assertEquals(
             """[{"attrs":{"b":"1"},"val":"ABC"},{"val":"\n"},""" +
                 """{"attrs":{"b":"1"},"val":"D"}]""",
@@ -38,10 +37,10 @@ class CrdtTextTest {
 
     @Test
     fun `should handle edit operations without attributes`() {
-        target.edit(target.createRange(0, 0), "A", TimeTicket.InitialTimeTicket)
+        target.edit(target.indexRangeToPosRange(0, 0), "A", TimeTicket.InitialTimeTicket)
         assertEquals("""[{"val":"A"}]""", target.toJson())
 
-        target.edit(target.createRange(0, 0), "B", TimeTicket.InitialTimeTicket)
+        target.edit(target.indexRangeToPosRange(0, 0), "B", TimeTicket.InitialTimeTicket)
         assertEquals(
             """[{"val":"A"},{"val":"B"}]""",
             target.toJson(),
@@ -50,10 +49,9 @@ class CrdtTextTest {
 
     @Test
     fun `should handle select operations`() {
-        target.edit(target.createRange(0, 0), "ABCD", TimeTicket.InitialTimeTicket)
+        target.edit(target.indexRangeToPosRange(0, 0), "ABCD", TimeTicket.InitialTimeTicket)
         val executedAt = TimeTicket(1L, 1u, ActorID.INITIAL_ACTOR_ID)
-        assertNull(target.select(target.createRange(1, 3), TimeTicket.InitialTimeTicket))
-        val textChange = target.select(target.createRange(2, 4), executedAt)
+        val textChange = target.select(target.indexRangeToPosRange(2, 4), executedAt)
         assertEquals(TextChangeType.Selection, textChange?.type)
         assertEquals(2 to 4, textChange?.from to textChange?.to)
     }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTreeTest.kt
@@ -236,10 +236,10 @@ class CrdtTreeTest {
         toIndex = target.toIndex(to)
         assertEquals(5 to 6, fromIndex to toIndex)
 
-        var range = target.createRange(0, 5)
+        var range = target.indexRangeToPosRange(0 to 5)
         assertEquals(0 to 5, target.rangeToIndex(range))
 
-        range = target.createRange(5, 7)
+        range = target.indexRangeToPosRange(5 to 7)
         assertEquals(5 to 7, target.rangeToIndex(range))
     }
 

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/ElementRhtTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/ElementRhtTest.kt
@@ -29,7 +29,7 @@ class ElementRhtTest {
         assertEquals(
             "test1: value1\ntest2: value2\ntest3: value3\ntest4: value4\n" +
                 "test5: value5\n",
-            elementRht.getStructureAsString(),
+            elementRht.toTestString(),
         )
 
         val nullObject = elementRht.set(
@@ -214,8 +214,8 @@ class ElementRhtTest {
         return TimeTicket(lamport, delimiter.toUInt(), ActorID(actorID))
     }
 
-    private fun ElementRht<CrdtPrimitive>.getStructureAsString() = buildString {
-        this@getStructureAsString.forEach {
+    private fun ElementRht<CrdtPrimitive>.toTestString() = buildString {
+        this@toTestString.forEach {
             append("${it.strKey}: ${it.value.value}").appendLine()
         }
     }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/RgaTreeListTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/RgaTreeListTest.kt
@@ -30,19 +30,19 @@ class RgaTreeListTest {
         assertEquals(0, target.length)
 
         target.insert(crdtElements[0])
-        assertEquals("A1", target.getStructureAsString())
+        assertEquals("A1", target.toTestString())
         target.insert(crdtElements[1])
-        assertEquals("A1B1", target.getStructureAsString())
+        assertEquals("A1B1", target.toTestString())
         target.insert(crdtElements[2])
-        assertEquals("A1B1C1", target.getStructureAsString())
+        assertEquals("A1B1C1", target.toTestString())
         target.insert(crdtElements[3])
-        assertEquals("A1B1C1D1", target.getStructureAsString())
+        assertEquals("A1B1C1D1", target.toTestString())
         target.insert(crdtElements[4])
-        assertEquals("A1B1C1D1E1", target.getStructureAsString())
+        assertEquals("A1B1C1D1E1", target.toTestString())
         target.insert(crdtElements[5])
-        assertEquals("A1B1C1D1E1F1", target.getStructureAsString())
+        assertEquals("A1B1C1D1E1F1", target.toTestString())
         target.insert(crdtElements[6])
-        assertEquals("A1B1C1D1E1F1G1", target.getStructureAsString())
+        assertEquals("A1B1C1D1E1F1G1", target.toTestString())
 
         assertEquals(crdtElements.size, target.length)
     }
@@ -58,13 +58,13 @@ class RgaTreeListTest {
         crdtElements.forEach(target::insert)
 
         target.remove(timeTickets[1], timeTickets[2])
-        assertEquals("A1B0C1D1E1F1G1", target.getStructureAsString())
+        assertEquals("A1B0C1D1E1F1G1", target.toTestString())
         target.remove(timeTickets[2], timeTickets[3])
-        assertEquals("A1B0C0D1E1F1G1", target.getStructureAsString())
+        assertEquals("A1B0C0D1E1F1G1", target.toTestString())
         target.remove(timeTickets[3], timeTickets[4])
-        assertEquals("A1B0C0D0E1F1G1", target.getStructureAsString())
+        assertEquals("A1B0C0D0E1F1G1", target.toTestString())
         target.remove(timeTickets[6], timeTickets[5])
-        assertEquals("A1B0C0D0E1F1G1", target.getStructureAsString())
+        assertEquals("A1B0C0D0E1F1G1", target.toTestString())
 
         assertEquals(crdtElements.size - 3, target.length)
     }
@@ -76,15 +76,15 @@ class RgaTreeListTest {
         crdtElements.forEach(target::insert)
 
         target.removeByIndex(1, timeTickets[2])
-        assertEquals("A1B0C1D1E1F1G1", target.getStructureAsString())
+        assertEquals("A1B0C1D1E1F1G1", target.toTestString())
         target.removeByIndex(1, timeTickets[3])
-        assertEquals("A1B0C0D1E1F1G1", target.getStructureAsString())
+        assertEquals("A1B0C0D1E1F1G1", target.toTestString())
         target.removeByIndex(1, timeTickets[4])
-        assertEquals("A1B0C0D0E1F1G1", target.getStructureAsString())
+        assertEquals("A1B0C0D0E1F1G1", target.toTestString())
         target.removeByIndex(1, timeTickets[5])
-        assertEquals("A1B0C0D0E0F1G1", target.getStructureAsString())
+        assertEquals("A1B0C0D0E0F1G1", target.toTestString())
         target.removeByIndex(crdtElements.size, timeTickets[6])
-        assertEquals("A1B0C0D0E0F1G1", target.getStructureAsString())
+        assertEquals("A1B0C0D0E0F1G1", target.toTestString())
 
         assertEquals(crdtElements.size - 4, target.length)
     }
@@ -102,13 +102,13 @@ class RgaTreeListTest {
 
         target.delete(crdtElements[0])
         assertEquals(crdtElements.size - 1, target.length)
-        assertEquals("B1C1D1E1F1G1", target.getStructureAsString())
+        assertEquals("B1C1D1E1F1G1", target.toTestString())
         target.delete(crdtElements[1])
         assertEquals(crdtElements.size - 2, target.length)
-        assertEquals("C1D1E1F1G1", target.getStructureAsString())
+        assertEquals("C1D1E1F1G1", target.toTestString())
         target.delete(crdtElements[2])
         assertEquals(crdtElements.size - 3, target.length)
-        assertEquals("D1E1F1G1", target.getStructureAsString())
+        assertEquals("D1E1F1G1", target.toTestString())
     }
 
     @Test
@@ -119,7 +119,7 @@ class RgaTreeListTest {
         assertEquals(crdtElements.size, target.length)
 
         target.insertAfter(timeTickets[0], CrdtPrimitive(1, createTimeTicket()))
-        assertEquals("A1H1B1C1D1E1F1G1", target.getStructureAsString())
+        assertEquals("A1H1B1C1D1E1F1G1", target.toTestString())
     }
 
     @Test
@@ -131,7 +131,7 @@ class RgaTreeListTest {
         crdtElements.forEach(target::insert)
 
         target.moveAfter(timeTickets[5], timeTickets[4], createTimeTicket())
-        assertEquals("A1B1C1D1F1E1G1", target.getStructureAsString())
+        assertEquals("A1B1C1D1F1E1G1", target.toTestString())
         assertEquals(crdtElements.size, target.length)
     }
 
@@ -139,13 +139,13 @@ class RgaTreeListTest {
     fun `should handle concurrent insertAfter operations`() {
         val sampleTarget1 = RgaTreeList().apply { insert(crdtElements[0]) }
         val sampleTarget2 = RgaTreeList().apply { insert(crdtElements[0]) }
-        assertEquals(sampleTarget1.getStructureAsString(), sampleTarget2.getStructureAsString())
+        assertEquals(sampleTarget1.toTestString(), sampleTarget2.toTestString())
 
         sampleTarget1.insertAfter(timeTickets[0], crdtElements[1])
         sampleTarget1.insertAfter(timeTickets[0], crdtElements[2])
         sampleTarget2.insertAfter(timeTickets[0], crdtElements[2])
         sampleTarget2.insertAfter(timeTickets[0], crdtElements[1])
-        assertEquals(sampleTarget1.getStructureAsString(), sampleTarget2.getStructureAsString())
+        assertEquals(sampleTarget1.toTestString(), sampleTarget2.toTestString())
     }
 
     @Test
@@ -154,13 +154,13 @@ class RgaTreeListTest {
         val sampleTarget2 = RgaTreeList().apply {
             timeTickets.map { CrdtPrimitive(1, it) }.forEach(this::insert)
         }
-        assertEquals(sampleTarget1.getStructureAsString(), sampleTarget2.getStructureAsString())
+        assertEquals(sampleTarget1.toTestString(), sampleTarget2.toTestString())
 
         sampleTarget1.moveAfter(timeTickets[3], timeTickets[1], timeTickets[1])
         sampleTarget1.moveAfter(timeTickets[3], timeTickets[2], timeTickets[2])
         sampleTarget2.moveAfter(timeTickets[3], timeTickets[2], timeTickets[2])
         sampleTarget2.moveAfter(timeTickets[3], timeTickets[1], timeTickets[1])
-        assertEquals(sampleTarget1.getStructureAsString(), sampleTarget2.getStructureAsString())
+        assertEquals(sampleTarget1.toTestString(), sampleTarget2.toTestString())
     }
 
     @Test
@@ -176,8 +176,8 @@ class RgaTreeListTest {
         return TimeTicket(crdtElements.size.toLong(), TimeTicket.INITIAL_DELIMITER, ActorID("H"))
     }
 
-    private fun RgaTreeList.getStructureAsString() = buildString {
-        this@getStructureAsString.forEach {
+    private fun RgaTreeList.toTestString() = buildString {
+        this@toTestString.forEach {
             append("${it.createdAt.actorID.value}${if (it.isRemoved) 0 else 1}")
         }
     }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/RgaTreeSplitTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/RgaTreeSplitTest.kt
@@ -15,9 +15,9 @@ class RgaTreeSplitTest {
 
     @Test
     fun `should handle edit operations with case1`() {
-        var range = RgaTreeSplitNodeRange(target.findNodePos(0), target.findNodePos(0))
+        var range = RgaTreeSplitPosRange(target.indexToPos(0), target.indexToPos(0))
         target.edit(range, TimeTicket.InitialTimeTicket, TextValue("ABCD"))
-        range = RgaTreeSplitNodeRange(target.findNodePos(1), target.findNodePos(3))
+        range = RgaTreeSplitPosRange(target.indexToPos(1), target.indexToPos(3))
         target.edit(range, TimeTicket.InitialTimeTicket, TextValue("12"))
 
         assertEquals("A12D", target.toString())
@@ -25,9 +25,9 @@ class RgaTreeSplitTest {
 
     @Test
     fun `should handle edit operations with case2`() {
-        var range = RgaTreeSplitNodeRange(target.findNodePos(0), target.findNodePos(0))
+        var range = RgaTreeSplitPosRange(target.indexToPos(0), target.indexToPos(0))
         target.edit(range, TimeTicket.InitialTimeTicket, TextValue("ABCD"))
-        range = RgaTreeSplitNodeRange(target.findNodePos(3), target.findNodePos(3))
+        range = RgaTreeSplitPosRange(target.indexToPos(3), target.indexToPos(3))
         target.edit(range, TimeTicket.InitialTimeTicket, TextValue("\n"))
 
         assertEquals("ABC\nD", target.toString())

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/RhtTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/RhtTest.kt
@@ -18,10 +18,10 @@ class RhtTest {
 
     @Test
     fun `should handle set operations`() {
-        assertTrue(target.getStructureAsString().isEmpty())
+        assertTrue(target.toTestString().isEmpty())
 
         target.set(TEST_KEY, TEST_VALUE, TimeTicket.InitialTimeTicket)
-        assertEquals("$TEST_KEY:$TEST_VALUE", target.getStructureAsString())
+        assertEquals("$TEST_KEY:$TEST_VALUE", target.toTestString())
     }
 
     @Test
@@ -51,7 +51,7 @@ class RhtTest {
         }
     }
 
-    private fun Rht.getStructureAsString(): String {
+    private fun Rht.toTestString(): String {
         return nodeKeyValueMap.entries.joinToString("") { "${it.key}:${it.value}" }
     }
 

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTextTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTextTest.kt
@@ -12,6 +12,7 @@ import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class JsonTextTest {
@@ -122,10 +123,10 @@ class JsonTextTest {
     }
 
     @Test
-    fun `should return false when index range is invalid with edit`() {
-        assertTrue(target.edit(0, 0, "ABC"))
-        assertFalse(target.edit(5, 0, "D"))
-        assertFalse(target.edit(5, 7, "E"))
+    fun `should return null when index range is invalid with edit`() {
+        target.edit(0, 0, "ABC")
+        assertNull(target.edit(5, 0, "D"))
+        assertNull(target.edit(5, 7, "E"))
     }
 
     @Test

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
@@ -428,6 +428,38 @@ class JsonTreeTest {
         )
     }
 
+    @Test
+    fun `should find pos range from index range and vice versa`() = runTest {
+        val document = Document(Document.Key(""))
+        fun JsonObject.tree() = getAs<JsonTree>("t")
+
+        document.updateAsync {
+            it.setNewTree(
+                "t",
+                element("root") {
+                    element("p") {
+                        element("b") {
+                            element("i") {
+                                text { "ab" }
+                            }
+                        }
+                    }
+                }
+            )
+        }.await()
+        assertEquals(
+            """<root><p><b><i>ab</i></b></p></root>""",
+            document.getRoot().tree().toXml(),
+        )
+
+        val tree = document.getRoot().tree()
+        var posRange = tree.indexRangeToPosRange(0 to 5)
+        assertEquals(0 to 5, tree.posRangeToIndexRange(posRange))
+
+        posRange = tree.indexRangeToPosRange(5 to 7)
+        assertEquals(5 to 7, tree.posRangeToIndexRange(posRange))
+    }
+
     companion object {
         private val DummyContext = ChangeContext(
             ChangeID.InitialChangeID,

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
@@ -444,7 +444,7 @@ class JsonTreeTest {
                             }
                         }
                     }
-                }
+                },
             )
         }.await()
         assertEquals(

--- a/yorkie/src/test/kotlin/dev/yorkie/util/SplayTreeSetTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/util/SplayTreeSetTest.kt
@@ -19,16 +19,16 @@ class SplayTreeSetTest {
         assertEquals(0, target.length)
 
         target.insert(Node("A2"))
-        assertEquals("[2,2]A2", target.getStructureAsString())
+        assertEquals("[2,2]A2", target.toTestString())
         target.insert(Node("B23"))
-        assertEquals("[2,2]A2[5,3]B23", target.getStructureAsString())
+        assertEquals("[2,2]A2[5,3]B23", target.toTestString())
         target.insert(Node("C234"))
-        assertEquals("[2,2]A2[5,3]B23[9,4]C234", target.getStructureAsString())
+        assertEquals("[2,2]A2[5,3]B23[9,4]C234", target.toTestString())
         target.insert(Node("D2345"))
-        assertEquals("[2,2]A2[5,3]B23[9,4]C234[14,5]D2345", target.getStructureAsString())
+        assertEquals("[2,2]A2[5,3]B23[9,4]C234[14,5]D2345", target.toTestString())
 
         target.splay(Node("B23"))
-        assertEquals("[2,2]A2[14,3]B23[9,4]C234[5,5]D2345", target.getStructureAsString())
+        assertEquals("[2,2]A2[14,3]B23[9,4]C234[5,5]D2345", target.toTestString())
 
         assertEquals(0, target.indexOf(Node("A2")))
         assertEquals(2, target.indexOf(Node("B23")))
@@ -42,17 +42,17 @@ class SplayTreeSetTest {
     @Test
     fun `should conform to specs when deletions occur`() {
         target.insert(Node("H"))
-        assertEquals("[1,1]H", target.getStructureAsString())
+        assertEquals("[1,1]H", target.toTestString())
         target.insert(Node("E"))
-        assertEquals("[1,1]H[2,1]E", target.getStructureAsString())
+        assertEquals("[1,1]H[2,1]E", target.toTestString())
         target.insert(Node("LL"))
-        assertEquals("[1,1]H[2,1]E[4,2]LL", target.getStructureAsString())
+        assertEquals("[1,1]H[2,1]E[4,2]LL", target.toTestString())
         target.insert(Node("O"))
-        assertEquals("[1,1]H[2,1]E[4,2]LL[5,1]O", target.getStructureAsString())
+        assertEquals("[1,1]H[2,1]E[4,2]LL[5,1]O", target.toTestString())
 
         target.valueToNodes[Node("E")]?.value?.isRemoved = true
         target.delete(Node("E"))
-        assertEquals("[4,1]H[3,2]LL[1,1]O", target.getStructureAsString())
+        assertEquals("[4,1]H[3,2]LL[1,1]O", target.toTestString())
 
         assertEquals(target.indexOf(Node("H")), 0)
         assertEquals(target.indexOf(Node("EE")), -1)
@@ -117,7 +117,7 @@ class SplayTreeSetTest {
         )
     }
 
-    private fun <V> SplayTreeSet<V>.getStructureAsString(): String {
+    private fun <V> SplayTreeSet<V>.toTestString(): String {
         val nodes = traverseInorder(root)
         return nodes.joinToString("") {
             "[${it.weight},${it.length}]${it.value}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- Cleaned up test-related terminology by renaming `getStructureAsString()` to `toTestString()`.
- Introduced `JsonSerializableStruct`
  - `TimeTicket` has a JSON serialization issue due to its `lamport` property being of type `Long`, which is not directly supported in JSON serialization. It can be problematic when `CrdtTreePos` and `RgaTreeSplitPos`, which have a `createdAt` property, need be serialized into JSON strings and passed through `Presence` between platforms for selection handling.
  - To properly serialize `TimeTicket`, its `lamport` type should be `String`, so I added `TimeTicketStruct` and other `XXStruct` data types based on the JS-SDK implementation. The postfix `Struct` is used to explicitly indicate that these classes are exclusively designed for JSON serialization.
#### Any background context you want to provide?
This PR only includes works released in v0.4.4.

#### What are the relevant tickets?
- https://github.com/yorkie-team/yorkie-js-sdk/pull/561
- https://github.com/yorkie-team/yorkie-js-sdk/pull/562

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
