### PR TITLE
Handle ErrClientNotActivated and ErrClientNotFound

### DIFF
--- a/yorkie/proto/com/google/rpc/error_details.proto
+++ b/yorkie/proto/com/google/rpc/error_details.proto
@@ -1,0 +1,50 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.rpc;
+
+import "google/protobuf/duration.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/rpc/errdetails;errdetails";
+option java_multiple_files = true;
+option java_outer_classname = "ErrorDetailsProto";
+option java_package = "com.google.rpc";
+option objc_class_prefix = "RPC";
+
+message ErrorInfo {
+  // The reason of the error. This is a constant value that identifies the
+  // proximate cause of the error. Error reasons are unique within a particular
+  // domain of errors. This should be at most 63 characters and match
+  // /[A-Z0-9_]+/.
+  string reason = 1;
+
+  // The logical grouping to which the "reason" belongs.  Often "domain" will
+  // contain the registered service name of the tool or product that is the
+  // source of the error. Example: "pubsub.googleapis.com". If the error is
+  // common across many APIs, the first segment of the example above will be
+  // omitted.  The value will be, "googleapis.com".
+  string domain = 2;
+
+  // Additional structured details about this error.
+  //
+  // Keys should match /[a-zA-Z0-9-_]/ and be limited to 64 characters in
+  // length. When identifying the current value of an exceeded limit, the units
+  // should be contained in the key, not the value.  For example, rather than
+  // {"instanceLimit": "100/request"}, should be returned as,
+  // {"instanceLimitPerRequest": "100"}, if the client exceeds the number of
+  // instances that can be created in a single (batch) request.
+  map<string, string> metadata = 3;
+}

--- a/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
@@ -175,7 +175,7 @@ internal fun PBValueType.toPrimitiveType(): CrdtPrimitive.Type {
         PBValueType.VALUE_TYPE_STRING -> CrdtPrimitive.Type.String
         PBValueType.VALUE_TYPE_BYTES -> CrdtPrimitive.Type.Bytes
         PBValueType.VALUE_TYPE_DATE -> CrdtPrimitive.Type.Date
-        else -> throw YorkieException(ErrUnimplemented, "unimplemented type : $this")
+        else -> throw YorkieException(ErrUnimplemented, "unimplemented value type : $this")
     }
 }
 
@@ -547,7 +547,7 @@ internal fun PBJsonElementSimple.toCrdtElement(): CrdtElement {
 
         PBValueType.VALUE_TYPE_TREE -> value.toCrdtTree()
 
-        else -> throw YorkieException(ErrUnimplemented, "unimplemented type : $this")
+        else -> throw YorkieException(ErrUnimplemented, "unimplemented element : $this")
     }
 }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/api/OperationConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/OperationConverter.kt
@@ -115,7 +115,7 @@ internal fun List<PBOperation>.toOperations(): List<Operation> {
                     .associate { (key, value) -> ActorID(key) to value.toTimeTicket() },
             )
 
-            else -> throw YorkieException(ErrUnimplemented, "unimplemented operation")
+            else -> throw YorkieException(ErrUnimplemented, "unimplemented operations")
         }
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/api/PresenceConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/PresenceConverter.kt
@@ -41,7 +41,7 @@ internal fun PBPresenceChange.toPresenceChange(): PresenceChange {
     return when (type) {
         PBPresenceChangeType.CHANGE_TYPE_PUT -> PresenceChange.Put(presence.toPresence())
         PBPresenceChangeType.CHANGE_TYPE_CLEAR -> PresenceChange.Clear
-        else -> throw YorkieException(Unsupported, "unsupported type : $type")
+        else -> throw YorkieException(ErrUnimplemented, "Unimplemented type: $type")
     }
 }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/util/ConnectRpcErrorUtil.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/ConnectRpcErrorUtil.kt
@@ -12,7 +12,7 @@ import dev.yorkie.util.YorkieException.Code.ErrClientNotFound
  * If caller want to handle the error about [ErrClientNotActivated] or [ErrClientNotFound],
  * then pass the lambda function to [handleError].
  */
