### PR TITLE
Fix incorrect tree snapshot encoding/decoding

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
@@ -48,7 +48,7 @@ import dev.yorkie.document.crdt.TextValue
 import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
 import dev.yorkie.util.IndexTreeNode
-import dev.yorkie.util.traverse
+import dev.yorkie.util.traverseAll
 
 internal typealias PBJsonElement = dev.yorkie.api.v1.JSONElement
 internal typealias PBJsonElementSimple = dev.yorkie.api.v1.JSONElementSimple
@@ -224,6 +224,7 @@ internal fun List<PBTreeNode>.toCrdtTreeRootNode(): CrdtTreeNode? {
         }.takeIf { it > -1 }?.plus(i + 1) ?: continue
         nodes[parentIndex].prepend(nodes[i])
     }
+    root.updateDescendantSize()
     return CrdtTree(root, InitialTimeTicket).root
 }
 
@@ -315,7 +316,7 @@ internal fun RgaTreeList.toPBRgaNodes(): List<PBRgaNode> {
 internal fun CrdtTreeNode.toPBTreeNodes(): List<PBTreeNode> {
     val treeNode = this
     return buildList {
-        traverse(treeNode) { node, nodeDepth ->
+        traverseAll(treeNode) { node, nodeDepth ->
             val pbTreeNode = treeNode {
                 id = node.id.toPBTreeNodeID()
                 type = node.type

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -1,5 +1,6 @@
 package dev.yorkie.document.crdt
 
+import androidx.annotation.VisibleForTesting
 import dev.yorkie.document.CrdtTreeNodeIDStruct
 import dev.yorkie.document.CrdtTreePosStruct
 import dev.yorkie.document.JsonSerializable
@@ -15,6 +16,7 @@ import dev.yorkie.util.IndexTreeNodeList
 import dev.yorkie.util.TokenType
 import dev.yorkie.util.TreePos
 import dev.yorkie.util.TreeToken
+import dev.yorkie.util.traverseAll
 import java.util.TreeMap
 
 public typealias TreePosRange = Pair<CrdtTreePos, CrdtTreePos>
@@ -46,13 +48,17 @@ internal data class CrdtTree(
         get() = indexTree.root.toTreeNode()
 
     init {
-        indexTree.traverse { node, _ ->
+        indexTree.traverseAll { node, _ ->
             nodeMapByID[node.id] = node
         }
     }
 
     val size: Int
         get() = indexTree.size
+
+    @VisibleForTesting
+    val nodeSize: Int
+        get() = nodeMapByID.size
 
     /**
      * Applies the given [attributes] of the given [range].
@@ -442,17 +448,6 @@ internal data class CrdtTree(
             }
         }
         return TreeOperationResult(changes, gcPairs)
-    }
-
-    private fun traverseAll(
-        node: CrdtTreeNode,
-        depth: Int = 0,
-        action: ((CrdtTreeNode, Int) -> Unit),
-    ) {
-        node.allChildren.forEach { child ->
-            traverseAll(child, depth + 1, action)
-        }
-        action.invoke(node, depth)
     }
 
     private fun traverseInPosRange(

--- a/yorkie/src/main/kotlin/dev/yorkie/util/IndexTreeExtensions.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/IndexTreeExtensions.kt
@@ -11,6 +11,17 @@ internal fun <T : IndexTreeNode<T>> traverse(
     action.invoke(node, depth)
 }
 
+internal fun <T : IndexTreeNode<T>> traverseAll(
+    node: T,
+    depth: Int = 0,
+    action: ((T, Int) -> Unit),
+) {
+    node.allChildren.forEach { child ->
+        traverseAll(child, depth + 1, action)
+    }
+    action.invoke(node, depth)
+}
+
 internal fun <T : IndexTreeNode<T>> findCommonAncestor(node1: T, node2: T): T? {
     if (node1 == node2) {
         return node1


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

#### Any background context you want to provide?

#### What are the relevant tickets?
- https://github.com/yorkie-team/yorkie-js-sdk/pull/836

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved tree traversal with a new `traverseAll` method for more efficient postorder traversal.
  - Enhanced tree size management with the `updateDescendantSize` method.

- **Tests**
  - Added a new test to ensure proper encoding and decoding of tree structures, including size assertions.

- **Refactor**
  - Replaced the `traverse` function with `traverseAll` for better performance and consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->