### PR TITLE
Prevent zombie presence events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,11 +115,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v2
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
           verbose: false
-          file: ./coverage/lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v2
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
           verbose: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,12 +115,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v2
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           verbose: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   microbenchmarks:
     name: Microbenchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,10 @@ jobs:
       - uses: actions/download-artifact@v2
       - uses: codecov/codecov-action@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   microbenchmarks:
     name: Microbenchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
         with:
           fail_ci_if_error: true
           verbose: false
+          file: ./coverage/lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/PresenceTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/PresenceTest.kt
@@ -718,7 +718,6 @@ class PresenceTest {
                 }
             }
 
-            assertEquals(3, d1Events.size)
             assertIs<Others.Watched>(d1Events.first())
             assertIs<Others.PresenceChanged>(d1Events[1])
             assertIs<Others.Unwatched>(d1Events.last())

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeSplitMergeTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeSplitMergeTest.kt
@@ -5,6 +5,7 @@ import dev.yorkie.TreeTest
 import dev.yorkie.core.Client.SyncMode.Manual
 import dev.yorkie.core.withTwoClientsAndDocuments
 import dev.yorkie.document.json.JsonTreeTest.Companion.rootTree
+import dev.yorkie.document.json.JsonTreeTest.Companion.updateAndSync
 import kotlin.test.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -16,7 +17,7 @@ class JsonTreeSplitMergeTest {
     @Test
     fun test_contained_split_and_split_at_the_same_position() {
         withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
-            JsonTreeTest.updateAndSync(
+            updateAndSync(
                 JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
                     root.setNewTree(
                         "t",
@@ -31,7 +32,7 @@ class JsonTreeSplitMergeTest {
             )
             JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p></r>", d1, d2)
 
-            JsonTreeTest.updateAndSync(
+            updateAndSync(
                 JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
                     root.rootTree().edit(2, 2, 1)
                 },
@@ -48,7 +49,7 @@ class JsonTreeSplitMergeTest {
     @Test
     fun test_contained_split_and_split_at_different_positions_on_the_same_node() {
         withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
-            JsonTreeTest.updateAndSync(
+            updateAndSync(
                 JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
                     root.setNewTree(
                         "t",
@@ -63,7 +64,7 @@ class JsonTreeSplitMergeTest {
             )
             JsonTreeTest.assertTreesXmlEquals("<r><p>abc</p></r>", d1, d2)
 
-            JsonTreeTest.updateAndSync(
+            updateAndSync(
                 JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
                     root.rootTree().edit(2, 2, 1)
                 },
@@ -81,7 +82,7 @@ class JsonTreeSplitMergeTest {
     @Test
     fun test_contained_split_and_insert_into_the_split_position() {
         withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
-            JsonTreeTest.updateAndSync(
+            updateAndSync(
                 JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
                     root.setNewTree(
                         "t",
@@ -96,7 +97,7 @@ class JsonTreeSplitMergeTest {
             )
             JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p></r>", d1, d2)
 
-            JsonTreeTest.updateAndSync(
+            updateAndSync(
                 JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
                     root.rootTree().edit(2, 2, 1)
                 },
@@ -114,7 +115,7 @@ class JsonTreeSplitMergeTest {
     @Test
     fun test_contained_split_and_insert_into_original_node() {
         withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
-            JsonTreeTest.updateAndSync(
+            updateAndSync(
                 JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
                     root.setNewTree(
                         "t",
@@ -129,7 +130,7 @@ class JsonTreeSplitMergeTest {
             )
             JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p></r>", d1, d2)
 
-            JsonTreeTest.updateAndSync(
+            updateAndSync(
                 JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
                     root.rootTree().edit(2, 2, 1)
                 },
@@ -147,7 +148,7 @@ class JsonTreeSplitMergeTest {
     @Test
     fun test_contained_split_and_insert_into_split_node() {
         withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
-            JsonTreeTest.updateAndSync(
+            updateAndSync(
                 JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
                     root.setNewTree(
                         "t",
@@ -162,7 +163,7 @@ class JsonTreeSplitMergeTest {
             )
             JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p></r>", d1, d2)
 
-            JsonTreeTest.updateAndSync(
+            updateAndSync(
                 JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
                     root.rootTree().edit(2, 2, 1)
                 },
@@ -180,7 +181,7 @@ class JsonTreeSplitMergeTest {
     @Test
     fun test_contained_split_and_delete_contents_in_split_node() {
         withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
-            JsonTreeTest.updateAndSync(
+            updateAndSync(
                 JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
                     root.setNewTree(
                         "t",
@@ -195,7 +196,7 @@ class JsonTreeSplitMergeTest {
             )
             JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p></r>", d1, d2)
 
-            JsonTreeTest.updateAndSync(
+            updateAndSync(
                 JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
                     root.rootTree().edit(2, 2, 1)
                 },
@@ -232,7 +233,7 @@ class JsonTreeSplitMergeTest {
             }.await()
             JsonTreeTest.assertTreesXmlEquals("<doc><p></p><p>ab</p></doc>", d1)
 
-            JsonTreeTest.updateAndSync(
+            updateAndSync(
                 JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
                     root.rootTree().edit(1, 3)
                 },
@@ -268,7 +269,7 @@ class JsonTreeSplitMergeTest {
                 d1.getRoot().rootTree().toXml(),
             )
 
-            JsonTreeTest.updateAndSync(
+            updateAndSync(
                 JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
                     root.rootTree().edit(2, 6)
                 },
@@ -309,7 +310,7 @@ class JsonTreeSplitMergeTest {
             }.await()
             assertEquals("<doc><p>a</p><p>c</p><p>b</p></doc>", d1.getRoot().rootTree().toXml())
 
-            JsonTreeTest.updateAndSync(
+            updateAndSync(
                 JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
                     root.rootTree().edit(2, 7)
                 },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Presence events are managed using the `presenceEventQueue` in the Yorkie Android SDK. When `_presences` collects a new value, it iterates through the `presenceEventQueue`, filters for related presence events, and emits them into the `eventStream`. However, because `_presences` is a `StateFlow`, when new values are emitted to `_presences` rapidly, only the most recent value is collected, and only its accompanying presence event is emitted into the `eventStream`. This can leave other unprocessed presence events as zombies in the `presenceEventQueue`, causing unintended behaviors.
This PR addresses the issue by ensuring all presence events are either properly emitted or dropped.

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new test to ensure presence event queues are empty after consecutive presence changes.
  
- **Chores**
  - Updated CI workflow to move `CODECOV_TOKEN` configuration to improve environment management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->