### PR TITLE
Restore interface changes due to server DB sharding

### DIFF
--- a/yorkie/proto/src/main/proto/yorkie/v1/yorkie.proto
+++ b/yorkie/proto/src/main/proto/yorkie/v1/yorkie.proto
@@ -48,7 +48,6 @@ message ActivateClientResponse {
 }
 
 message DeactivateClientRequest {
-  string client_key = 2;
   string client_id = 1;
 }
 
@@ -56,7 +55,6 @@ message DeactivateClientResponse {
 }
 
 message AttachDocumentRequest {
-  string client_key = 3;
   string client_id = 1;
   ChangePack change_pack = 2;
 }
@@ -67,7 +65,6 @@ message AttachDocumentResponse {
 }
 
 message DetachDocumentRequest {
-  string client_key = 5;
   string client_id = 1;
   string document_id = 2;
   ChangePack change_pack = 3;
@@ -79,9 +76,7 @@ message DetachDocumentResponse {
 }
 
 message WatchDocumentRequest {
-  string client_key = 4;
   string client_id = 1;
-  string document_key = 3;
   string document_id = 2;
 }
 
@@ -97,7 +92,6 @@ message WatchDocumentResponse {
 }
 
 message RemoveDocumentRequest {
-  string client_key = 4;
   string client_id = 1;
   string document_id = 2;
   ChangePack change_pack = 3;
@@ -108,7 +102,6 @@ message RemoveDocumentResponse {
 }
 
 message PushPullChangesRequest {
-  string client_key = 5;
   string client_id = 1;
   string document_id = 2;
   ChangePack change_pack = 3;
@@ -120,9 +113,7 @@ message PushPullChangesResponse {
 }
 
 message BroadcastRequest {
-  string client_key = 6;
   string client_id = 1;
-  string document_key = 5;
   string document_id = 2;
   string topic = 3;
   bytes payload = 4;

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -214,7 +214,6 @@ public class Client @VisibleForTesting internal constructor(
                             changePack = document.createChangePack().toPBChangePack()
                             documentId = documentID
                             pushOnly = syncMode == SyncMode.PushOnly
-                            clientKey = options.key
                         }
                         val response = service.pushPullChanges(
                             request,
@@ -265,8 +264,6 @@ public class Client @VisibleForTesting internal constructor(
                 watchDocumentRequest {
                     clientId = requireClientId().value
                     documentId = attachment.documentID
-                    clientKey = options.key
-                    documentKey = attachment.document.key.value
                 },
                 documentBasedRequestHeader(attachment.document.key),
             ).retry {
@@ -360,7 +357,6 @@ public class Client @VisibleForTesting internal constructor(
             val request = attachDocumentRequest {
                 clientId = requireClientId().value
                 changePack = document.createChangePack().toPBChangePack()
-                clientKey = options.key
             }
             val response = try {
                 service.attachDocument(
@@ -413,7 +409,6 @@ public class Client @VisibleForTesting internal constructor(
                 clientId = requireClientId().value
                 changePack = document.createChangePack().toPBChangePack()
                 documentId = attachment.documentID
-                clientKey = options.key
             }
             val response = try {
                 service.detachDocument(
@@ -449,7 +444,6 @@ public class Client @VisibleForTesting internal constructor(
                 service.deactivateClient(
                     deactivateClientRequest {
                         clientId = requireClientId().value
-                        clientKey = options.key
                     },
                     projectBasedRequestHeader,
                 )
@@ -477,7 +471,6 @@ public class Client @VisibleForTesting internal constructor(
                 clientId = requireClientId().value
                 changePack = document.createChangePack(forceRemove = true).toPBChangePack()
                 documentId = attachment.documentID
-                clientKey = options.key
             }
             val response = try {
                 service.removeDocument(


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR restores passing sharding keys to the SDK in accordance with https://github.com/yorkie-team/yorkie/pull/776.

#### Any background context you want to provide?

#### What are the relevant tickets?
- https://github.com/yorkie-team/yorkie-js-sdk/pull/740
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
