### PR TITLE
Avoid unnecessary syncs in push-only sync mode

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -11,7 +11,9 @@ import dev.yorkie.document.Document.Event.LocalChange
 import dev.yorkie.document.Document.Event.RemoteChange
 import dev.yorkie.document.Document.Event.SyncStatusChanged
 import dev.yorkie.document.json.JsonCounter
+import dev.yorkie.document.json.JsonObject
 import dev.yorkie.document.json.JsonPrimitive
+import dev.yorkie.document.json.JsonText
 import dev.yorkie.document.json.JsonTree
 import dev.yorkie.document.json.JsonTreeTest.Companion.assertTreesXmlEquals
 import dev.yorkie.document.json.JsonTreeTest.Companion.rootTree
@@ -695,6 +697,76 @@ class ClientTest {
             c1.deactivateAsync().await()
             c1.close()
             d1.close()
+        }
+    }
+
+    @Test
+    fun test_avoid_unnecessary_syncs_in_push_only() {
+        withTwoClientsAndDocuments { c1, _, d1, d2, _ ->
+            val d1SyncEvents = mutableListOf<SyncStatusChanged>()
+            val d2SyncEvents = mutableListOf<SyncStatusChanged>()
+            val collectJobs = listOf(
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    d1.events.filterIsInstance<SyncStatusChanged>().collect(d1SyncEvents::add)
+                },
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    d2.events.filterIsInstance<SyncStatusChanged>().collect(d2SyncEvents::add)
+                },
+            )
+
+            d1.updateAsync { root, _ ->
+                root.setNewText("t").edit(0, 0, "a")
+            }.await()
+
+            withTimeout(GENERAL_TIMEOUT) {
+                while (d2SyncEvents.isEmpty()) {
+                    delay(50)
+                }
+            }
+
+            fun JsonObject.rootText() = getAs<JsonText>("t")
+
+            assertIs<SyncStatusChanged.Synced>(d2SyncEvents.last())
+            assertEquals("a", d1.getRoot().rootText().toString())
+            assertEquals("a", d2.getRoot().rootText().toString())
+
+            d1SyncEvents.clear()
+            c1.changeSyncMode(d1, RealtimePushOnly)
+            d2.updateAsync { root, _ ->
+                root.rootText().edit(1, 1, "b")
+            }.await()
+
+            withTimeout(GENERAL_TIMEOUT) {
+                while (d2SyncEvents.size < 2) {
+                    delay(50)
+                }
+            }
+            assertIs<SyncStatusChanged.Synced>(d2SyncEvents.last())
+
+            d2.updateAsync { root, _ ->
+                root.rootText().edit(2, 2, "c")
+            }.await()
+
+            withTimeout(GENERAL_TIMEOUT) {
+                while (d2SyncEvents.size < 3) {
+                    delay(50)
+                }
+            }
+            assertIs<SyncStatusChanged.Synced>(d2SyncEvents.last())
+
+            assertTrue(d1SyncEvents.isEmpty())
+            c1.changeSyncMode(d1, Realtime)
+
+            withTimeout(GENERAL_TIMEOUT) {
+                while (d1SyncEvents.isEmpty()) {
+                    delay(50)
+                }
+            }
+            assertIs<SyncStatusChanged.Synced>(d1SyncEvents.last())
+            assertEquals("abc", d1.getRoot().rootText().toString())
+            assertEquals("abc", d2.getRoot().rootText().toString())
+
+            collectJobs.forEach(Job::cancel)
         }
     }
 }

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeConcurrencyTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeConcurrencyTest.kt
@@ -2,7 +2,6 @@ package dev.yorkie.document.json
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dev.yorkie.TreeTest
-import dev.yorkie.core.GENERAL_TIMEOUT
 import dev.yorkie.core.createClient
 import dev.yorkie.document.json.OpCode.EditOpCode
 import dev.yorkie.document.json.TestOperation.EditOperationType
