### PR TITLE
Fix presenceEventQueue Iteration Issues in publishPresenceEvents()

### DIFF
--- a/microbenchmark/src/androidTest/kotlin/dev/yorkie/microbenchmark/DocumentBenchmark.kt
+++ b/microbenchmark/src/androidTest/kotlin/dev/yorkie/microbenchmark/DocumentBenchmark.kt
@@ -22,7 +22,9 @@ class DocumentBenchmark {
     @Test
     fun construct() {
         benchmarkRule.measureRepeated {
-            Document(Document.Key("d1"))
+            Document(Document.Key("d1")).also {
+                it.close()
+            }
         }
     }
 
@@ -44,6 +46,7 @@ class DocumentBenchmark {
 
                 assert(docs[0].toJson() != docs[1].toJson())
                 assert(docs[1].toJson() == docs[2].toJson())
+                docs.forEach(Document::close)
             }
         }
     }
@@ -69,6 +72,7 @@ class DocumentBenchmark {
                     }
                 }.await()
                 assert(document.toJson() == expected)
+                document.close()
             }
         }
     }
@@ -102,6 +106,7 @@ class DocumentBenchmark {
                     root.remove("k2")
                 }.await()
                 assert(document.toJson() == expected)
+                document.close()
             }
         }
     }
@@ -118,6 +123,7 @@ class DocumentBenchmark {
                     root["k1"] = "v2"
                 }.await()
                 assert(document.toJson() == """{"k1":"v2"}""")
+                document.close()
             }
         }
     }
@@ -175,6 +181,7 @@ class DocumentBenchmark {
                         }
                     }
                 }.await()
+                document.close()
             }
         }
     }
@@ -197,6 +204,7 @@ class DocumentBenchmark {
                     "<doc><p></p></doc>"
                 }
                 assert(document.getRoot().getAs<JsonTree>("tree").toXml() == expected)
+                document.close()
             }
         }
     }
@@ -227,6 +235,7 @@ class DocumentBenchmark {
                 assert(document.garbageLength == size)
                 assert(document.garbageCollect(MaxTimeTicket) == size)
                 assert(document.garbageLength == 0)
+                document.close()
             }
         }
     }
@@ -254,6 +263,7 @@ class DocumentBenchmark {
                 assert(document.garbageLength == size)
                 assert(document.garbageCollect(MaxTimeTicket) == size)
                 assert(document.garbageLength == 0)
+                document.close()
             }
         }
     }

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -288,7 +288,7 @@ public class Client @VisibleForTesting internal constructor(
         if (response.hasInitialization()) {
             val document = attachments.value[documentKey]?.document ?: return
             val clientIDs = response.initialization.clientIdsList.map { ActorID(it) }
-            document.presenceEventQueue.add(
+            document.pendingPresenceEvents.add(
                 PresenceChange.MyPresence.Initialized(
                     document.allPresences.value.filterKeys { it in clientIDs }.asPresences(),
                 ),
@@ -310,7 +310,7 @@ public class Client @VisibleForTesting internal constructor(
                 // unless we also know their initial presence data at this point.
                 val presence = document.allPresences.value[publisher]
                 if (presence != null) {
-                    document.presenceEventQueue.add(
+                    document.pendingPresenceEvents.add(
                         PresenceChange.Others.Watched(PresenceInfo(publisher, presence)),
                     )
                 }
@@ -322,7 +322,7 @@ public class Client @VisibleForTesting internal constructor(
                 // when PresenceChange(clear) is applied before unwatching. In that case,
                 // the 'unwatched' event is triggered while handling the PresenceChange.
                 val presence = document.presences.value[publisher] ?: return
-                document.presenceEventQueue.add(
+                document.pendingPresenceEvents.add(
                     PresenceChange.Others.Unwatched(PresenceInfo(publisher, presence)),
                 )
                 document.onlineClients.value -= publisher


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
The `presenceEventQueue` iteration in `publishPresenceEvents()` faced several issues:
- Using `listIterator()` resulted in a `ConcurrentModificationException` due to the possibility of new events being added to the queue during iteration.
- Copying the queue for iteration caused already processed events to be republished asynchronously by `publishPresenceEvent()`.

This PR resolves these issues by enforcing that new events can only be added to the `presenceEventQueue` right before iteration begins. This approach prevents `ConcurrentModificationException` without the need for queue copying, addressing the problems.

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
