### PR TITLE
Avoid too many Integer instance creations

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.23" />
+    <option name="version" value="1.9.24" />
   </component>
 </project>

--- a/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
@@ -218,10 +218,10 @@ internal fun List<PBTreeNode>.toCrdtTreeRootNode(): CrdtTreeNode? {
     }
     val nodes = map { it.toCrdtTreeNode() }
     val root = nodes.last()
-    for (i in nodes.size - 2 downTo 0) {
-        val parentIndex = ((i + 1)..nodes.lastIndex).find {
-            this[i].depth - 1 == this[it].depth
-        } ?: continue
+    for (i in size - 2 downTo 0) {
+        val parentIndex = subList(i + 1, size).indexOfFirst {
+            this[i].depth - 1 == it.depth
+        }.takeIf { it > -1 }?.plus(i + 1) ?: continue
         nodes[parentIndex].prepend(nodes[i])
     }
     return CrdtTree(root, InitialTimeTicket).root


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Elements of IntRange were being compiled into java.lang.Integer class instead of the primitive int's.
This was creating millions of instances on snapshot load for large texts, and causes too many GCs running on a short period.

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Kotlin version from "1.9.23" to "1.9.24" for improved performance and compatibility.

- **Bug Fixes**
	- Improved the logic for finding parent nodes in tree structures, ensuring more accurate parent-child relationship determination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->