### PR TITLE
Enable users to choose which dispatchers for Client and Document

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -155,6 +155,10 @@ class ClientTest {
             client2.detachAsync(document2).await()
             client1.deactivateAsync().await()
             client2.deactivateAsync().await()
+            document1.close()
+            document2.close()
+            client1.close()
+            client2.close()
 
             collectJobs.forEach(Job::cancel)
         }
@@ -230,6 +234,10 @@ class ClientTest {
             client2.detachAsync(document2).await()
             client1.deactivateAsync().await()
             client2.deactivateAsync().await()
+            document1.close()
+            document2.close()
+            client1.close()
+            client2.close()
         }
     }
 
@@ -294,6 +302,11 @@ class ClientTest {
 
         client1.deactivateAsync().await()
         client2.deactivateAsync().await()
+
+        document1.close()
+        document2.close()
+        client1.close()
+        client2.close()
         collectJob.cancel()
     }
 
@@ -362,6 +375,10 @@ class ClientTest {
             client1.deactivateAsync().await()
             client2.deactivateAsync().await()
             client3.deactivateAsync().await()
+            document1.close()
+            document2.close()
+            client1.close()
+            client2.close()
         }
     }
 
@@ -504,6 +521,9 @@ class ClientTest {
 
             client.detachAsync(document).await()
             client.deactivateAsync().await()
+
+            document.close()
+            client.close()
         }
     }
 }

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
@@ -71,6 +71,8 @@ class DocumentTest {
             }
 
             client.deactivateAsync().await()
+            document.close()
+            client.close()
         }
     }
 
@@ -105,6 +107,10 @@ class DocumentTest {
 
             client1.deactivateAsync().await()
             client2.deactivateAsync().await()
+            document1.close()
+            document2.close()
+            client1.close()
+            client2.close()
         }
     }
 
@@ -221,6 +227,9 @@ class DocumentTest {
             }
 
             client.deactivateAsync().await()
+
+            document.close()
+            client.close()
         }
     }
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/GCTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/GCTest.kt
@@ -10,7 +10,6 @@ import dev.yorkie.document.json.JsonTree
 import dev.yorkie.document.json.JsonTree.TextNode
 import dev.yorkie.document.json.TreeBuilder.element
 import dev.yorkie.document.json.TreeBuilder.text
-import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.TimeTicket.Companion.MaxTimeTicket
 import dev.yorkie.gson
 import dev.yorkie.util.IndexTreeNode
@@ -46,8 +45,10 @@ class GCTest {
             }.await()
             assertJsonContentEquals("""{"1":1,"3":3}""", document.toJson())
             assertEquals(4, document.garbageLength)
-            assertEquals(4, document.garbageCollect(TimeTicket.MaxTimeTicket))
+            assertEquals(4, document.garbageCollect(MaxTimeTicket))
             assertEquals(0, document.garbageLength)
+
+            document.close()
         }
     }
 
@@ -70,8 +71,10 @@ class GCTest {
                 document.toJson(),
             )
             assertEquals(1, document.garbageLength)
-            assertEquals(1, document.garbageCollect(TimeTicket.MaxTimeTicket))
+            assertEquals(1, document.garbageCollect(MaxTimeTicket))
             assertEquals(0, document.garbageLength)
+
+            document.close()
         }
     }
 
@@ -107,8 +110,10 @@ class GCTest {
                 document.toJson(),
             )
             assertEquals(4, document.garbageLength)
-            assertEquals(4, document.garbageCollect(TimeTicket.MaxTimeTicket))
+            assertEquals(4, document.garbageCollect(MaxTimeTicket))
             assertEquals(0, document.garbageLength)
+
+            document.close()
         }
     }
 
