### PR TITLE
Avoid unnecessary map instance creations on Presences

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/core/Presences.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Presences.kt
@@ -5,18 +5,18 @@ import dev.yorkie.document.time.ActorID
 public typealias P = Map<String, String>
 
 public class Presences private constructor(
-    private val map: MutableMap<ActorID, MutableMap<String, String>>,
+    private val map: Map<ActorID, Map<String, String>>,
 ) : Map<ActorID, P> by map {
-
-    internal constructor() : this(mutableMapOf())
 
     public operator fun plus(presenceInfo: Pair<ActorID, P>): Presences {
         val (actorID, presence) = presenceInfo
         val newPresence = map[actorID].orEmpty() + presence
-        return (map + (actorID to newPresence)).asPresences()
+        return Presences(map + (actorID to newPresence))
     }
 
-    public operator fun minus(actorID: ActorID): Presences = (map - actorID).asPresences()
+    public operator fun minus(actorID: ActorID): Presences {
+        return Presences(map - actorID)
+    }
 
     override fun toString(): String {
         return map.entries.toString()
@@ -24,11 +24,15 @@ public class Presences private constructor(
 
     companion object {
         public fun Map<ActorID, P>.asPresences(): Presences {
-            return Presences(mapValues { it.value.toMutableMap() }.toMutableMap())
+            return if (this is Presences) {
+                Presences(map)
+            } else {
+                Presences(this)
+            }
         }
 
         public fun Pair<ActorID, P>.asPresences(): Presences {
-            return Presences(mutableMapOf(first to second.toMutableMap()))
+            return Presences(mapOf(this))
         }
 
         internal val UninitializedPresences = Presences(

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -111,7 +111,7 @@ public class Document(
     public val presences: StateFlow<Presences> =
         combine(_presences, onlineClients) { presences, onlineClients ->
             presences.filterKeys { it in onlineClients + changeID.actor }.asPresences()
-        }.stateIn(scope, SharingStarted.Eagerly, _presences.value.asPresences()).also {
+        }.stateIn(scope, SharingStarted.Eagerly, _presences.value).also {
             scope.launch {
                 it.collect { presences ->
                     presenceEventQueue.addAll(pendingPresenceEvents)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Each time there is a change in presence, we create a new Presences instance for StateFlow.  And yet we used a MutableMap, which resulted in multiple toMutableMap invocations.

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of presence data for better performance and maintainability.
  - Simplified initialization of presence-related properties in documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->