### PR TITLE
Sync android-sdk with js-sdk: Implement updates to v0.5.7

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
@@ -46,6 +46,7 @@ fun createTwoClientsAndDocuments(
 }
 
 fun withTwoClientsAndDocuments(
+    attachDocuments: Boolean = true,
     detachDocuments: Boolean = true,
     syncMode: Client.SyncMode = Client.SyncMode.Realtime,
     presences: Pair<Map<String, String>, Map<String, String>> = Pair(emptyMap(), emptyMap()),
@@ -55,16 +56,18 @@ fun withTwoClientsAndDocuments(
         client1.activateAsync().await()
         client2.activateAsync().await()
 
-        client1.attachAsync(
-            document1,
-            syncMode = syncMode,
-            initialPresence = presences.first,
-        ).await()
-        client2.attachAsync(
-            document2,
-            syncMode = syncMode,
-            initialPresence = presences.second,
-        ).await()
+        if (attachDocuments) {
+            client1.attachAsync(
+                document1,
+                syncMode = syncMode,
+                initialPresence = presences.first,
+            ).await()
+            client2.attachAsync(
+                document2,
+                syncMode = syncMode,
+                initialPresence = presences.second,
+            ).await()
+        }
 
         callback.invoke(this, client1, client2, document1, document2, key)
 

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -64,12 +64,14 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
@@ -736,32 +738,44 @@ public class Client constructor(
 
     /**
      * Deactivates this [Client].
+     *
+     * @param keepalive 비활성화 요청을 앱이 종료되더라도 완료하도록 보장합니다. 페이지 언로드 또는 앱 종료 시에 사용합니다.
      */
-    public fun deactivateAsync(): Deferred<OperationResult> {
-        return scope.async {
-            if (!isActive) {
-                return@async SUCCESS
-            }
-            activationJob.cancelChildren()
+    @OptIn(DelicateCoroutinesApi::class)
+    public fun deactivateAsync(keepalive: Boolean = false): Deferred<OperationResult> {
+        if (!isActive) {
+            return CompletableDeferred(SUCCESS)
+        }
 
-            service.deactivateClient(
-                deactivateClientRequest {
-                    clientId = requireClientId().value
-                },
-                projectBasedRequestHeader,
-            ).getOrElse {
-                ensureActive()
-                handleConnectException(it) { exception ->
+        val task = suspend {
+            activationJob.cancelChildren()
+            try {
+                service.deactivateClient(
+                    deactivateClientRequest {
+                        clientId = requireClientId().value
+                    },
+                    projectBasedRequestHeader,
+                ).getOrThrow()
+
+                deactivateInternal()
+                SUCCESS
+            } catch (e: ConnectException) {
+                handleConnectException(e) { exception ->
                     if (errorCodeOf(exception) == ErrUnauthenticated.codeString) {
                         shouldRefreshToken = true
                     }
                     deactivateInternal()
                 }
-                return@async Result.failure(it)
+                Result.failure(e)
             }
+        }
 
-            deactivateInternal()
-            SUCCESS
+        return if (keepalive) {
+            GlobalScope.async(Dispatchers.IO) {
+                NonCancellable.run { task() }
+            }
+        } else {
+            scope.async { task() }
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -858,6 +858,15 @@ public class Client constructor(
                     }
                     return SUCCESS
                 } catch (err: Exception) {
+                    if (err is ConnectException && errorCodeOf(err) == ErrUnauthenticated.codeString) {
+                        shouldRefreshToken = true
+                        attachment.document.publishEvent(
+                            AuthError(
+                                errorMetadataOf(err)["reason"] ?: "AuthError",
+                                Document.Event.AuthError.AuthErrorMethod.Broadcast,
+                            ),
+                        )
+                    }
                     retryCount++
                     if (retryCount > maxRetries) {
                         logError("BROADCAST", "Exceeded maximum retry attempts for topic $topic")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -280,7 +280,6 @@ public class Document(
     internal suspend fun applyChangePack(pack: ChangePack): Unit = withContext(dispatcher) {
         if (pack.hasSnapshot) {
             applySnapshot(
-                pack.checkPoint.serverSeq,
                 pack.versionVector,
                 checkNotNull(pack.snapshot),
                 pack.checkPoint.clientSeq,
@@ -309,7 +308,6 @@ public class Document(
      * Applies the given [snapshot] into this document.
      */
     private suspend fun applySnapshot(
-        serverSeq: Long,
         snapshotVector: VersionVector,
         snapshot: ByteString,
         clientSeq: UInt,
@@ -323,7 +321,7 @@ public class Document(
         logDebug("Document.snapshot") {
             "Snapshot: ${snapshot.toSnapshot()}"
         }
-        changeID = changeID.setClocks(serverSeq, snapshotVector)
+        changeID = changeID.setClocks(snapshotVector.maxLamport(), snapshotVector)
         clone = null
         removePushedLocalChanges(clientSeq)
         eventStream.emit(Event.Snapshot(snapshot))

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -521,6 +521,13 @@ public class Document(
     }
 
     /**
+     * `getVersionVector` returns the version vector of document
+     */
+    fun getVersionVector(): VersionVector {
+        return changeID.versionVector
+    }
+
+    /**
      * Deletes elements that were removed before the given time.
      */
     @VisibleForTesting

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -658,6 +658,7 @@ public class Document(
             enum class AuthErrorMethod(val value: String) {
                 PushPull("PushPull"),
                 WatchDocuments("WatchDocuments"),
+                Broadcast("Broadcast"),
             }
         }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/Change.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/Change.kt
@@ -40,6 +40,6 @@ public data class Change internal constructor(
                 is PresenceChange.Clear -> presences - id.actor
             }
         }
-        return operations.flatMap { it.execute(root) } to newPresences
+        return operations.flatMap { it.execute(root, id.versionVector) } to newPresences
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/ChangeID.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/ChangeID.kt
@@ -43,6 +43,13 @@ public data class ChangeID(
      */
     fun syncClocks(other: ChangeID): ChangeID {
         val lamport = if (other.lamport > lamport) other.lamport + 1 else lamport + 1
+
+        var otherVersionVector = other.versionVector
+        if (otherVersionVector.size() == 0) {
+            otherVersionVector = otherVersionVector.deepCopy()
+            otherVersionVector.set(other.actor.value, other.lamport)
+        }
+
         val maxVersionVector = versionVector.max(other.versionVector)
         val newID = copy(
             lamport = lamport,
@@ -57,7 +64,9 @@ public data class ChangeID(
      * is given from the server.
      */
     fun setClocks(otherLamport: Long, vector: VersionVector): ChangeID {
-        val lamport = if (otherLamport > lamport) otherLamport else lamport + 1
+        val lamport = if (otherLamport > lamport) otherLamport + 1 else lamport + 1
+        vector.unset(INITIAL_ACTOR_ID.value)
+
         val maxVersionVector = this.versionVector.max(vector)
         maxVersionVector.set(actor.value, lamport)
         return copy(

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -1,5 +1,6 @@
 package dev.yorkie.document.crdt
 
+import android.annotation.SuppressLint
 import androidx.annotation.VisibleForTesting
 import dev.yorkie.document.CrdtTreeNodeIDStruct
 import dev.yorkie.document.CrdtTreePosStruct
@@ -8,8 +9,9 @@ import dev.yorkie.document.json.TreePosStructRange
 import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
-import dev.yorkie.document.time.TimeTicket.Companion.MaxTimeTicket
+import dev.yorkie.document.time.TimeTicket.Companion.MAX_LAMPORT
 import dev.yorkie.document.time.TimeTicket.Companion.compareTo
+import dev.yorkie.document.time.VersionVector
 import dev.yorkie.util.IndexTree
 import dev.yorkie.util.IndexTreeNode
 import dev.yorkie.util.IndexTreeNodeList
@@ -25,6 +27,7 @@ internal typealias CrdtTreeToken = TreeToken<CrdtTreeNode>
 
 internal typealias TreeNodePair = Pair<CrdtTreeNode, CrdtTreeNode>
 
+@SuppressLint("VisibleForTests")
 internal data class CrdtTree(
     val root: CrdtTreeNode,
     override val createdAt: TimeTicket,
@@ -70,6 +73,7 @@ internal data class CrdtTree(
         attributes: Map<String, String>?,
         executedAt: TimeTicket,
         maxCreatedAtMapByActor: Map<ActorID, TimeTicket>? = null,
+        versionVector: VersionVector? = null,
     ): TreeOperationResult {
         val (fromParent, fromLeft) = findNodesAndSplitText(range.first, executedAt)
         val (toParent, toLeft) = findNodesAndSplitText(range.second, executedAt)
@@ -84,11 +88,23 @@ internal data class CrdtTree(
             toLeft = toLeft,
         ) { (node, _), _ ->
             val actorID = node.createdAt.actorID
-            val maxCreatedAt = maxCreatedAtMapByActor?.let {
-                maxCreatedAtMapByActor[actorID] ?: InitialTimeTicket
-            } ?: MaxTimeTicket
+            var maxCreatedAt: TimeTicket? = null
+            var clientLamportAtChange = 0L
 
-            if (node.canStyle(executedAt, maxCreatedAt) && attributes != null) {
+            if (versionVector == null && maxCreatedAtMapByActor.isNullOrEmpty()) {
+                clientLamportAtChange = MAX_LAMPORT
+            } else if (versionVector != null && versionVector.size() > 0) {
+                clientLamportAtChange = versionVector.get(actorID.value) ?: 0
+            } else {
+                maxCreatedAt = maxCreatedAtMapByActor?.get(actorID) ?: InitialTimeTicket
+            }
+
+            if (node.canStyle(
+                    executedAt,
+                    maxCreatedAt,
+                    clientLamportAtChange,
+                ) && attributes != null
+            ) {
                 val max = createdAtMapByActor[actorID]
                 val createdAt = node.createdAt
                 if (max == null || max < createdAt) {
@@ -173,6 +189,7 @@ internal data class CrdtTree(
         executedAt: TimeTicket,
         issueTimeTicket: (() -> TimeTicket)? = null,
         maxCreatedAtMapByActor: Map<ActorID, TimeTicket>? = null,
+        versionVector: VersionVector? = null,
     ): TreeOperationResult {
         // 01. find nodes from the given range and split nodes.
         val (fromParent, fromLeft) = findNodesAndSplitText(range.first, executedAt)
@@ -199,11 +216,23 @@ internal data class CrdtTree(
             }
 
             val actorID = node.createdAt.actorID
-            val maxCreatedAt = maxCreatedAtMapByActor?.let {
-                maxCreatedAtMapByActor[actorID] ?: InitialTimeTicket
-            } ?: MaxTimeTicket
+            var maxCreatedAt: TimeTicket? = null
+            var clientLamportAtChange = 0L
 
-            if (node.canDelete(executedAt, maxCreatedAt) || node.parent in nodesToBeRemoved) {
+            if (versionVector == null && maxCreatedAtMapByActor.isNullOrEmpty()) {
+                clientLamportAtChange = MAX_LAMPORT
+            } else if (versionVector != null && versionVector.size() > 0) {
+                clientLamportAtChange = versionVector.get(actorID.value) ?: 0
+            } else {
+                maxCreatedAt = maxCreatedAtMapByActor?.get(actorID) ?: InitialTimeTicket
+            }
+
+            if (node.canDelete(
+                    executedAt,
+                    maxCreatedAt,
+                    clientLamportAtChange,
+                ) || node.parent in nodesToBeRemoved
+            ) {
                 val max = maxCreatedAtMap[actorID]
                 val createdAt = node.createdAt
 
@@ -429,6 +458,7 @@ internal data class CrdtTree(
         attributeToRemove: List<String>,
         executedAt: TimeTicket,
         maxCreatedAtMapByActor: Map<ActorID, TimeTicket>? = null,
+        versionVector: VersionVector? = null,
     ): TreeOperationResult {
         val (fromParent, fromLeft) = findNodesAndSplitText(range.first, executedAt)
         val (toParent, toLeft) = findNodesAndSplitText(range.second, executedAt)
@@ -438,11 +468,23 @@ internal data class CrdtTree(
         val gcPairs = mutableListOf<GCPair<RhtNode>>()
         traverseInPosRange(fromParent, fromLeft, toParent, toLeft) { (node, _), _ ->
             val actorID = node.createdAt.actorID
-            val maxCreatedAt = maxCreatedAtMapByActor?.let {
-                maxCreatedAtMapByActor[actorID] ?: InitialTimeTicket
-            } ?: MaxTimeTicket
+            var maxCreatedAt: TimeTicket? = null
+            var clientLamportAtChange = 0L
 
-            if (node.canStyle(executedAt, maxCreatedAt) && attributeToRemove.isNotEmpty()) {
+            if (versionVector == null && maxCreatedAtMapByActor.isNullOrEmpty()) {
+                clientLamportAtChange = MAX_LAMPORT
+            } else if (versionVector != null && versionVector.size() > 0) {
+                clientLamportAtChange = versionVector.get(actorID.value) ?: 0
+            } else {
+                maxCreatedAt = maxCreatedAtMapByActor?.get(actorID) ?: InitialTimeTicket
+            }
+
+            if (node.canStyle(
+                    executedAt,
+                    maxCreatedAt,
+                    clientLamportAtChange,
+                ) && attributeToRemove.isNotEmpty()
+            ) {
                 val max = createdAtMapByActor[actorID]
                 val createdAt = node.createdAt
                 if (max < createdAt) {
@@ -895,15 +937,33 @@ internal data class CrdtTreeNode private constructor(
     /**
      * Checks if node is able to delete.
      */
-    fun canDelete(executedAt: TimeTicket, maxCreatedAt: TimeTicket): Boolean {
-        return createdAt <= maxCreatedAt && (removedAt == null || removedAt < executedAt)
+    fun canDelete(
+        executedAt: TimeTicket,
+        maxCreatedAt: TimeTicket?,
+        clientLamportAtChange: Long,
+    ): Boolean {
+        val nodeExisted = if (maxCreatedAt != null) {
+            createdAt <= maxCreatedAt
+        } else {
+            createdAt.lamport <= clientLamportAtChange
+        }
+        return nodeExisted && (removedAt == null || executedAt > removedAt)
     }
 
-    fun canStyle(executedAt: TimeTicket, maxCreatedAt: TimeTicket): Boolean {
+    fun canStyle(
+        executedAt: TimeTicket,
+        maxCreatedAt: TimeTicket?,
+        clientLamportAtChange: Long,
+    ): Boolean {
         if (isText) {
             return false
         }
-        return createdAt <= maxCreatedAt && removedAt < executedAt
+        val nodeExisted = if (maxCreatedAt != null) {
+            createdAt <= maxCreatedAt
+        } else {
+            createdAt.lamport <= clientLamportAtChange
+        }
+        return nodeExisted && (removedAt == null || executedAt > removedAt)
     }
 
     override fun delete(node: RhtNode) {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
@@ -4,6 +4,7 @@ import dev.yorkie.document.crdt.CrdtArray
 import dev.yorkie.document.crdt.CrdtElement
 import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.document.time.VersionVector
 import dev.yorkie.util.Logger.Companion.logError
 
 /**
@@ -25,7 +26,7 @@ internal data class AddOperation(
     /**
      * Executes this [AddOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot): List<OperationInfo> {
+    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtArray) {
             val copiedValue = value.deepCopy()

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/EditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/EditOperation.kt
@@ -7,6 +7,7 @@ import dev.yorkie.document.crdt.RgaTreeSplitPosRange
 import dev.yorkie.document.crdt.TextWithAttributes
 import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.document.time.VersionVector
 import dev.yorkie.util.Logger.Companion.logError
 
 /**
@@ -28,7 +29,7 @@ internal data class EditOperation(
     override val effectedCreatedAt: TimeTicket
         get() = parentCreatedAt
 
-    override fun execute(root: CrdtRoot): List<OperationInfo> {
+    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtText) {
             val result = parentObject.edit(
@@ -37,6 +38,7 @@ internal data class EditOperation(
                 executedAt,
                 attributes,
                 maxCreatedAtMapByActor,
+                versionVector,
             )
             result.gcPairs.forEach(root::registerGCPair)
             result.textChanges.map { (_, _, from, to, content, attributes) ->

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/IncreaseOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/IncreaseOperation.kt
@@ -6,6 +6,7 @@ import dev.yorkie.document.crdt.CrdtPrimitive
 import dev.yorkie.document.crdt.CrdtPrimitive.Type
 import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.document.time.VersionVector
 import dev.yorkie.util.Logger.Companion.logError
 
 /**
@@ -27,7 +28,7 @@ internal data class IncreaseOperation(
     /**
      * Executes this [IncreaseOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot): List<OperationInfo> {
+    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtCounter) {
             val copiedValue = value.deepCopy() as CrdtPrimitive

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
@@ -3,6 +3,7 @@ package dev.yorkie.document.operation
 import dev.yorkie.document.crdt.CrdtArray
 import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.document.time.VersionVector
 import dev.yorkie.util.Logger.Companion.logError
 
 /**
@@ -24,7 +25,7 @@ internal data class MoveOperation(
     /**
      * Executes this [MoveOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot): List<OperationInfo> {
+    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtArray) {
             val previousIndex = parentObject.subPathOf(createdAt).toInt()

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/Operation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/Operation.kt
@@ -3,6 +3,7 @@ package dev.yorkie.document.operation
 import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.document.time.VersionVector
 
 /**
  * Represents an operation to be executed on a document.
@@ -22,7 +23,7 @@ internal abstract class Operation {
     /**
      * Executes this [Operation] on the given [root].
      */
-    abstract fun execute(root: CrdtRoot): List<OperationInfo>
+    abstract fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo>
 
     /**
      * Sets the given [ActorID] to this [Operation].

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/Operation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/Operation.kt
@@ -23,7 +23,7 @@ internal abstract class Operation {
     /**
      * Executes this [Operation] on the given [root].
      */
-    abstract fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo>
+    abstract fun execute(root: CrdtRoot, versionVector: VersionVector? = null): List<OperationInfo>
 
     /**
      * Sets the given [ActorID] to this [Operation].

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/RemoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/RemoveOperation.kt
@@ -4,6 +4,7 @@ import dev.yorkie.document.crdt.CrdtArray
 import dev.yorkie.document.crdt.CrdtContainer
 import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.document.time.VersionVector
 import dev.yorkie.util.Logger.Companion.logError
 
 /**
@@ -24,7 +25,7 @@ internal data class RemoveOperation(
     /**
      * Executes this [RemoveOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot): List<OperationInfo> {
+    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtContainer) {
             val key = parentObject.subPathOf(createdAt)

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
@@ -4,6 +4,7 @@ import dev.yorkie.document.crdt.CrdtElement
 import dev.yorkie.document.crdt.CrdtObject
 import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.document.time.VersionVector
 import dev.yorkie.util.Logger.Companion.logError
 
 /**
@@ -26,7 +27,7 @@ internal data class SetOperation(
     /**
      * Executes this [SetOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot): List<OperationInfo> {
+    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtObject) {
             val copiedValue = value.deepCopy()

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt
@@ -6,6 +6,7 @@ import dev.yorkie.document.crdt.RgaTreeSplitPos
 import dev.yorkie.document.crdt.RgaTreeSplitPosRange
 import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.document.time.VersionVector
 import dev.yorkie.util.Logger.Companion.logError
 
 internal data class StyleOperation(
@@ -20,7 +21,7 @@ internal data class StyleOperation(
     override val effectedCreatedAt: TimeTicket
         get() = parentCreatedAt
 
-    override fun execute(root: CrdtRoot): List<OperationInfo> {
+    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtText) {
             val changes = parentObject.style(
@@ -28,6 +29,7 @@ internal data class StyleOperation(
                 attributes,
                 executedAt,
                 maxCreatedAtMapByActor,
+                versionVector,
             ).textChanges
             changes.map {
                 OperationInfo.StyleOpInfo(

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
@@ -7,6 +7,7 @@ import dev.yorkie.document.crdt.CrdtTreePos
 import dev.yorkie.document.crdt.TreeNode
 import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.document.time.VersionVector
 import dev.yorkie.util.Logger.Companion.logError
 
 /**
@@ -23,7 +24,7 @@ internal data class TreeEditOperation(
 ) : Operation() {
     override val effectedCreatedAt = parentCreatedAt
 
-    override fun execute(root: CrdtRoot): List<OperationInfo> {
+    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
         val tree = root.findByCreatedAt(parentCreatedAt)
         if (tree == null) {
             logError(TAG, "fail to find $parentCreatedAt")
@@ -47,6 +48,7 @@ internal data class TreeEditOperation(
                 editedAt,
                 issueTimeTicket(editedAt),
                 maxCreatedAtMapByActor,
+                versionVector
             )
         gcPairs.forEach(root::registerGCPair)
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeStyleOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeStyleOperation.kt
@@ -6,6 +6,7 @@ import dev.yorkie.document.crdt.CrdtTreePos
 import dev.yorkie.document.operation.OperationInfo.TreeStyleOpInfo
 import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.document.time.VersionVector
 import dev.yorkie.util.Logger.Companion.logError
 
 /**
@@ -22,7 +23,7 @@ internal data class TreeStyleOperation(
 ) : Operation() {
     override val effectedCreatedAt = parentCreatedAt
 
-    override fun execute(root: CrdtRoot): List<OperationInfo> {
+    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
         val tree = root.findByCreatedAt(parentCreatedAt)
         if (tree == null) {
             logError(TAG, "fail to find $parentCreatedAt")
@@ -40,6 +41,7 @@ internal data class TreeStyleOperation(
                     attributes,
                     executedAt,
                     maxCreatedAtMapByActor,
+                    versionVector
                 )
                 gcPairs.forEach(root::registerGCPair)
                 changes.map {
@@ -60,6 +62,7 @@ internal data class TreeStyleOperation(
                     attributesToRemove,
                     executedAt,
                     maxCreatedAtMapByActor,
+                    versionVector
                 )
                 gcPairs.forEach(root::registerGCPair)
                 changes.map {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/time/VersionVector.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/time/VersionVector.kt
@@ -84,6 +84,13 @@ public data class VersionVector(
     fun deepCopy(): VersionVector = VersionVector(vectorMap.toMutableMap())
 
     /**
+     * `unset` removes the version for the given actor from the VersionVector.
+     */
+    fun unset(actorID: String) {
+        vectorMap.remove(actorID)
+    }
+
+    /**
      * Allows iteration over the `VersionVector`.
      */
     operator fun iterator(): Iterator<Map.Entry<String, Long>> = vectorMap.entries.iterator()

--- a/yorkie/src/main/kotlin/dev/yorkie/util/VersionVectorUtil.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/VersionVectorUtil.kt
@@ -1,0 +1,22 @@
+package dev.yorkie.util
+
+import dev.yorkie.document.time.VersionVector
+
+fun versionVectorHelper(
+    versionVector: VersionVector,
+    actorData: Array<Pair<String, Long>>,
+): Boolean {
+    if (versionVector.size() != actorData.size) {
+        return false
+    }
+
+    for ((actor, lamport) in actorData) {
+        val vvLamport = versionVector.get(actor) ?: return false
+
+        if (vvLamport != lamport) {
+            return false
+        }
+    }
+
+    return true
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
1. 0.5.6 
- [x] Add keepalive option in client.deactivate : https://github.com/yorkie-team/yorkie-js-sdk/pull/928
- [ ] Improve GC for deactivated client's nodes : https://github.com/yorkie-team/yorkie-js-sdk/pull/926
  - This PR was reverted in 0.5.7

2. 0.5.7
- [ ] Enhance webhook tests and error handling for authentication : https://github.com/yorkie-team/yorkie-js-sdk/pull/930
- [x] Preserve Detached Client's Lamport in Version Vector : https://github.com/yorkie-team/yorkie-js-sdk/pull/931
  - This PR requires no implementation as it only includes a rollback commit.
- [x] Replace maxCreatedAtMap with version vector for causal-concurrent operations : https://github.com/yorkie-team/yorkie-js-sdk/pull/932
- [x]Improve Version Vector Handling for Legacy SDK and Snapshots : https://github.com/yorkie-team/yorkie-js-sdk/pull/933

#### Any background context you want to provide?
.

#### What are the relevant tickets?
- https://github.com/yorkie-team/yorkie-android-sdk/pull/217

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