@@ -146,7 +151,7 @@ class GCTest {
             var nodeLengthBeforeGC =
                 getNodeLength(document.getRoot().getAs<JsonTree>("t").indexTree.root)
             assertEquals(2, document.garbageLength)
-            assertEquals(2, document.garbageCollect(TimeTicket.MaxTimeTicket))
+            assertEquals(2, document.garbageCollect(MaxTimeTicket))
             assertEquals(0, document.garbageLength)
             var nodeLengthAfterGC =
                 getNodeLength(document.getRoot().getAs<JsonTree>("t").indexTree.root)
@@ -168,7 +173,7 @@ class GCTest {
             nodeLengthBeforeGC =
                 getNodeLength(document.getRoot().getAs<JsonTree>("t").indexTree.root)
             assertEquals(1, document.garbageLength)
-            assertEquals(1, document.garbageCollect(TimeTicket.MaxTimeTicket))
+            assertEquals(1, document.garbageCollect(MaxTimeTicket))
             assertEquals(0, document.garbageLength)
             nodeLengthAfterGC =
                 getNodeLength(document.getRoot().getAs<JsonTree>("t").indexTree.root)
@@ -191,11 +196,13 @@ class GCTest {
                 getNodeLength(document.getRoot().getAs<JsonTree>("t").indexTree.root)
 
             assertEquals(5, document.garbageLength)
-            assertEquals(5, document.garbageCollect(TimeTicket.MaxTimeTicket))
+            assertEquals(5, document.garbageCollect(MaxTimeTicket))
             assertEquals(0, document.garbageLength)
             nodeLengthAfterGC =
                 getNodeLength(document.getRoot().getAs<JsonTree>("t").indexTree.root)
             assertEquals(5, nodeLengthBeforeGC - nodeLengthAfterGC)
+
+            document.close()
         }
     }
 
@@ -456,7 +463,7 @@ class GCTest {
         }.await()
         assertJsonContentEquals("""{"1":1, "3":3}""", document.toJson())
         assertEquals(4, document.garbageLength)
-        assertEquals(0, document.garbageCollect(TimeTicket.MaxTimeTicket))
+        assertEquals(0, document.garbageCollect(MaxTimeTicket))
         assertEquals(4, document.garbageLength)
     }
 
@@ -489,6 +496,9 @@ class GCTest {
 
         assertEquals(3, document.garbageLength)
         assertEquals(3, document.garbageLengthFromClone)
+
+        document.close()
+        client.close()
     }
 
     @Test
@@ -545,6 +555,11 @@ class GCTest {
 
             c1.deactivateAsync().await()
             c2.deactivateAsync().await()
+
+            d1.close()
+            d2.close()
+            c1.close()
+            c2.close()
         }
     }
 
@@ -600,6 +615,11 @@ class GCTest {
 
             c1.deactivateAsync().await()
             c2.deactivateAsync().await()
+
+            d1.close()
+            d2.close()
+            c1.close()
+            c2.close()
         }
     }
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/PresenceTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/PresenceTest.kt
@@ -175,6 +175,10 @@ class PresenceTest {
             c2.detachAsync(d2).await()
             c1.deactivateAsync().await()
             c2.deactivateAsync().await()
+            d1.close()
+            d2.close()
+            c1.close()
+            c2.close()
         }
     }
 
@@ -285,6 +289,10 @@ class PresenceTest {
             c2.detachAsync(d2).await()
             c1.deactivateAsync().await()
             c2.deactivateAsync().await()
+            d1.close()
+            d2.close()
+            c1.close()
+            c2.close()
         }
     }
 
@@ -343,6 +351,10 @@ class PresenceTest {
             c1.detachAsync(d1).await()
             c1.deactivateAsync().await()
             c2.deactivateAsync().await()
+            d1.close()
+            d2.close()
+            c1.close()
+            c2.close()
         }
     }
 
@@ -429,6 +441,12 @@ class PresenceTest {
             c1.deactivateAsync().await()
             c2.deactivateAsync().await()
             c3.deactivateAsync().await()
+            d1.close()
+            d2.close()
+            d3.close()
+            c1.close()
+            c2.close()
+            c3.close()
         }
     }
 