@@ -344,7 +343,7 @@ class JsonTreeConcurrencyTest {
                 op1s.forEach { op1 ->
                     op2s.forEach { op2 ->
                         val testDesc = "$desc-${range.desc}(${op1.desc},${op2.desc})"
-                        val result = withTimeout(GENERAL_TIMEOUT) {
+                        val result = withTimeout(10_000) {
                             runTest(c1, c2, root, initialXml, range, op1, op2, testDesc)
                         }
                         assertEquals(result.after.first, result.after.second)

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeConcurrencyTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeConcurrencyTest.kt
@@ -2,6 +2,7 @@ package dev.yorkie.document.json
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dev.yorkie.TreeTest
+import dev.yorkie.core.GENERAL_TIMEOUT
 import dev.yorkie.core.createClient
 import dev.yorkie.document.json.OpCode.EditOpCode
 import dev.yorkie.document.json.TestOperation.EditOperationType
@@ -343,7 +344,7 @@ class JsonTreeConcurrencyTest {
                 op1s.forEach { op1 ->
                     op2s.forEach { op2 ->
                         val testDesc = "$desc-${range.desc}(${op1.desc},${op2.desc})"
-                        val result = withTimeout(10_000) {
+                        val result = withTimeout(GENERAL_TIMEOUT) {
                             runTest(c1, c2, root, initialXml, range, op1, op2, testDesc)
                         }
                         assertEquals(result.after.first, result.after.second)

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
@@ -7,4 +7,13 @@ internal data class Attachment(
     val documentID: String,
     val syncMode: Client.SyncMode = Client.SyncMode.Realtime,
     val remoteChangeEventReceived: Boolean = false,
-)
+) {
+
+    fun needRealTimeSync(): Boolean {
+        return if (syncMode == Client.SyncMode.RealtimePushOnly) {
+            document.hasLocalChanges
+        } else {
+            syncMode.needRealTimeSync
+        }
+    }
+}

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
@@ -10,10 +10,11 @@ internal data class Attachment(
 ) {
 
     fun needRealTimeSync(): Boolean {
-        return if (syncMode == Client.SyncMode.RealtimePushOnly) {
+        val needRealTimeSyncMode = if (syncMode == Client.SyncMode.RealtimePushOnly) {
             document.hasLocalChanges
         } else {
             syncMode.needRealTimeSync
         }
+        return needRealTimeSyncMode && (document.hasLocalChanges || remoteChangeEventReceived)
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -181,13 +181,11 @@ public class Client @VisibleForTesting internal constructor(
         }
     }
 
-    private fun filterRealTimeSyncNeeded() = attachments.value.filterValues { attachment ->
-        attachment.needRealTimeSync() &&
-            (attachment.document.hasLocalChanges || attachment.remoteChangeEventReceived)
-    }.map { (key, attachment) ->
-        attachments.value += key to attachment.copy(remoteChangeEventReceived = false)
-        attachment
-    }
+    private fun filterRealTimeSyncNeeded() =
+        attachments.value.filterValues(Attachment::needRealTimeSync).map { (key, attachment) ->
+            attachments.value += key to attachment.copy(remoteChangeEventReceived = false)
+            attachment
+        }
 
     /**
      * Pushes local changes of the attached documents to the server and

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -182,7 +182,7 @@ public class Client @VisibleForTesting internal constructor(
     }
 
     private fun filterRealTimeSyncNeeded() = attachments.value.filterValues { attachment ->
-        attachment.syncMode.needRealTimeSync &&
+        attachment.needRealTimeSync() &&
             (attachment.document.hasLocalChanges || attachment.remoteChangeEventReceived)
     }.map { (key, attachment) ->
         attachments.value += key to attachment.copy(remoteChangeEventReceived = false)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

#### Any background context you want to provide?

#### What are the relevant tickets?
- https://github.com/yorkie-team/yorkie-js-sdk/pull/818

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new test for synchronization events and text editing operations.
  - Added method to determine real-time synchronization needs in the Attachment class.

- **Improvements**
  - Replaced hardcoded timeout value with a reusable constant for better maintainability.
  - Enhanced logic for determining real-time synchronization needs in the Client class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->