### PR TITLE
Add rootTreeNode for JsonTree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,7 @@ jobs:
       - run: chmod +x gradlew
       - uses: gradle/gradle-build-action@v2
       - name: Setup Docker on macOS
-        uses: 7hong13/setup-docker-macos-action@fix_formula_paths
-        id: docker
+        uses: douglascamata/setup-docker-macos-action@fix-python-dep
       - run: docker-compose -f docker/docker-compose-ci.yml up --build -d
       - uses: actions/cache@v3
         id: avd-cache

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - yorkie
   yorkie:
-    image: 'yorkieteam/yorkie:0.4.6'
+    image: 'yorkieteam/yorkie:0.4.7'
     container_name: 'yorkie'
     command: [
       'server',

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
   yorkie:
-    image: 'yorkieteam/yorkie:0.4.6'
+    image: 'yorkieteam/yorkie:0.4.7'
     container_name: 'yorkie'
     command: [
       'server',

--- a/examples/texteditor/src/main/java/com/example/texteditor/EditorViewModel.kt
+++ b/examples/texteditor/src/main/java/com/example/texteditor/EditorViewModel.kt
@@ -56,18 +56,18 @@ class EditorViewModel(private val client: Client) : ViewModel(), YorkieEditText.
             if (client.activateAsync().await() && client.attachAsync(document).await()) {
                 client.syncAsync().await()
             }
+        }
 
-            viewModelScope.launch {
-                document.events.collect { event ->
-                    when (event) {
-                        is Document.Event.Snapshot -> syncText()
+        viewModelScope.launch {
+            document.events.collect { event ->
+                when (event) {
+                    is Document.Event.Snapshot -> syncText()
 
-                        is Document.Event.RemoteChange -> emitEditOpInfos(event.changeInfo)
+                    is Document.Event.RemoteChange -> emitEditOpInfos(event.changeInfo)
 
-                        is PresenceChange.Others.PresenceChanged -> event.changed.emitSelection()
+                    is PresenceChange.Others.PresenceChanged -> event.changed.emitSelection()
 
-                        else -> {}
-                    }
+                    else -> {}
                 }
             }
         }

--- a/examples/texteditor/src/main/java/com/example/texteditor/EditorViewModel.kt
+++ b/examples/texteditor/src/main/java/com/example/texteditor/EditorViewModel.kt
@@ -30,16 +30,18 @@ class EditorViewModel(private val client: Client) : ViewModel(), YorkieEditText.
     private val _content = MutableSharedFlow<String>()
     val content = _content.asSharedFlow()
 
-    private val _textOperationInfos =
-        MutableSharedFlow<Pair<ActorID, OperationInfo.TextOperationInfo>>()
-    val textOpInfos = _textOperationInfos.asSharedFlow()
+    private val _editOpInfos = MutableSharedFlow<OperationInfo.EditOpInfo>()
+    val editOpInfos = _editOpInfos.asSharedFlow()
+
+    private val _selections = MutableSharedFlow<Selection>()
+    val selections = _selections.asSharedFlow()
 
     val removedPeers = document.events.filterIsInstance<PresenceChange.Others.Unwatched>()
-        .map { it.unwatched.actorID }
+        .map { it.changed.actorID }
 
-    private val _peerSelectionInfos = mutableMapOf<ActorID, PeerSelectionInfo>()
-    val peerSelectionInfos: Map<ActorID, PeerSelectionInfo>
-        get() = _peerSelectionInfos
+    private val _selectionColors = mutableMapOf<ActorID, Int>()
+    val selectionColors: Map<ActorID, Int>
+        get() = _selectionColors
 
     private val gson = Gson()
 
@@ -54,39 +56,21 @@ class EditorViewModel(private val client: Client) : ViewModel(), YorkieEditText.
             if (client.activateAsync().await() && client.attachAsync(document).await()) {
                 client.syncAsync().await()
             }
-        }
 
-        viewModelScope.launch {
-            document.events.collect { event ->
-                when (event) {
-                    is Document.Event.Snapshot -> syncText()
+            viewModelScope.launch {
+                document.events.collect { event ->
+                    when (event) {
+                        is Document.Event.Snapshot -> syncText()
 
-                    is Document.Event.RemoteChange -> emitEditOpInfos(event.changeInfo)
+                        is Document.Event.RemoteChange -> emitEditOpInfos(event.changeInfo)
 
-                    is PresenceChange.Others.PresenceChanged -> event.changed.emitSelectOpInfo()
+                        is PresenceChange.Others.PresenceChanged -> event.changed.emitSelection()
 
-                    else -> {}
+                        else -> {}
+                    }
                 }
             }
         }
-    }
-
-    private suspend fun emitEditOpInfos(changeInfo: Document.Event.ChangeInfo) {
-        changeInfo.operations.filterIsInstance<OperationInfo.EditOpInfo>()
-            .forEach { opInfo ->
-                _textOperationInfos.emit(changeInfo.actorID to opInfo)
-            }
-    }
-
-    private suspend fun PresenceInfo.emitSelectOpInfo() {
-        val jsonArray = JSONArray(presence["selection"] ?: return)
-        val fromPos =
-            gson.fromJson(jsonArray.getString(0), TextPosStructure::class.java) ?: return
-        val toPos =
-            gson.fromJson(jsonArray.getString(1), TextPosStructure::class.java) ?: return
-        val (from, to) = document.getRoot().getAs<JsonText>(TEXT_KEY)
-            .posRangeToIndexRange(fromPos to toPos)
-        _textOperationInfos.emit(actorID to OperationInfo.SelectOpInfo(from, to))
     }
 
     fun syncText() {
@@ -94,6 +78,22 @@ class EditorViewModel(private val client: Client) : ViewModel(), YorkieEditText.
             val content = document.getRoot().getAsOrNull<JsonText>(TEXT_KEY)
             _content.emit(content?.toString().orEmpty())
         }
+    }
+
+    private suspend fun emitEditOpInfos(changeInfo: Document.Event.ChangeInfo) {
+        changeInfo.operations.filterIsInstance<OperationInfo.EditOpInfo>()
+            .forEach { _editOpInfos.emit(it) }
+    }
+
+    private suspend fun PresenceInfo.emitSelection() {
+        val jsonArray = JSONArray(presence["selection"] ?: return)
+        val fromPos =
+            gson.fromJson(jsonArray.getString(0), TextPosStructure::class.java) ?: return
+        val toPos =
+            gson.fromJson(jsonArray.getString(1), TextPosStructure::class.java) ?: return
+        val (from, to) = document.getRoot().getAs<JsonText>(TEXT_KEY)
+            .posRangeToIndexRange(fromPos to toPos)
+        _selections.emit(Selection(actorID, from, to))
     }
 
     override fun handleEditEvent(from: Int, to: Int, content: CharSequence) {
@@ -119,21 +119,13 @@ class EditorViewModel(private val client: Client) : ViewModel(), YorkieEditText.
 
     @ColorInt
     fun getPeerSelectionColor(actorID: ActorID): Int {
-        return _peerSelectionInfos[actorID]?.color ?: run {
-            val newColor =
-                Color.argb(51, Random.nextInt(256), Random.nextInt(256), Random.nextInt(256))
-            _peerSelectionInfos[actorID] = PeerSelectionInfo(newColor)
-            newColor
+        return _selectionColors.getOrPut(actorID) {
+            Color.argb(51, Random.nextInt(256), Random.nextInt(256), Random.nextInt(256))
         }
     }
 
-    fun updatePeerPrevSelection(actorID: ActorID, prevSelection: Pair<Int, Int>?) {
-        val peerSelectionInfo = _peerSelectionInfos[actorID] ?: return
-        _peerSelectionInfos[actorID] = peerSelectionInfo.copy(prevSelection = prevSelection)
-    }
-
-    fun removeDetachedPeerSelectionInfo(actorID: ActorID) {
-        _peerSelectionInfos.remove(actorID)
+    fun removeUnwatchedPeerSelectionInfo(actorID: ActorID) {
+        _selectionColors.remove(actorID)
     }
 
     override fun handleHangulCompositionStart() {
@@ -152,14 +144,11 @@ class EditorViewModel(private val client: Client) : ViewModel(), YorkieEditText.
         super.onCleared()
     }
 
-    data class PeerSelectionInfo(
-        @ColorInt val color: Int,
-        val prevSelection: Pair<Int, Int>? = null,
-    )
+    data class Selection(val clientID: ActorID, val from: Int, val to: Int)
 
     companion object {
-        private const val DOCUMENT_KEY = "document-key"
-        private const val TEXT_KEY = "text-key"
+        private const val DOCUMENT_KEY = "codemirror6"
+        private const val TEXT_KEY = "content"
 
         private val TerminationScope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
     }

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -180,7 +180,9 @@ class ClientTest {
             document1.updateAsync { root, _ ->
                 root["version"] = "v1"
             }.await()
-            assertNotEquals(document1.toJson(), document2.toJson())
+            assertJsonContentEquals("""{"version":"v1"}""", document1.toJson())
+            assertJsonContentEquals("""{}""", document2.toJson())
+
             client1.syncAsync().await()
             client2.syncAsync().await()
             assertEquals(document1.toJson(), document2.toJson())
@@ -190,11 +192,13 @@ class ClientTest {
             val collectJob = launch(start = CoroutineStart.UNDISPATCHED) {
                 client2.events.collect(client2Events::add)
             }
+
             client2.resume(document2)
             document1.updateAsync { root, _ ->
                 root["version"] = "v2"
             }.await()
             client1.syncAsync().await()
+
             withTimeout(GENERAL_TIMEOUT) {
                 while (client2Events.size < 2) {
                     delay(50)
@@ -210,6 +214,7 @@ class ClientTest {
                 root["version"] = "v3"
             }.await()
             assertNotEquals(document1.toJson(), document2.toJson())
+
             client1.syncAsync().await()
             client2.syncAsync().await()
             assertEquals(document1.toJson(), document2.toJson())

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -194,6 +194,7 @@ class ClientTest {
             }
 
             client2.resume(document2)
+            delay(30)
             document1.updateAsync { root, _ ->
                 root["version"] = "v2"
             }.await()

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
@@ -31,7 +31,6 @@ import org.junit.runner.RunWith
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 class DocumentTest {
@@ -167,8 +166,10 @@ class DocumentTest {
             client2.syncAsync().await()
             assertEquals(document1.toJson(), document2.toJson())
 
-            assertTrue(client1.removeAsync(document1).await())
-            assertTrue(client2.removeAsync(document2).await())
+            client1.removeAsync(document1).await()
+            if (document2.status == DocumentStatus.Attached) {
+                client2.removeAsync(document2).await()
+            }
             assertEquals(DocumentStatus.Removed, document1.status)
             assertEquals(DocumentStatus.Removed, document2.status)
         }

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/PresenceTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/PresenceTest.kt
@@ -531,6 +531,7 @@ class PresenceTest {
             // from c3, only the watched event is triggered.
             c3.syncAsync().await()
             c1.syncAsync().await()
+            delay(50)
             c3.resume(d3)
 
             withTimeout(GENERAL_TIMEOUT) {
@@ -593,6 +594,7 @@ class PresenceTest {
             // 05-2. c2 resumes the document, c1 receives a watched event from c2.
             c2.syncAsync().await()
             c1.syncAsync().await()
+            delay(50)
             c2.resume(d2)
 
             withTimeout(GENERAL_TIMEOUT) {

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/PresenceTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/PresenceTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.filterNot
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -235,7 +236,6 @@ class PresenceTest {
                     .collect(d1Events::add)
             }
 
-            println("c2 attach")
             c2.attachAsync(d2, mapOf("name" to "b", "cursor" to previousCursor)).await()
             val d2Job = launch(start = CoroutineStart.UNDISPATCHED) {
                 d2.events.filterIsInstance<Document.Event.PresenceChange>()
@@ -243,7 +243,7 @@ class PresenceTest {
                     .collect(d2Events::add)
             }
 
-            withTimeout(GENERAL_TIMEOUT + 1) {
+            withTimeout(GENERAL_TIMEOUT) {
                 while (d1Events.isEmpty()) {
                     delay(50)
                 }
@@ -260,7 +260,7 @@ class PresenceTest {
                 presence.put(mapOf("name" to "X"))
             }.await()
 
-            withTimeout(GENERAL_TIMEOUT + 2) {
+            withTimeout(GENERAL_TIMEOUT) {
                 while (d1Events.size < 2 || d2Events.isEmpty()) {
                     delay(50)
                 }
@@ -372,15 +372,14 @@ class PresenceTest {
             c1.attachAsync(d1, initialPresence = mapOf("name" to "a1", "cursor" to cursor)).await()
 
             val d1CollectJob = launch(start = CoroutineStart.UNDISPATCHED) {
-                d1.events.filterIsInstance<Document.Event.PresenceChange>()
-                    .collect(d1Events::add)
+                d1.events.filterIsInstance<Others>().collect(d1Events::add)
             }
 
             // 01. c2 attaches doc in realtime sync, and c3 attached doc in manual sync.
             c2.attachAsync(d2, initialPresence = mapOf("name" to "b1", "cursor" to cursor)).await()
             c3.attachAsync(d3, mapOf("name" to "c1", "cursor" to cursor), false).await()
 
-            withTimeout(GENERAL_TIMEOUT) {
+            withTimeout(GENERAL_TIMEOUT + 1) {
                 // c2 watched
                 while (d1Events.isEmpty()) {
                     delay(50)
@@ -397,7 +396,7 @@ class PresenceTest {
             // 02. c2 pauses the document (in manual sync), c3 resumes the document (in realtime sync).
             c2.pause(d2)
 
-            withTimeout(GENERAL_TIMEOUT) {
+            withTimeout(GENERAL_TIMEOUT + 2) {
                 // c2 unwatched
                 while (d1Events.size < 2) {
                     delay(50)
@@ -407,7 +406,7 @@ class PresenceTest {
             assertIs<Others.Unwatched>(d1Events.last())
             c3.resume(d3)
 
-            withTimeout(GENERAL_TIMEOUT) {
+            withTimeout(GENERAL_TIMEOUT + 3) {
                 // c3 watched
                 while (d1Events.size < 3) {
                     delay(50)
@@ -415,6 +414,9 @@ class PresenceTest {
             }
 
             assertIs<Others.Watched>(d1Events.last())
+            withTimeout(GENERAL_TIMEOUT) {
+                d3.presences.first { c3ID in d3.presences.value }
+            }
             assertEquals(
                 mapOf(c1ID to d1.presences.value[c1ID], c3ID to d3.presences.value[c3ID]),
                 d1.presences.value.toMap(),
@@ -455,7 +457,7 @@ class PresenceTest {
                 .await()
 
             val d1CollectJob = launch(start = CoroutineStart.UNDISPATCHED) {
-                d1.events.filterIsInstance<Document.Event.PresenceChange>()
+                d1.events.filterIsInstance<Others>()
                     .collect(d1Events::add)
             }
 
@@ -594,7 +596,7 @@ class PresenceTest {
             c2.resume(d2)
 
             withTimeout(GENERAL_TIMEOUT) {
-                // c3 unwatched
+                // c2 watched
                 while (d1Events.size < 7) {
                     delay(50)
                 }

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -295,7 +295,7 @@ public class Client @VisibleForTesting internal constructor(
             DocEventType.DOC_EVENT_TYPE_DOCUMENT_WATCHED -> {
                 // NOTE(chacha912): We added to onlineClients, but we won't trigger watched event
                 // unless we also know their initial presence data at this point.
-                document.onlineClients.value = document.onlineClients.value + publisher
+                document.onlineClients.value += publisher
                 if (publisher in document.allPresences.value) {
                     val presence = document.presences.first { publisher in it }[publisher] ?: return
                     document.publish(
@@ -309,7 +309,7 @@ public class Client @VisibleForTesting internal constructor(
                 // when PresenceChange(clear) is applied before unwatching. In that case,
                 // the 'unwatched' event is triggered while handling the PresenceChange.
                 val presence = document.presences.value[publisher] ?: return
-                document.onlineClients.value = document.onlineClients.value - publisher
+                document.onlineClients.value -= publisher
                 document.publish(PresenceChange.Others.Unwatched(PresenceInfo(publisher, presence)))
             }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -277,10 +277,10 @@ public class Client @VisibleForTesting internal constructor(
         if (response.hasInitialization()) {
             val document = attachments.value[documentKey]?.document ?: return
             val clientIDs = response.initialization.clientIdsList.map { ActorID(it) }
-            document.onlineClients.value = document.onlineClients.value + clientIDs
-            document.publish(
-                PresenceChange.MyPresence.Initialized(document.presences.value.asPresences()),
-            )
+            document.onlineClients.value += clientIDs
+
+            val presences = document.presences.first { it.keys.containsAll(clientIDs) }
+            document.publish(PresenceChange.MyPresence.Initialized(presences.asPresences()))
             return
         }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Presences.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Presences.kt
@@ -33,7 +33,6 @@ public class Presences private constructor(
 
         internal val UninitializedPresences = Presences(
             object : HashMap<ActorID, MutableMap<String, String>>() {
-
                 override fun equals(other: Any?): Boolean = this === other
             },
         )

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -288,7 +288,7 @@ public class Document(public val key: Key) {
                         presences.value[actorID]?.let { presence ->
                             Others.Unwatched(PresenceInfo(actorID, presence))
                         }.also {
-                            onlineClients.value = onlineClients.value - actorID
+                            onlineClients.value -= actorID
                         }
                     }
                 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -422,24 +422,24 @@ public class Document(public val key: Key) {
                 public data class PresenceChanged(public val changed: PresenceInfo) : MyPresence
             }
 
-            public sealed class Others(public open val changed: PresenceInfo) : PresenceChange {
+            public sealed interface Others : PresenceChange {
+                public val changed: PresenceInfo
 
                 /**
                  * Means that the client has established a connection with the server,
                  * enabling real-time synchronization.
                  */
-                public data class Watched(override val changed: PresenceInfo) : Others(changed)
+                public data class Watched(override val changed: PresenceInfo) : Others
 
                 /**
                  * Means that the client has been disconnected.
                  */
-                public data class Unwatched(override val changed: PresenceInfo) : Others(changed)
+                public data class Unwatched(override val changed: PresenceInfo) : Others
 
                 /**
                  * Means that the presences of the client has been updated.
                  */
-                public data class PresenceChanged(override val changed: PresenceInfo) :
-                    Others(changed)
+                public data class PresenceChanged(override val changed: PresenceInfo) : Others
             }
         }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -363,11 +363,11 @@ public class Document(public val key: Key) {
     internal suspend fun publish(event: Event) {
         when (event) {
             is Others.Watched -> {
-                presences.first { event.watched.actorID in it.keys }
+                presences.first { event.changed.actorID in it.keys }
             }
 
             is Others.Unwatched -> {
-                presences.first { event.unwatched.actorID !in it.keys }
+                presences.first { event.changed.actorID !in it.keys }
             }
 
             is MyPresence.Initialized -> {
@@ -380,12 +380,7 @@ public class Document(public val key: Key) {
     }
 
     private fun Change.toChangeInfo(operationInfos: List<OperationInfo>) =
-        Event.ChangeInfo(message.orEmpty(), operationInfos.map { it.updatePath() }, id.actor)
-
-    private fun OperationInfo.updatePath(): OperationInfo {
-        val path = root.createSubPaths(executedAt).joinToString(".")
-        return apply { this.path = path }
-    }
+        Event.ChangeInfo(message.orEmpty(), operationInfos, id.actor)
 
     public fun toJson(): String {
         return root.toJson()
@@ -427,23 +422,24 @@ public class Document(public val key: Key) {
                 public data class PresenceChanged(public val changed: PresenceInfo) : MyPresence
             }
 
-            public sealed interface Others : PresenceChange {
+            public sealed class Others(public open val changed: PresenceInfo) : PresenceChange {
 
                 /**
                  * Means that the client has established a connection with the server,
                  * enabling real-time synchronization.
                  */
-                public data class Watched(public val watched: PresenceInfo) : Others
+                public data class Watched(override val changed: PresenceInfo) : Others(changed)
 
                 /**
                  * Means that the client has been disconnected.
                  */
-                public data class Unwatched(public val unwatched: PresenceInfo) : Others
+                public data class Unwatched(override val changed: PresenceInfo) : Others(changed)
 
                 /**
                  * Means that the presences of the client has been updated.
                  */
-                public data class PresenceChanged(public val changed: PresenceInfo) : Others
+                public data class PresenceChanged(override val changed: PresenceInfo) :
+                    Others(changed)
             }
         }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -30,6 +30,9 @@ internal class CrdtTree(
 
     private val removedNodeMap = mutableMapOf<Pair<TimeTicket, Int>, CrdtTreeNode>()
 
+    val rootTreeNode: TreeNode
+        get() = indexTree.root.toTreeNode()
+
     init {
         indexTree.traverse { node, _ ->
             nodeMapByID[node.id] = node
@@ -142,7 +145,7 @@ internal class CrdtTree(
                 fromPath = toPath(fromParent, fromLeft),
                 toPath = toPath(toParent, toLeft),
                 actorID = executedAt.actorID,
-                value = contents?.map(CrdtTreeNode::toJson),
+                value = contents?.map(CrdtTreeNode::toTreeNode),
             ),
         )
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -58,7 +58,7 @@ internal class CrdtTree(
         // TODO(7hong13): check whether toPath is set correctly
         val changes = listOf(
             TreeChange(
-                type = TreeChangeType.Style.type,
+                type = TreeChangeType.Style,
                 from = toIndex(fromParent, fromLeft),
                 to = toIndex(toParent, toLeft),
                 fromPath = toPath(fromParent, fromLeft),
@@ -139,7 +139,7 @@ internal class CrdtTree(
         // range(from, to) into multiple ranges.
         val changes = listOf(
             TreeChange(
-                type = TreeChangeType.Content.type,
+                type = TreeChangeType.Content,
                 from = toIndex(fromParent, fromLeft),
                 to = toIndex(toParent, toLeft),
                 fromPath = toPath(fromParent, fromLeft),

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTreeExtensions.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTreeExtensions.kt
@@ -16,10 +16,10 @@ internal fun CrdtTreeNode.toXml(): String {
 /**
  * Converts the given node to JSON.
  */
-internal fun CrdtTreeNode.toJson(): TreeNode {
+internal fun CrdtTreeNode.toTreeNode(): TreeNode {
     return if (isText) {
         TreeNode(type, value = value)
     } else {
-        TreeNode(type, children.map { it.toJson() }, attributes = attributes)
+        TreeNode(type, children.map { it.toTreeNode() }, attributes = attributes)
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TreeInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TreeInfo.kt
@@ -1,5 +1,6 @@
 package dev.yorkie.document.crdt
 
+import dev.yorkie.document.json.JsonTree
 import dev.yorkie.document.time.ActorID
 import dev.yorkie.util.IndexTreeNode.Companion.DEFAULT_TEXT_TYPE
 
@@ -7,12 +8,24 @@ import dev.yorkie.util.IndexTreeNode.Companion.DEFAULT_TEXT_TYPE
  * [TreeNode] represents the JSON representation of a node in the tree.
  * It is used to serialize and deserialize the tree.
  */
-public data class TreeNode(
+internal data class TreeNode(
     val type: String,
     val children: List<TreeNode>? = null,
     val value: String? = null,
     val attributes: Map<String, String>? = null,
 ) {
+
+    fun toJsonTreeNode(): JsonTree.TreeNode {
+        return if (type == DEFAULT_TEXT_TYPE) {
+            JsonTree.TextNode(value.orEmpty())
+        } else {
+            JsonTree.ElementNode(
+                type,
+                attributes.orEmpty(),
+                children?.map(TreeNode::toJsonTreeNode).orEmpty(),
+            )
+        }
+    }
 
     override fun toString(): String {
         return if (type == DEFAULT_TEXT_TYPE) {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TreeInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TreeInfo.kt
@@ -54,7 +54,7 @@ internal data class TreeNode(
 
 internal data class TreeChange(
     val actorID: ActorID,
-    val type: String,
+    val type: TreeChangeType,
     val from: Int,
     val to: Int,
     val fromPath: List<Int>,
@@ -63,6 +63,6 @@ internal data class TreeChange(
     val attributes: Map<String, String>? = null,
 )
 
-internal enum class TreeChangeType(val type: String) {
-    Content("content"), Style("style")
+internal enum class TreeChangeType {
+    Content, Style
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonStringifier.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonStringifier.kt
@@ -8,7 +8,6 @@ import dev.yorkie.document.crdt.CrdtObject
 import dev.yorkie.document.crdt.CrdtPrimitive
 import dev.yorkie.document.crdt.CrdtText
 import dev.yorkie.document.crdt.CrdtTree
-import dev.yorkie.document.crdt.toJson
 import java.util.Date
 
 internal object JsonStringifier {
@@ -69,7 +68,7 @@ internal object JsonStringifier {
             }
 
             is CrdtTree -> {
-                buffer.append(root.toJson())
+                buffer.append(rootTreeNode)
             }
         }
     }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonTree.kt
@@ -29,6 +29,9 @@ public class JsonTree internal constructor(
 
     internal val indexTree by target::indexTree
 
+    public val rootTreeNode: TreeNode
+        get() = target.rootTreeNode.toJsonTreeNode()
+
     /**
      * Sets the [attributes] to the elements of the given [path].
      */

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
@@ -32,9 +32,10 @@ internal data class AddOperation(
             parentObject.insertAfter(prevCreatedAt, copiedValue)
             root.registerElement(copiedValue, parentObject)
             listOf(
-                OperationInfo.AddOpInfo(parentObject.subPathOf(effectedCreatedAt).toInt()).apply {
-                    executedAt = parentCreatedAt
-                },
+                OperationInfo.AddOpInfo(
+                    parentObject.subPathOf(effectedCreatedAt).toInt(),
+                    root.createPath(parentCreatedAt),
+                ),
             )
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/EditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/EditOperation.kt
@@ -4,7 +4,6 @@ import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.crdt.CrdtText
 import dev.yorkie.document.crdt.RgaTreeSplitPos
 import dev.yorkie.document.crdt.RgaTreeSplitPosRange
-import dev.yorkie.document.crdt.TextChangeType
 import dev.yorkie.document.crdt.TextWithAttributes
 import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket
@@ -42,18 +41,13 @@ internal data class EditOperation(
             if (fromPos != toPos) {
                 root.registerElementHasRemovedNodes(parentObject)
             }
-            changes.map { (type, _, from, to, content, attributes) ->
-                if (type == TextChangeType.Content) {
-                    OperationInfo.EditOpInfo(
-                        from,
-                        to,
-                        TextWithAttributes(content.orEmpty() to attributes.orEmpty()),
-                    )
-                } else {
-                    OperationInfo.SelectOpInfo(from, to)
-                }.apply {
-                    executedAt = parentCreatedAt
-                }
+            changes.map { (_, _, from, to, content, attributes) ->
+                OperationInfo.EditOpInfo(
+                    from,
+                    to,
+                    TextWithAttributes(content.orEmpty() to attributes.orEmpty()),
+                    root.createPath(parentCreatedAt),
+                )
             }
         } else {
             if (parentObject == null) {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/IncreaseOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/IncreaseOperation.kt
@@ -37,11 +37,7 @@ internal data class IncreaseOperation(
             } else {
                 copiedValue.value as Long
             }
-            listOf(
-                OperationInfo.IncreaseOpInfo(increasedValue).apply {
-                    executedAt = effectedCreatedAt
-                },
-            )
+            listOf(OperationInfo.IncreaseOpInfo(increasedValue, root.createPath(parentCreatedAt)))
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")
             YorkieLogger.e(TAG, "fail to execute, only Counter can execute increase")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
@@ -31,9 +31,11 @@ internal data class MoveOperation(
             parentObject.moveAfter(prevCreatedAt, createdAt, executedAt)
             val index = parentObject.subPathOf(createdAt).toInt()
             listOf(
-                OperationInfo.MoveOpInfo(previousIndex = previousIndex, index = index).apply {
-                    executedAt = parentCreatedAt
-                },
+                OperationInfo.MoveOpInfo(
+                    previousIndex = previousIndex,
+                    index = index,
+                    path = root.createPath(parentCreatedAt),
+                ),
             )
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/OperationInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/OperationInfo.kt
@@ -1,7 +1,6 @@
 package dev.yorkie.document.operation
 
 import dev.yorkie.document.crdt.TextWithAttributes
-import dev.yorkie.document.crdt.TreeNode
 import dev.yorkie.document.json.JsonArray
 import dev.yorkie.document.json.JsonCounter
 import dev.yorkie.document.json.JsonObject
@@ -79,18 +78,12 @@ public sealed class OperationInfo {
         override var path: String = INITIAL_PATH,
     ) : OperationInfo(), TextOperationInfo
 
-    public data class SelectOpInfo(
-        val from: Int,
-        val to: Int,
-        override var path: String = INITIAL_PATH,
-    ) : OperationInfo(), TextOperationInfo
-
     public data class TreeEditOpInfo(
         val from: Int,
         val to: Int,
         val fromPath: List<Int>,
         val toPath: List<Int>,
-        val nodes: List<TreeNode>?,
+        val nodes: List<JsonTree.TreeNode>?,
         override var path: String = INITIAL_PATH,
     ) : OperationInfo(), TreeOperationInfo
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/RemoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/RemoveOperation.kt
@@ -31,11 +31,7 @@ internal data class RemoveOperation(
             val element = parentObject.remove(createdAt, executedAt)
             root.registerRemovedElement(element)
             val index = if (parentObject is CrdtArray) key?.toInt() else null
-            listOf(
-                OperationInfo.RemoveOpInfo(key, index).apply {
-                    executedAt = effectedCreatedAt
-                },
-            )
+            listOf(OperationInfo.RemoveOpInfo(key, index, root.createPath(parentCreatedAt)))
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")
             YorkieLogger.e(TAG, "only object and array can execute remove: $parentObject")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
@@ -32,11 +32,7 @@ internal data class SetOperation(
             val copiedValue = value.deepCopy()
             parentObject[key] = copiedValue
             root.registerElement(copiedValue, parentObject)
-            listOf(
-                OperationInfo.SetOpInfo(key).apply {
-                    executedAt = parentCreatedAt
-                },
-            )
+            listOf(OperationInfo.SetOpInfo(key, root.createPath(parentCreatedAt)))
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")
             YorkieLogger.e(TAG, "fail to execute, only object can execute set")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt
@@ -28,9 +28,8 @@ internal data class StyleOperation(
                     it.from,
                     it.to,
                     it.attributes.orEmpty(),
-                ).apply {
-                    executedAt = parentCreatedAt
-                }
+                    root.createPath(parentCreatedAt),
+                )
             }
         } else {
             parentObject ?: YorkieLogger.e(TAG, "fail to find $parentCreatedAt")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
@@ -4,6 +4,7 @@ import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.crdt.CrdtTree
 import dev.yorkie.document.crdt.CrdtTreeNode
 import dev.yorkie.document.crdt.CrdtTreePos
+import dev.yorkie.document.crdt.TreeNode
 import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.util.YorkieLogger
@@ -49,10 +50,9 @@ internal data class TreeEditOperation(
                 it.to,
                 it.fromPath,
                 it.toPath,
-                it.value,
-            ).apply {
-                executedAt = parentCreatedAt
-            }
+                it.value?.map(TreeNode::toJsonTreeNode),
+                root.createPath(parentCreatedAt),
+            )
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeStyleOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeStyleOperation.kt
@@ -38,9 +38,8 @@ internal data class TreeStyleOperation(
                 it.fromPath,
                 it.toPath,
                 it.attributes.orEmpty(),
-            ).apply {
-                executedAt = parentCreatedAt
-            }
+                root.createPath(parentCreatedAt),
+            )
         }
     }
 

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
@@ -10,7 +10,6 @@ import dev.yorkie.document.crdt.CrdtTree
 import dev.yorkie.document.crdt.CrdtTreeNode
 import dev.yorkie.document.crdt.CrdtTreeNode.Companion.CrdtTreeElement
 import dev.yorkie.document.crdt.CrdtTreeNodeID
-import dev.yorkie.document.crdt.TreeNode
 import dev.yorkie.document.json.TreeBuilder.element
 import dev.yorkie.document.json.TreeBuilder.text
 import dev.yorkie.document.operation.OperationInfo.TreeEditOpInfo
@@ -316,7 +315,7 @@ class JsonTreeTest {
                     1,
                     listOf(0, 0),
                     listOf(0, 0),
-                    listOf(TreeNode("text", value = "X")),
+                    listOf(JsonTree.TextNode("X")),
                     "$.t",
                 ),
                 // TODO(7hong13): need to check whether toPath is correctly passed
@@ -383,7 +382,7 @@ class JsonTreeTest {
                     4,
                     listOf(0, 0, 0, 1),
                     listOf(0, 0, 0, 1),
-                    listOf(TreeNode("text", value = "X")),
+                    listOf(JsonTree.TextNode("X")),
                     "$.t",
                 ),
                 // TODO(7hong13): need to check whether toPath is correctly passed


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- add the `rootTreeNode` for `JsonTree` and make only `JsonTree.TreeNode` publicly visible
- remove `SelectOpInfo`
- fix updating path of `Operation`s (I think I missed some changes in the JS SDK.)
- improved handling `PresenceChange.Others`
- updated the sample app's code

#### Any background context you want to provide?

#### What are the relevant tickets?
- https://github.com/yorkie-team/yorkie-js-sdk/pull/639
- https://github.com/yorkie-team/yorkie-js-sdk/pull/636

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