-public suspend fun handleConnectException(
+internal suspend fun handleConnectException(
     exception: ConnectException?,
     handleError: (suspend () -> Unit)? = null,
 ): Boolean {
@@ -30,7 +30,6 @@ public suspend fun handleConnectException(
     if (yorkieErrorCode == ErrClientNotActivated.codeString ||
         yorkieErrorCode == ErrClientNotFound.codeString
     ) {
-        print("Yorkie error: $yorkieErrorCode")
         handleError?.invoke()
     }
     return false

--- a/yorkie/src/main/kotlin/dev/yorkie/util/ConnectRpcErrorUtil.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/ConnectRpcErrorUtil.kt
@@ -1,16 +1,45 @@
 package dev.yorkie.util
 
 import com.connectrpc.Code
-import com.connectrpc.ConnectErrorDetail
 import com.connectrpc.ConnectException
+import com.google.rpc.ErrorInfo
+import dev.yorkie.util.YorkieException.Code.ErrClientNotActivated
+import dev.yorkie.util.YorkieException.Code.ErrClientNotFound
 
 /**
- * [isRetryable] will return true if the given error is retryable.
+ * [handleConnectException] will return true if the given error is retryable.
+ *
+ * If caller want to handle the error about [ErrClientNotActivated] or [ErrClientNotFound],
+ * then pass the lambda function to [handleError].
  */
-public fun isRetryable(exception: ConnectException?): Boolean {
+public suspend fun handleConnectException(
+    exception: ConnectException?,
+    handleError: (suspend () -> Unit)? = null,
+): Boolean {
     val errorCode = exception?.code ?: return false
-    return errorCode == Code.CANCELED ||
+
+    if (errorCode == Code.CANCELED ||
         errorCode == Code.UNKNOWN ||
         errorCode == Code.RESOURCE_EXHAUSTED ||
         errorCode == Code.UNAVAILABLE
+    ) {
+        return true
+    }
+
+    val yorkieErrorCode = errorCodeOf(exception)
+    if (yorkieErrorCode == ErrClientNotActivated.codeString ||
+        yorkieErrorCode == ErrClientNotFound.codeString
+    ) {
+        print("Yorkie error: $yorkieErrorCode")
+        handleError?.invoke()
+    }
+    return false
+}
+
+private fun errorCodeOf(exception: ConnectException): String {
+    val infos = exception.unpackedDetails(ErrorInfo::class)
+    for (info in infos) {
+        info.metadataMap["code"]?.let { return it }
+    }
+    return ""
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/util/YorkieException.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/YorkieException.kt
@@ -7,36 +7,36 @@ import kotlin.contracts.contract
  * `YorkieError` is an error returned by a Yorkie operation.
  */
 public data class YorkieException(public val code: Code, public val errorMessage: String) : RuntimeException(errorMessage) {
-    public enum class Code {
+    public enum class Code(val codeString: String) {
         // Ok is returned when the operation completed successfully.
-        Ok,
+        Ok("ok"),
 
         // ErrClientNotActivated is returned when the client is not active.
-        ErrClientNotActivated,
+        ErrClientNotActivated("ErrClientNotActivated"),
 
         // ErrClientNotFound is returned when the client is not found.
-        ErrClientNotFound,
+        ErrClientNotFound("ErrClientNotFound"),
 
         // ErrUnimplemented is returned when the operation is not implemented.
-        ErrUnimplemented,
+        ErrUnimplemented("ErrUnimplemented"),
 
         // Unsupported is returned when the operation is not supported.
-        Unsupported,
+        Unsupported("Unsupported"),
 
         // ErrDocumentNotAttached is returned when the document is not attached.
-        ErrDocumentNotAttached,
+        ErrDocumentNotAttached("ErrDocumentNotAttached"),
 
         // ErrDocumentNotDetached is returned when the document is not detached.
-        ErrDocumentNotDetached,
+        ErrDocumentNotDetached("ErrDocumentNotDetached"),
 
         // ErrDocumentRemoved is returned when the document is removed.
-        ErrDocumentRemoved,
+        ErrDocumentRemoved("ErrDocumentRemoved"),
 
         // InvalidObjectKey is returned when the object key is invalid.
-        ErrInvalidObjectKey,
+        ErrInvalidObjectKey("ErrInvalidObjectKey"),
 
         // ErrInvalidArgument is returned when the argument is invalid.
-        ErrInvalidArgument,
+        ErrInvalidArgument("ErrInvalidArgument");
     }
 }
 

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -31,9 +31,12 @@ import dev.yorkie.document.change.CheckPoint
 import dev.yorkie.document.json.JsonText
 import dev.yorkie.document.presence.PresenceChange
 import dev.yorkie.document.time.ActorID
+import dev.yorkie.util.YorkieException
+import dev.yorkie.util.YorkieException.Code.ErrDocumentNotAttached
 import dev.yorkie.util.createSingleThreadDispatcher
-import dev.yorkie.util.isRetryable
+import dev.yorkie.util.handleConnectException
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
@@ -154,7 +157,6 @@ class ClientTest {
         val document = Document(Key(WATCH_SYNC_ERROR_DOCUMENT_KEY))
         target.activateAsync().await()
         target.attachAsync(document).await()
-
         val syncEventDeferred = async(start = CoroutineStart.UNDISPATCHED) {
             document.events.filterIsInstance<SyncStatusChanged>().first()
         }
@@ -182,11 +184,15 @@ class ClientTest {
         assertTrue(target.syncAsync().await().isSuccess)
         target.detachAsync(success).await()
 
-        val failing = Document(Key(WATCH_SYNC_ERROR_DOCUMENT_KEY))
-        target.attachAsync(failing).await()
-        assertFalse(target.syncAsync().await().isSuccess)
+        val failing = Document(Key(ATTACH_ERROR_DOCUMENT_KEY))
+        assertTrue(target.attachAsync(failing).await().isFailure)
 
-        target.detachAsync(failing).await()
+        val exception = assertFailsWith(YorkieException::class) {
+            target.detachAsync(failing).await()
+        }
+        assertEquals(ErrDocumentNotAttached, exception.code)
+        assertTrue(target.syncAsync().await().isSuccess)
+
         target.deactivateAsync().await()
     }
 
@@ -260,7 +266,11 @@ class ClientTest {
 
             val client = Client(
                 yorkieService,
-                Client.Options(key = TEST_KEY, apiKey = TEST_KEY, syncLoopDuration = 500.milliseconds),
+                Client.Options(
+                    key = TEST_KEY,
+                    apiKey = TEST_KEY,
+                    syncLoopDuration = 500.milliseconds,
+                ),
                 createSingleThreadDispatcher("Client Test"),
                 OkHttpClient(),
                 OkHttpClient(),
@@ -314,7 +324,7 @@ class ClientTest {
 
             // 02. Simulate FailedPrecondition error which is not retryable.
             Code.entries.filterNot { errorCode ->
-                isRetryable(ConnectException(errorCode))
+                handleConnectException(ConnectException(errorCode))
             }.forEach { nonRetryableErrorCode ->
                 mockYorkieService.customError[WATCH_SYNC_ERROR_DOCUMENT_KEY] = nonRetryableErrorCode
                 document.updateAsync { root, _ ->


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
I have added the missing changes that was mentioned in the previous PR discussion (#212)
This change is related to the PR for the JS SDK : https://github.com/yorkie-team/yorkie-js-sdk/pull/865

#### Any background context you want to provide?
Since it was hard to include the entire library containing ErrorInfo as a dependency, I opted to use only a subset of the proto files. I consider this a tricky approach, and if it becomes difficult to maintain in the future, we might need to reconsider the method of transmitting error codes between the server and the client. 

#### What are the relevant tickets?
1. #212 
2. https://github.com/yorkie-team/yorkie-js-sdk/pull/865

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
