### PR TITLE
Lock local changes to assert transactions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 minSdk = "24"
 compileSdk = "34"
 targetSdk = "34"
-agp = "8.4.1"
+agp = "8.4.2"
 connectKotlin = "0.6.1"
 okhttp = "4.12.0"
 coroutines = "1.8.1"

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -883,7 +883,7 @@ class ClientTest {
 
             delay(500)
 
-            assert(d2Events.size == 1)
+            assertEquals(1, d2Events.size)
 
             c2.detachAsync(d2).await()
 

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -270,6 +270,7 @@ public class Client @VisibleForTesting internal constructor(
                             // be disconnected to not receive an event for that document.
                             if (document.status == DocumentStatus.Removed) {
                                 attachments.value -= document.key
+                                mutexForDocuments.remove(document.key)
                             }
                         }
                     }.onFailure {
@@ -561,6 +562,7 @@ public class Client @VisibleForTesting internal constructor(
                 if (document.status != DocumentStatus.Removed) {
                     document.status = DocumentStatus.Detached
                     attachments.value -= document.key
+                    mutexForDocuments.remove(document.key)
                 }
             }
             SUCCESS
@@ -618,6 +620,7 @@ public class Client @VisibleForTesting internal constructor(
                 val pack = response.changePack.toChangePack()
                 document.applyChangePack(pack)
                 attachments.value -= document.key
+                mutexForDocuments.remove(document.key)
             }
             SUCCESS
         }

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -72,6 +72,8 @@ import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 
@@ -108,6 +110,11 @@ public class Client @VisibleForTesting internal constructor(
         get() = mapOf(
             "x-shard-key" to listOf("${options.apiKey.orEmpty()}/$value"),
         )
+
+    private val mutexForDocuments = mutableMapOf<Document.Key, Mutex>()
+
+    private val Document.mutex
+        get() = mutexForDocuments.getOrPut(key) { Mutex() }
 
     public constructor(
         host: String,
@@ -236,32 +243,34 @@ public class Client @VisibleForTesting internal constructor(
                 SyncResult(
                     document,
                     runCatching {
-                        val request = pushPullChangesRequest {
-                            clientId = requireClientId().value
-                            changePack = document.createChangePack().toPBChangePack()
-                            documentId = documentID
-                            pushOnly = syncMode == SyncMode.RealtimePushOnly
-                        }
-                        val response = service.pushPullChanges(
-                            request,
-                            document.key.documentBasedRequestHeader,
-                        ).getOrThrow()
-                        val responsePack = response.changePack.toChangePack()
-                        // NOTE(7hong13, chacha912, hackerwins): If syncLoop already executed with
-                        // PushPull, ignore the response when the syncMode is PushOnly.
-                        val currentSyncMode = attachments.value[document.key]?.syncMode
-                        if (responsePack.hasChanges &&
-                            currentSyncMode == SyncMode.RealtimePushOnly ||
-                            currentSyncMode == SyncMode.RealtimeSyncOff
-                        ) {
-                            return@runCatching
-                        }
+                        document.mutex.withLock {
+                            val request = pushPullChangesRequest {
+                                clientId = requireClientId().value
+                                changePack = document.createChangePack().toPBChangePack()
+                                documentId = documentID
+                                pushOnly = syncMode == SyncMode.RealtimePushOnly
+                            }
+                            val response = service.pushPullChanges(
+                                request,
+                                document.key.documentBasedRequestHeader,
+                            ).getOrThrow()
+                            val responsePack = response.changePack.toChangePack()
+                            // NOTE(7hong13, chacha912, hackerwins): If syncLoop already executed with
+                            // PushPull, ignore the response when the syncMode is PushOnly.
+                            val currentSyncMode = attachments.value[document.key]?.syncMode
+                            if (responsePack.hasChanges &&
+                                currentSyncMode == SyncMode.RealtimePushOnly ||
+                                currentSyncMode == SyncMode.RealtimeSyncOff
+                            ) {
+                                return@runCatching
+                            }
 
-                        document.applyChangePack(responsePack)
-                        // NOTE(chacha912): If a document has been removed, watchStream should
-                        // be disconnected to not receive an event for that document.
-                        if (document.status == DocumentStatus.Removed) {
-                            attachments.value -= document.key
+                            document.applyChangePack(responsePack)
+                            // NOTE(chacha912): If a document has been removed, watchStream should
+                            // be disconnected to not receive an event for that document.
+                            if (document.status == DocumentStatus.Removed) {
+                                attachments.value -= document.key
+                            }
                         }
                     }.onFailure {
                         coroutineContext.ensureActive()
@@ -478,36 +487,38 @@ public class Client @VisibleForTesting internal constructor(
             require(document.status == DocumentStatus.Detached) {
                 "document is not detached"
             }
-            document.setActor(requireClientId())
-            document.updateAsync { _, presence ->
-                presence.put(initialPresence)
-            }.await()
+            document.mutex.withLock {
+                document.setActor(requireClientId())
+                document.updateAsync { _, presence ->
+                    presence.put(initialPresence)
+                }.await()
 
-            val request = attachDocumentRequest {
-                clientId = requireClientId().value
-                changePack = document.createChangePack().toPBChangePack()
-            }
-            val response = service.attachDocument(
-                request,
-                document.key.documentBasedRequestHeader,
-            ).getOrElse {
-                ensureActive()
-                return@async Result.failure(it)
-            }
-            val pack = response.changePack.toChangePack()
-            document.applyChangePack(pack)
+                val request = attachDocumentRequest {
+                    clientId = requireClientId().value
+                    changePack = document.createChangePack().toPBChangePack()
+                }
+                val response = service.attachDocument(
+                    request,
+                    document.key.documentBasedRequestHeader,
+                ).getOrElse {
+                    ensureActive()
+                    return@async Result.failure(it)
+                }
+                val pack = response.changePack.toChangePack()
+                document.applyChangePack(pack)
 
-            if (document.status == DocumentStatus.Removed) {
-                return@async SUCCESS
-            }
+                if (document.status == DocumentStatus.Removed) {
+                    return@async SUCCESS
+                }
 
-            document.status = DocumentStatus.Attached
-            attachments.value += document.key to Attachment(
-                document,
-                response.documentId,
-                syncMode,
-            )
-            waitForInitialization(document.key)
+                document.status = DocumentStatus.Attached
+                attachments.value += document.key to Attachment(
+                    document,
+                    response.documentId,
+                    syncMode,
+                )
+                waitForInitialization(document.key)
+            }
             SUCCESS
         }
     }
@@ -525,30 +536,32 @@ public class Client @VisibleForTesting internal constructor(
             check(isActive) {
                 "client is not active"
             }
-            val attachment = attachments.value[document.key]
-                ?: throw IllegalArgumentException("document is not attached")
+            document.mutex.withLock {
+                val attachment = attachments.value[document.key]
+                    ?: throw IllegalArgumentException("document is not attached")
 
-            document.updateAsync { _, presence ->
-                presence.clear()
-            }.await()
+                document.updateAsync { _, presence ->
+                    presence.clear()
+                }.await()
 
-            val request = detachDocumentRequest {
-                clientId = requireClientId().value
-                changePack = document.createChangePack().toPBChangePack()
-                documentId = attachment.documentID
-            }
-            val response = service.detachDocument(
-                request,
-                document.key.documentBasedRequestHeader,
-            ).getOrElse {
-                ensureActive()
-                return@async Result.failure(it)
-            }
-            val pack = response.changePack.toChangePack()
-            document.applyChangePack(pack)
-            if (document.status != DocumentStatus.Removed) {
-                document.status = DocumentStatus.Detached
-                attachments.value -= document.key
+                val request = detachDocumentRequest {
+                    clientId = requireClientId().value
+                    changePack = document.createChangePack().toPBChangePack()
+                    documentId = attachment.documentID
+                }
+                val response = service.detachDocument(
+                    request,
+                    document.key.documentBasedRequestHeader,
+                ).getOrElse {
+                    ensureActive()
+                    return@async Result.failure(it)
+                }
+                val pack = response.changePack.toChangePack()
+                document.applyChangePack(pack)
+                if (document.status != DocumentStatus.Removed) {
+                    document.status = DocumentStatus.Detached
+                    attachments.value -= document.key
+                }
             }
             SUCCESS
         }
@@ -586,24 +599,26 @@ public class Client @VisibleForTesting internal constructor(
             check(isActive) {
                 "client is not active"
             }
-            val attachment = attachments.value[document.key]
-                ?: throw IllegalArgumentException("document is not attached")
+            document.mutex.withLock {
+                val attachment = attachments.value[document.key]
+                    ?: throw IllegalArgumentException("document is not attached")
 
-            val request = removeDocumentRequest {
-                clientId = requireClientId().value
-                changePack = document.createChangePack(forceRemove = true).toPBChangePack()
-                documentId = attachment.documentID
+                val request = removeDocumentRequest {
+                    clientId = requireClientId().value
+                    changePack = document.createChangePack(forceRemove = true).toPBChangePack()
+                    documentId = attachment.documentID
+                }
+                val response = service.removeDocument(
+                    request,
+                    document.key.documentBasedRequestHeader,
+                ).getOrElse {
+                    ensureActive()
+                    return@async Result.failure(it)
+                }
+                val pack = response.changePack.toChangePack()
+                document.applyChangePack(pack)
+                attachments.value -= document.key
             }
-            val response = service.removeDocument(
-                request,
-                document.key.documentBasedRequestHeader,
-            ).getOrElse {
-                ensureActive()
-                return@async Result.failure(it)
-            }
-            val pack = response.changePack.toChangePack()
-            document.applyChangePack(pack)
-            attachments.value -= document.key
             SUCCESS
         }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
When detach and other changes happen almost asynchonously, duplicated local changes could be sent to the server.
This PR uses mutex to assert transactions for push-pull and local application.


#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new test to ensure duplicated local changes are not sent to the server.

- **Refactor**
  - Introduced synchronization for document operations to enhance concurrency management.

- **Chores**
  - Updated the Android Gradle Plugin version to 8.4.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->