### PR TITLE
Sync android-sdk with js-sdk: Implement updates to v0.6.8

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
@@ -181,7 +181,7 @@ internal fun PBValueType.toPrimitiveType(): CrdtPrimitive.Type {
 
 internal fun PBCounter.toCrdtCounter(): CrdtCounter {
     val type = type.toCounterType()
-    return if (type == CounterType.IntegerCnt) {
+    return if (type == CounterType.Int) {
         CrdtCounter(
             value = value.toByteArray().asCounterValue(type).toInt(),
             createdAt = createdAt.toTimeTicket(),
@@ -200,8 +200,8 @@ internal fun PBCounter.toCrdtCounter(): CrdtCounter {
 
 internal fun PBValueType.toCounterType(): CounterType {
     return when (this) {
-        PBValueType.VALUE_TYPE_INTEGER_CNT -> CounterType.IntegerCnt
-        PBValueType.VALUE_TYPE_LONG_CNT -> CounterType.LongCnt
+        PBValueType.VALUE_TYPE_INTEGER_CNT -> CounterType.Int
+        PBValueType.VALUE_TYPE_LONG_CNT -> CounterType.Long
         else -> throw YorkieException(ErrUnimplemented, "unimplemented value type : $this")
     }
 }
@@ -493,8 +493,8 @@ internal fun CrdtCounter.toPBCounter(): PBJsonElement {
 
 internal fun CounterType.toPBCounterType(): PBValueType {
     return when (this) {
-        CounterType.IntegerCnt -> PBValueType.VALUE_TYPE_INTEGER_CNT
-        CounterType.LongCnt -> PBValueType.VALUE_TYPE_LONG_CNT
+        CounterType.Int -> PBValueType.VALUE_TYPE_INTEGER_CNT
+        CounterType.Long -> PBValueType.VALUE_TYPE_LONG_CNT
     }
 }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -29,6 +29,7 @@ import dev.yorkie.document.presence.Presences.Companion.asPresences
 import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
 import dev.yorkie.document.time.VersionVector
+import dev.yorkie.util.DocSize
 import dev.yorkie.util.Logger.Companion.logDebug
 import dev.yorkie.util.OperationResult
 import dev.yorkie.util.YorkieException
@@ -482,6 +483,13 @@ public class Document(
         val clone = ensureClone()
         val context = ChangeContext(changeID.next(), clone.root)
         JsonObject(context, clone.root.rootObject)
+    }
+
+    /**
+     * `getDocSize` returns the size of this document.
+     */
+    public fun getDocSize(): DocSize {
+        return root.docSize
     }
 
     /**

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtArray.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtArray.kt
@@ -1,6 +1,7 @@
 package dev.yorkie.document.crdt
 
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.util.DataSize
 
 /**
  * [CrdtArray] represents an array data type containing [CrdtElement]s.
@@ -134,4 +135,12 @@ internal data class CrdtArray(
             }
         }
     }
+
+    /**
+     * `getDataSize` returns the data usage of this element.
+     */
+    override fun getDataSize(): DataSize = DataSize(
+        data = 0,
+        meta = getMetaUsage(),
+    )
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtElement.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtElement.kt
@@ -2,7 +2,9 @@ package dev.yorkie.document.crdt
 
 import dev.yorkie.document.json.JsonStringifier.toJsonString
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.document.time.TimeTicket.Companion.TIME_TICKET_SIZE
 import dev.yorkie.document.time.TimeTicket.Companion.compareTo
+import dev.yorkie.util.DataSize
 
 /**
  * [CrdtElement] represents an element that has [TimeTicket]s.
@@ -51,5 +53,23 @@ internal abstract class CrdtElement {
         return toJsonString()
     }
 
+    /**
+     * `getMetaUsage` returns the meta usage of this element.
+     */
+    fun getMetaUsage(): Int {
+        var meta = TIME_TICKET_SIZE
+
+        if (_movedAt != null) {
+            meta += TIME_TICKET_SIZE
+        }
+
+        if (_removedAt != null) {
+            meta += TIME_TICKET_SIZE
+        }
+
+        return meta
+    }
+
     abstract fun deepCopy(): CrdtElement
+    abstract fun getDataSize(): DataSize
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtObject.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtObject.kt
@@ -1,6 +1,7 @@
 package dev.yorkie.document.crdt
 
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.util.DataSize
 
 /**
  * [CrdtObject] represents an object data type, but unlike regular JSON, it has
@@ -81,6 +82,11 @@ internal data class CrdtObject(
         }
         return copy(rht = rhtClone)
     }
+
+    override fun getDataSize(): DataSize = DataSize(
+        data = 0,
+        meta = getMetaUsage(),
+    )
 
     /**
      * Returns the descendants of this object by traversing.

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtPrimitive.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtPrimitive.kt
@@ -4,6 +4,7 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.kotlin.toByteString
 import com.google.protobuf.kotlin.toByteStringUtf8
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.util.DataSize
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.Date
@@ -51,6 +52,11 @@ internal data class CrdtPrimitive private constructor(
         }
     }
 
+    override fun getDataSize(): DataSize = DataSize(
+        data = getValueSize(),
+        meta = getMetaUsage(),
+    )
+
     fun toBytes(): ByteString {
         return when (type) {
             Type.Null -> ByteString.EMPTY
@@ -87,6 +93,30 @@ internal data class CrdtPrimitive private constructor(
                     .putLong((value as Date).time)
                     .array()
                     .toByteString()
+            }
+        }
+    }
+
+    /**
+     * `getValueSize` returns the size of the value. The size is similar to
+     * the size of primitives in JavaScript.
+     */
+    private fun getValueSize(): Int {
+        return when (type) {
+            Type.Null, Type.Long, Type.Double, Type.Date -> {
+                8
+            }
+
+            Type.Boolean, Type.Integer -> {
+                4
+            }
+
+            Type.String -> {
+                (value as String).length * 2
+            }
+
+            Type.Bytes -> {
+                (value as ByteString).size()
             }
         }
     }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtText.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtText.kt
@@ -6,6 +6,7 @@ import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
 import dev.yorkie.document.time.TimeTicket.Companion.MAX_LAMPORT
 import dev.yorkie.document.time.VersionVector
+import dev.yorkie.util.DataSize
 import dev.yorkie.util.SplayTreeSet
 import java.util.TreeMap
 
@@ -177,6 +178,26 @@ internal data class CrdtText(
 
     override fun deepCopy(): CrdtElement {
         return copy(rgaTreeSplit = rgaTreeSplit.deepCopy())
+    }
+
+    override fun getDataSize(): DataSize {
+        var data = 0
+        var meta = 0
+
+        for (node in rgaTreeSplit) {
+            if (node.isRemoved) {
+                continue
+            }
+
+            val dataSize = node.dataSize
+            data += dataSize.data
+            meta += dataSize.meta
+        }
+
+        return DataSize(
+            data = data,
+            meta = meta + getMetaUsage(),
+        )
     }
 
     override fun toString(): String {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/GC.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/GC.kt
@@ -1,6 +1,7 @@
 package dev.yorkie.document.crdt
 
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.util.DataSize
 
 /**
  * [GCPair] is a structure that represents a pair of parent and child for garbage
@@ -26,6 +27,7 @@ internal interface GCParent<T : GCChild> {
  */
 internal sealed interface GCChild {
     val removedAt: TimeTicket?
+    val dataSize: DataSize
 }
 
 internal sealed interface GCCrdtElement {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeSplit.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeSplit.kt
@@ -8,8 +8,10 @@ import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
 import dev.yorkie.document.time.TimeTicket.Companion.MAX_LAMPORT
+import dev.yorkie.document.time.TimeTicket.Companion.TIME_TICKET_SIZE
 import dev.yorkie.document.time.TimeTicket.Companion.compareTo
 import dev.yorkie.document.time.VersionVector
+import dev.yorkie.util.DataSize
 import dev.yorkie.util.SplayTreeSet
 import java.util.TreeMap
 
@@ -438,6 +440,11 @@ internal class RgaTreeSplit<T : RgaTreeSplitValue<T>> :
 
             override fun deepCopy(): InitialNodeValue = this
 
+            override fun getDataSize(): DataSize = DataSize(
+                data = 0,
+                meta = 0,
+            )
+
             override val length: Int = 0
 
             override fun get(index: Int): Char = throw IndexOutOfBoundsException()
@@ -450,6 +457,8 @@ internal class RgaTreeSplit<T : RgaTreeSplitValue<T>> :
 internal interface RgaTreeSplitValue<T : RgaTreeSplitValue<T>> : CharSequence {
 
     fun deepCopy(): T
+
+    fun getDataSize(): DataSize
 }
 
 internal data class RgaTreeSplitNode<T : RgaTreeSplitValue<T>>(
@@ -486,6 +495,20 @@ internal data class RgaTreeSplitNode<T : RgaTreeSplitValue<T>>(
 
     override val removedAt: TimeTicket?
         get() = _removedAt
+
+    override val dataSize: DataSize
+        get() {
+            val dataSize = _value.getDataSize()
+            var meta = TIME_TICKET_SIZE
+            if (_removedAt != null) {
+                meta += TIME_TICKET_SIZE
+            }
+
+            return DataSize(
+                data = dataSize.data,
+                meta = meta,
+            )
+        }
 
     val value
         get() = _value

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/Rht.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/Rht.kt
@@ -2,7 +2,9 @@ package dev.yorkie.document.crdt
 
 import dev.yorkie.document.json.escapeString
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.document.time.TimeTicket.Companion.TIME_TICKET_SIZE
 import dev.yorkie.document.time.TimeTicket.Companion.compareTo
+import dev.yorkie.util.DataSize
 
 /**
  * [Rht] is a replicated hash table by creation time.
@@ -154,6 +156,12 @@ data class RhtNode(
 ) : GCChild {
 
     override val removedAt: TimeTicket? = executedAt.takeIf { isRemoved }
+
+    override val dataSize: DataSize
+        get() = DataSize(
+            data = (key.length + value.length) * 2,
+            meta = TIME_TICKET_SIZE,
+        )
 }
 
 data class RhtSetResult(val prev: RhtNode?, val new: RhtNode?)

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TextInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TextInfo.kt
@@ -3,6 +3,7 @@ package dev.yorkie.document.crdt
 import dev.yorkie.document.json.escapeString
 import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.util.DataSize
 
 internal data class TextChange(
     val type: TextChangeType,
@@ -43,6 +44,22 @@ internal data class TextValue(
 
     override fun deepCopy(): TextValue {
         return copy(_attributes = _attributes.deepCopy())
+    }
+
+    override fun getDataSize(): DataSize {
+        var data = content.length * 2
+        var meta = 0
+
+        for (node in _attributes) {
+            val dataSize = node.dataSize
+            data += dataSize.data
+            meta += dataSize.meta
+        }
+
+        return DataSize(
+            data = data,
+            meta = meta,
+        )
     }
 
     override fun subSequence(startIndex: Int, endIndex: Int): CharSequence {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/time/TimeTicket.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/time/TimeTicket.kt
@@ -33,6 +33,12 @@ public data class TimeTicket(
         internal const val INITIAL_DELIMITER = 0u
         internal const val MAX_DELIMITER = UInt.MAX_VALUE
 
+        /**
+         * TimeTicketSize is the size of the ticket in bytes.
+         * lamport(int64) + delimiter(uint32) + actorID(12 bytes)
+         */
+        internal const val TIME_TICKET_SIZE = 8 + 4 + 12
+
         public const val MAX_LAMPORT = Long.MAX_VALUE
 
         private val NullTimeTicket = TimeTicket(

--- a/yorkie/src/main/kotlin/dev/yorkie/util/Resource.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/Resource.kt
@@ -1,0 +1,11 @@
+package dev.yorkie.util
+
+data class DocSize(
+    val live: DataSize,
+    val gc: DataSize,
+)
+
+data class DataSize(
+    val data: Int,
+    val meta: Int,
+)

--- a/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
@@ -46,6 +46,7 @@ import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
 import dev.yorkie.document.time.TimeTicket.Companion.MaxTimeTicket
 import dev.yorkie.document.time.VersionVector
+import dev.yorkie.util.DataSize
 import dev.yorkie.util.IndexTreeNode.Companion.DEFAULT_ROOT_TYPE
 import dev.yorkie.util.YorkieException
 import dev.yorkie.util.YorkieException.Code.ErrUnimplemented
@@ -499,5 +500,10 @@ class ConverterTest {
         override var _removedAt: TimeTicket? = null,
     ) : CrdtElement() {
         override fun deepCopy() = this
+
+        override fun getDataSize(): DataSize = DataSize(
+            data = 0,
+            meta = 0,
+        )
     }
 }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/DocumentSizeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/DocumentSizeTest.kt
@@ -1,0 +1,586 @@
+package dev.yorkie.document
+
+import dev.yorkie.document.json.JsonArray
+import dev.yorkie.document.json.JsonObject
+import dev.yorkie.document.json.JsonText
+import dev.yorkie.document.json.JsonTree
+import dev.yorkie.document.json.TreeBuilder.element
+import dev.yorkie.document.json.TreeBuilder.text
+import dev.yorkie.util.DataSize
+import java.util.Date
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+
+class DocumentSizeTest {
+    private lateinit var document: Document
+
+    @Before
+    fun setup() {
+        document = Document(Document.Key(""))
+    }
+
+    @Test
+    fun `should return correct doc size with primitive type`() = runTest {
+        document.updateAsync { root, _ ->
+            root["k0"] = null
+        }.await()
+        // Root (primitive) + Primitive (null)
+        assertEquals(
+            expected = DataSize(
+                data = 8,
+                meta = 48,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            root["k1"] = true
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 12,
+                meta = 72,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            root["k2"] = 102020
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 16,
+                meta = 96,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            root["k3"] = 102020L
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 24,
+                meta = 120,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            root["k4"] = 1.79
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 32,
+                meta = 144,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            root["k5"] = "40"
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 36,
+                meta = 168,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            root["k6"] = byteArrayOf(65, 66)
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 38,
+                meta = 192,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            root["k7"] = Date()
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 46,
+                meta = 216,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            root.remove("k0")
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 38,
+                meta = 192,
+            ),
+            actual = document.getDocSize().live,
+        )
+        assertEquals(
+            expected = DataSize(
+                data = 8,
+                meta = 48,
+            ),
+            actual = document.getDocSize().gc,
+        )
+
+        document.updateAsync { root, _ ->
+            root.remove("k1")
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 34,
+                meta = 168,
+            ),
+            actual = document.getDocSize().live,
+        )
+        assertEquals(
+            expected = DataSize(
+                data = 12,
+                meta = 96,
+            ),
+            actual = document.getDocSize().gc,
+        )
+
+        document.updateAsync { root, _ ->
+            root.remove("k2")
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 30,
+                meta = 144,
+            ),
+            actual = document.getDocSize().live,
+        )
+        assertEquals(
+            expected = DataSize(
+                data = 16,
+                meta = 144,
+            ),
+            actual = document.getDocSize().gc,
+        )
+
+        document.updateAsync { root, _ ->
+            root.remove("k3")
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 22,
+                meta = 120,
+            ),
+            actual = document.getDocSize().live,
+        )
+        assertEquals(
+            expected = DataSize(
+                data = 24,
+                meta = 192,
+            ),
+            actual = document.getDocSize().gc,
+        )
+
+        document.updateAsync { root, _ ->
+            root.remove("k4")
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 14,
+                meta = 96,
+            ),
+            actual = document.getDocSize().live,
+        )
+        assertEquals(
+            expected = DataSize(
+                data = 32,
+                meta = 240,
+            ),
+            actual = document.getDocSize().gc,
+        )
+
+        document.updateAsync { root, _ ->
+            root.remove("k5")
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 10,
+                meta = 72,
+            ),
+            actual = document.getDocSize().live,
+        )
+        assertEquals(
+            expected = DataSize(
+                data = 36,
+                meta = 288,
+            ),
+            actual = document.getDocSize().gc,
+        )
+
+        document.updateAsync { root, _ ->
+            root.remove("k6")
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 8,
+                meta = 48,
+            ),
+            actual = document.getDocSize().live,
+        )
+        assertEquals(
+            expected = DataSize(
+                data = 38,
+                meta = 336,
+            ),
+            actual = document.getDocSize().gc,
+        )
+
+        document.updateAsync { root, _ ->
+            root.remove("k7")
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 0,
+                meta = 24,
+            ),
+            actual = document.getDocSize().live,
+        )
+        assertEquals(
+            expected = DataSize(
+                data = 46,
+                meta = 384,
+            ),
+            actual = document.getDocSize().gc,
+        )
+    }
+
+    @Test
+    fun `should return correct doc size with array type`() = runTest {
+        document.updateAsync { root, _ ->
+            val array = root.setNewArray("arr")
+            array.put("a")
+        }.await()
+
+        assertEquals(
+            expected = DataSize(
+                data = 2,
+                meta = 72,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            val array = root.getAs<JsonArray>("arr")
+            array.removeAt(0)
+        }.await()
+
+        assertEquals(
+            expected = DataSize(
+                data = 0,
+                meta = 48,
+            ),
+            actual = document.getDocSize().live,
+        )
+        assertEquals(
+            expected = DataSize(
+                data = 2,
+                meta = 48,
+            ),
+            actual = document.getDocSize().gc,
+        )
+    }
+
+    @Test
+    fun `should return correct doc size with object type`() = runTest {
+        document.updateAsync { root, _ ->
+            val obj = root.setNewObject("obj")
+            obj["k0"] = 1
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 4,
+                meta = 72,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            val obj = root.getAs<JsonObject>("obj")
+            obj.remove("k0")
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 0,
+                meta = 48,
+            ),
+            actual = document.getDocSize().live,
+        )
+        assertEquals(
+            expected = DataSize(
+                data = 4,
+                meta = 48,
+            ),
+            actual = document.getDocSize().gc,
+        )
+    }
+
+    @Test
+    fun `should return correct doc size with counter type`() = runTest {
+        document.updateAsync { root, _ ->
+            root.setNewCounter("counter", 0)
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 4,
+                meta = 48,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            root.remove("counter")
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 0,
+                meta = 24,
+            ),
+            actual = document.getDocSize().live,
+        )
+        assertEquals(
+            expected = DataSize(
+                data = 4,
+                meta = 48,
+            ),
+            actual = document.getDocSize().gc,
+        )
+    }
+
+    @Test
+    fun `should return correct doc size with text type`() = runTest {
+        document.updateAsync { root, _ ->
+            val text = root.setNewText("text")
+            text.edit(0, 0, "helloworld")
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 20,
+                meta = 72,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            val text = root.getAs<JsonText>("text")
+            text.edit(5, 5, " ")
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 22,
+                meta = 120,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            val text = root.getAs<JsonText>("text")
+            text.edit(6, 11, "")
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 12,
+                meta = 96,
+            ),
+            actual = document.getDocSize().live,
+        )
+        assertEquals(
+            expected = DataSize(
+                data = 10,
+                meta = 48,
+            ),
+            actual = document.getDocSize().gc,
+        )
+
+        document.updateAsync { root, _ ->
+            val text = root.getAs<JsonText>("text")
+            text.style(0, 5, mapOf("bold" to "true"))
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 28,
+                meta = 96,
+            ),
+            actual = document.getDocSize().live,
+        )
+        assertEquals(
+            expected = DataSize(
+                data = 10,
+                meta = 48,
+            ),
+            actual = document.getDocSize().gc,
+        )
+    }
+
+    @Test
+    fun `should return correct doc size with tree type`() = runTest {
+        document.updateAsync { root, _ ->
+            root.setNewTree(
+                key = "tree",
+                initialRoot = element("doc") {
+                    element("p")
+                },
+            )
+            assertEquals(
+                expected = root.getAs<JsonTree>("tree").toXml(),
+                actual = "<doc><p></p></doc>",
+            )
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 0,
+                meta = 96,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            val tree = root.getAs<JsonTree>("tree")
+            tree.edit(
+                fromIndex = 1,
+                toIndex = 1,
+                text {
+                    "helloworld"
+                },
+            )
+            assertEquals(
+                expected = root.getAs<JsonTree>("tree").toXml(),
+                actual = "<doc><p>helloworld</p></doc>",
+            )
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 20,
+                meta = 120,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            val tree = root.getAs<JsonTree>("tree")
+            tree.edit(
+                fromIndex = 1,
+                toIndex = 7,
+                text {
+                    "w"
+                },
+            )
+            assertEquals(
+                expected = root.getAs<JsonTree>("tree").toXml(),
+                actual = "<doc><p>world</p></doc>",
+            )
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 10,
+                meta = 144,
+            ),
+            actual = document.getDocSize().live,
+        )
+        assertEquals(
+            expected = DataSize(
+                data = 12,
+                meta = 48,
+            ),
+            actual = document.getDocSize().gc,
+        )
+
+        document.updateAsync { root, _ ->
+            val tree = root.getAs<JsonTree>("tree")
+            tree.edit(
+                fromIndex = 7,
+                toIndex = 7,
+                element("p") {
+                    text {
+                        "abcd"
+                    }
+                },
+            )
+            assertEquals(
+                expected = root.getAs<JsonTree>("tree").toXml(),
+                actual = "<doc><p>world</p><p>abcd</p></doc>",
+            )
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 18,
+                meta = 192,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            val tree = root.getAs<JsonTree>("tree")
+            tree.edit(7, 13)
+            assertEquals(
+                expected = root.getAs<JsonTree>("tree").toXml(),
+                actual = "<doc><p>world</p></doc>",
+            )
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 10,
+                meta = 144,
+            ),
+            actual = document.getDocSize().live,
+        )
+        assertEquals(
+            expected = DataSize(
+                data = 20,
+                meta = 144,
+            ),
+            actual = document.getDocSize().gc,
+        )
+
+        document.updateAsync { root, _ ->
+            val tree = root.getAs<JsonTree>("tree")
+            tree.style(0, 7, mapOf("bold" to "true"))
+            assertEquals(
+                expected = root.getAs<JsonTree>("tree").toXml(),
+                actual = "<doc><p bold=\"true\">world</p></doc>",
+            )
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 26,
+                meta = 168,
+            ),
+            actual = document.getDocSize().live,
+        )
+
+        document.updateAsync { root, _ ->
+            val tree = root.getAs<JsonTree>("tree")
+            tree.removeStyle(0, 7, listOf("bold"))
+            assertEquals(
+                expected = root.getAs<JsonTree>("tree").toXml(),
+                actual = "<doc><p>world</p></doc>",
+            )
+        }.await()
+        assertEquals(
+            expected = DataSize(
+                data = 10,
+                meta = 144,
+            ),
+            actual = document.getDocSize().live,
+        )
+        assertEquals(
+            expected = DataSize(
+                data = 36,
+                meta = 168,
+            ),
+            actual = document.getDocSize().gc,
+        )
+    }
+}

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtCounterTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtCounterTest.kt
@@ -81,7 +81,7 @@ class CrdtCounterTest {
             .order(ByteOrder.LITTLE_ENDIAN)
             .putInt(39)
             .array()
-        val intValue = intInBytes.asCounterValue(CrdtCounter.CounterType.IntegerCnt)
+        val intValue = intInBytes.asCounterValue(CrdtCounter.CounterType.Int)
         assertEquals(39, intValue)
         assertArrayEquals(intInBytes, CrdtCounter(39, InitialTimeTicket).toBytes())
 
@@ -89,7 +89,7 @@ class CrdtCounterTest {
             .order(ByteOrder.LITTLE_ENDIAN)
             .putLong(333L)
             .array()
-        val longValue = longInBytes.asCounterValue(CrdtCounter.CounterType.LongCnt)
+        val longValue = longInBytes.asCounterValue(CrdtCounter.CounterType.Long)
         assertEquals(333L, longValue)
         assertArrayEquals(longInBytes, CrdtCounter(333L, InitialTimeTicket).toBytes())
     }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonCounterTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonCounterTest.kt
@@ -46,11 +46,11 @@ class JsonCounterTest {
             val obj = root.setNewObject("k1")
             val lengthLong = obj.setNewCounter("lengthLong", 1L)
             lengthLong.increase(1000)
-            assertEquals(CounterType.IntegerCnt, lengthLong.target.type)
+            assertEquals(CounterType.Int, lengthLong.target.type)
 
             val lengthInt = obj.setNewCounter("lengthInt", 1)
             lengthInt.increase(1000L)
-            assertEquals(CounterType.LongCnt, lengthInt.target.type)
+            assertEquals(CounterType.Long, lengthInt.target.type)
         }.await()
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- [ ] Update client initialization to use rpcAddr option in examples: https://github.com/yorkie-team/yorkie-js-sdk/pull/979
- [x] Add size tracking to CRDT: https://github.com/yorkie-team/yorkie-js-sdk/pull/981
- [ ] Add document to DocumentContext: https://github.com/yorkie-team/yorkie-js-sdk/pull/983
- [ ] Apply HMR in dev mode: https://github.com/yorkie-team/yorkie-js-sdk/pull/984

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://jira.navercorp.com/browse/RTCOLLABPLATFORM-318

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to retrieve the size of a document, including both data and metadata, for live and deleted elements.
  * Introduced detailed size reporting for arrays, objects, counters, text, trees, and primitive values.
  * Size information is now accessible for advanced document structures like text and tree nodes.

* **Bug Fixes**
  * None.

* **Tests**
  * Added comprehensive tests to verify document size calculations for various data types and operations.

* **Style**
  * Renamed internal counter type labels for improved clarity (no impact on user-facing behavior).

* **Chores**
  * Introduced new internal data structures to represent document and data sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->