### PR TITLE
[RTCOLLABPLATFORM-308] Change Mockito to MockK

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,6 @@ androidx-test-runner = { group = "androidx.test", name = "runner", version = "1.
 androidx-test-junit = { group = "androidx.test.ext", name = "junit-ktx", version = "1.2.1" }
 androidx-test-monitor = { group = "androidx.test", name = "monitor", version = "1.7.2" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version = "3.6.1" }
-mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version = "4.1.0" }
 
 [bundles]
 rpc = ["okhttp", "connect-kotlin-okhttp", "connect-kotlin-google-javalite-ext"]

--- a/yorkie/build.gradle.kts
+++ b/yorkie/build.gradle.kts
@@ -173,7 +173,6 @@ dependencies {
     implementation(libs.apache.commons.collections)
 
     testImplementation(libs.junit)
-    testImplementation(libs.mockito.kotlin)
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.gson)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- Since our project is pure Kotlin I think we should change from Mockito to MockK for better mocking support
- Compare Mockito and MockK

Feature | MockK | Mockito
-- | -- | --
Top-level function mocking | ✅ `mockkStatic()` | ⚠️ Very limited
Extension function mocking | ✅ Yes | ❌ Not supported
Coroutine support | ✅ `coEvery`, `coVerify` | ⚠️ Use `runBlocking` manually
DSL-like syntax | ✅ idiomatic Kotlin | ⚠️ Java-style APIs

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://jira.navercorp.com/browse/RTCOLLABPLATFORM-308

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated test code to use MockK instead of Mockito for mocking and verification in tests.
- **Chores**
  - Removed the Mockito Kotlin dependency from the project configuration and build scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->