### PR TITLE
Sync android-sdk with js-sdk: Implement updates to v0.6.1

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,6 +15,8 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: gradle
+      - name: Set Yorkie Server Url
+        run: echo YORKIE_SERVER_URL="https://api.yorkie.dev" > ./local.properties
       - run: ./gradlew dokkaHtml --no-configuration-cache
       - uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ jobs:
           java-version: "17"
           distribution: "temurin"
           cache: gradle
+      - name: Set Yorkie Server Url
+        run: echo YORKIE_SERVER_URL="https://api.yorkie.dev" > ./local.properties
       - run: chmod +x gradlew
       - uses: gradle/gradle-build-action@v2
         with:

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -22,6 +22,7 @@ import dev.yorkie.core.MockYorkieService.Companion.TEST_ACTOR_ID
 import dev.yorkie.core.MockYorkieService.Companion.TEST_KEY
 import dev.yorkie.core.MockYorkieService.Companion.WATCH_SYNC_ERROR_DOCUMENT_KEY
 import dev.yorkie.document.Document
+import dev.yorkie.document.Document.DocStatus
 import dev.yorkie.document.Document.Event.StreamConnectionChanged
 import dev.yorkie.document.Document.Event.SyncStatusChanged
 import dev.yorkie.document.Document.Key
@@ -400,6 +401,47 @@ class ClientTest {
             document.close()
             client.close()
         }
+    }
+
+    @Test
+    fun `detachAsync with keepalive true should work even after client close`() = runTest {
+        val service = spyk(MockYorkieService())
+        val client = Client(
+            options = Client.Options(
+                key = TEST_KEY,
+                apiKey = TEST_KEY,
+            ),
+            unaryClient = OkHttpClient(),
+            streamClient = OkHttpClient(),
+            dispatcher = createSingleThreadDispatcher("Client Test"),
+            host = "0.0.0.0",
+        )
+        client.service = service
+
+        val document = Document(Key(NORMAL_DOCUMENT_KEY))
+
+        // Activate and attach document
+        client.activateAsync().await()
+        client.attachAsync(document, syncMode = Manual).await()
+        assertEquals(DocStatus.Attached, document.status)
+
+        // Start detach with keepalive = true
+        val detachDeferred = async {
+            client.detachAsync(document, keepalive = true).await()
+        }
+
+        // Add a small delay to ensure the detach has started
+        delay(10)
+
+        // Close the client while detach might still be in progress
+        client.close()
+
+        // Wait for detach to complete
+        val result = detachDeferred.await()
+
+        // Verify that detach completed successfully despite client being closed
+        assertTrue(result.isSuccess)
+        assertEquals(DocStatus.Detached, document.status)
     }
 
     private fun assertIsTestActorID(clientId: String) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- [ ] Refactor package names to include scope by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/944
- [ ] Add @yorkie-js/react package with hooks for SDK integration by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/945
- [ ] Add YorkieProvider, DocumentProvider and suspense hooks by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/946
- [ ] Refactor import paths to use '@yorkie-js/sdk' by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/947
- [x] Add keepalive option when detaching a document by @emplam27 in https://github.com/yorkie-team/yorkie-js-sdk/pull/948
- [ ] Support React 18 and guard hasDocument check by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/950

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://jira.navercorp.com/browse/RTCOLLABPLATFORM-315

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detaching documents asynchronously with an optional keepalive mode, allowing detachment to complete even if the client is closed during the process.

* **Tests**
  * Introduced a new test to verify that detaching with keepalive enabled works correctly, even after the client is closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->