### PR TITLE
Add RHTNode removal to converter for consistency

### DIFF
--- a/yorkie/proto/yorkie/v1/resources.proto
+++ b/yorkie/proto/yorkie/v1/resources.proto
@@ -226,6 +226,7 @@ message RGANode {
 message NodeAttr {
   string value = 1;
   TimeTicket updated_at = 2;
+  bool is_removed = 3;
 }
 
 message TextNode {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/Rht.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/Rht.kt
@@ -46,6 +46,19 @@ internal class Rht : Collection<RhtNode> {
         return RhtSetResult(null, null)
     }
 
+    fun setInternal(
+        key: String,
+        value: String,
+        executedAt: TimeTicket,
+        removed: Boolean,
+    ) {
+        val node = RhtNode(key, value, executedAt, removed)
+        nodeMapByKey[key] = node
+        if (removed) {
+            numberOfRemovedElements++
+        }
+    }
+
     /**
      * Removes the Element of the given [key].
      */
@@ -84,9 +97,8 @@ internal class Rht : Collection<RhtNode> {
 
     fun deepCopy(): Rht {
         val rht = Rht()
-        nodeMapByKey.forEach {
-            val node = it.value
-            rht.set(node.key, node.value, node.executedAt, node.isRemoved)
+        nodeMapByKey.values.forEach { node ->
+            rht.setInternal(node.key, node.value, node.executedAt, node.isRemoved)
         }
         return rht
     }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/RhtTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/RhtTest.kt
@@ -231,6 +231,16 @@ class RhtTest {
         }
     }
 
+    @Test
+    fun `should deepcopy correctly`() {
+        target.set("key1", "value1", issueTime())
+        target.remove("key2", issueTime())
+
+        val copiedRht = target.deepCopy()
+        assertEquals(target.toJson(), copiedRht.toJson())
+        assertEquals(target.size, copiedRht.size)
+    }
+
     private fun Rht.toTestString(): String {
         return nodeKeyValueMap.entries.joinToString("") { "${it.key}:${it.value}" }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

#### Any background context you want to provide?

#### What are the relevant tickets?
- https://github.com/yorkie-team/yorkie-js-sdk/pull/842

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new field `is_removed` to enhance node attribute management.

- **Refactor**
  - Improved internal conversion functions for node attributes.
  - Enhanced the `Rht` class with a new method for setting key-value pairs.

- **Tests**
  - Introduced new test cases to verify deep copy functionality and tree manipulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->