@@ -617,6 +635,12 @@ class PresenceTest {
             c1.deactivateAsync().await()
             c2.deactivateAsync().await()
             c3.deactivateAsync().await()
+            d1.close()
+            d2.close()
+            d3.close()
+            c1.close()
+            c2.close()
+            c3.close()
         }
     }
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
@@ -58,5 +58,10 @@ fun withTwoClientsAndDocuments(
         }
         client1.deactivateAsync().await()
         client2.deactivateAsync().await()
+
+        document1.close()
+        document2.close()
+        client1.close()
+        client2.close()
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -29,10 +29,13 @@ import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
 import dev.yorkie.util.YorkieLogger
 import dev.yorkie.util.createSingleThreadDispatcher
+import java.io.Closeable
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -50,9 +53,16 @@ import kotlinx.coroutines.withContext
 /**
  * A CRDT-based data type.
  * We can represent the model of the application and edit it even while offline.
+ *
+ * A single-threaded, [Closeable] [dispatcher] is used as default.
+ * Therefore you need to [close] the client, when the client is no longer needed.
+ * If you provide your own [dispatcher], it is up to you to decide [close] is needed or not.
  */
-public class Document(public val key: Key, private val options: Options = Options()) {
-    private val dispatcher = createSingleThreadDispatcher("Document($key)")
+public class Document(
+    public val key: Key,
+    private val options: Options = Options(),
+    private val dispatcher: CoroutineDispatcher = createSingleThreadDispatcher("Document($key)"),
+) : Closeable {
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
     private val localChanges = mutableListOf<Change>()
 
@@ -393,6 +403,11 @@ public class Document(public val key: Key, private val options: Options = Option
 
     public fun toJson(): String {
         return root.toJson()
+    }
+
+    override fun close() {
+        scope.cancel()
+        (dispatcher as? Closeable)?.close()
     }
 
     public sealed interface Event {

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -27,6 +27,7 @@ import dev.yorkie.document.change.ChangeID
 import dev.yorkie.document.change.ChangePack
 import dev.yorkie.document.change.CheckPoint
 import dev.yorkie.document.time.ActorID
+import dev.yorkie.util.createSingleThreadDispatcher
 import io.grpc.Channel
 import io.grpc.inprocess.InProcessChannelBuilder
 import io.grpc.inprocess.InProcessServerBuilder
@@ -38,6 +39,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -72,7 +74,16 @@ class ClientTest {
         channel = grpcCleanup.register(
             InProcessChannelBuilder.forName(serverName).directExecutor().build(),
         )
-        target = Client(channel, Client.Options(key = TEST_KEY, apiKey = TEST_KEY))
+        target = Client(
+            channel,
+            Client.Options(key = TEST_KEY, apiKey = TEST_KEY),
+            createSingleThreadDispatcher("Client Test"),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        target.close()
     }
 
     @Test

--- a/yorkie/src/test/kotlin/dev/yorkie/document/DocumentTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/DocumentTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
@@ -29,6 +30,11 @@ class DocumentTest {
     @Before
     fun setUp() {
         target = Document(Document.Key(""))
+    }
+
+    @After
+    fun tearDown() {
+        target.close()
     }
 
     @Test


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Enabled users to choose which dispatcher to use for Client and Document, rather than using a fixed single-threaded dispatcher.

#### Any background context you want to provide?
While applying Yorkie to a text editor it was found that using a background thread for document updates could cause problems as users can input text while remote changes for document are being applied.
It is very hard to control Android's text input as it is mostly controlled by Android framework, therefore using a main thread for document updates should be recommended.
But for usecases where developer can control the sequence of data changes in detail, using a background thread can still be advantageous.

I also changed Client and Doucment to Closeable as default single-thread dispatcher should be closed.

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
