### PR TITLE
Sync android-sdk with js-sdk: Implement updates to v0.6.21

### DIFF
--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -1,6 +1,6 @@
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.20'
+    image: 'yorkieteam/yorkie:0.6.21'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.20'
+    image: 'yorkieteam/yorkie:0.6.21'
     container_name: 'yorkie'
     restart: always
     ports:

--- a/yorkie.rb
+++ b/yorkie.rb
@@ -1,8 +1,8 @@
 class Yorkie < Formula
   desc "Document store for collaborative applications"
   homepage "https://yorkie.dev/"
-  url "https://github.com/yorkie-team/yorkie/archive/refs/tags/v0.6.20.tar.gz"
-  sha256 "bd95b8f03f2f915a65a9a1af48c2f832703104893b90666e97a4c6cee35543af"
+  url "https://github.com/yorkie-team/yorkie/archive/refs/tags/v0.6.21.tar.gz"
+  sha256 "d67508c6bde8f948cf6f3fdaddfa9f7a710746408ec29fa41b9344a7aa7c04f7"
   license "Apache-2.0"
   head "https://github.com/yorkie-team/yorkie.git", branch: "main"
 
@@ -12,12 +12,12 @@ class Yorkie < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8cd729c17a8bf03c699e63778ea666d05d175abe9402f20e60eb23ee34f92466"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "74dc4264c37aa6ccca90b8e0f8d22aeb6db1af503468c7645aaf9133798ebcb4"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "3cc16550dac0cabff81de4b0ac056f406fe316276cc28ba384e38b8e94e3c889"
-    sha256 cellar: :any_skip_relocation, sonoma:        "177b90550d068cd3a9a611e1e2b7e0ab7ccf027a6eecda6e9c06570792ffc495"
-    sha256 cellar: :any_skip_relocation, ventura:       "ba680dc8c2155c5560bc54acd7ca8dfe5c05524e524baed82079f1444915a543"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c9f4e5472b5b7f76827e4986e28934189829fc9cba95e2824425a2026e00ccea"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5b59b336e30f5baf644699c47ca730cbc80e9fbb3c75829f5d0f664c6dd74b4e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "41a0f08761abebd16a2b78ffbe1e31349d91ce9cfe4e97ed2d934341a319dda2"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "1ed00126bde5998fd0247d6c5e9ff5d8ad0a3e1e9d9ae5af6dba580d803cb1c0"
+    sha256 cellar: :any_skip_relocation, sonoma:        "d9a350023e557a462ebea4143ed27cc1f5c33a2e1b28d6941f7263e7c1d7c5d8"
+    sha256 cellar: :any_skip_relocation, ventura:       "2ac8b59a278e9f4fe51b73d9710cf3c96ae07daec9626a00f78a4fffe0557280"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a5b26d271fd78d4e6f867050a760e49835276c98f29f008b465dcc3ed0425183"
   end
 
   depends_on "go" => :build

--- a/yorkie/src/main/kotlin/dev/yorkie/api/RuleConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/RuleConverter.kt
@@ -7,33 +7,45 @@ internal typealias PBRule = dev.yorkie.api.v1.Rule
 fun List<PBRule>.fromSchemaRules(): List<Rule> {
     return map {
         when (it.type) {
-            "string", "boolean", "integer", "double", "long", "date", "bytes", "null" -> {
+            in Rule.PrimitiveRule.Type.entries.map { it.value } -> {
                 Rule.PrimitiveRule(
                     path = it.path,
                     type = it.type,
                 )
             }
 
-            "object" -> {
+            Rule.ObjectRule.TYPE -> {
                 Rule.ObjectRule(
                     path = it.path,
-                    type = it.type,
                     properties = emptyList(),
                     optional = emptyList(),
                 )
             }
 
-            "array" -> {
+            Rule.ArrayRule.TYPE -> {
                 Rule.ArrayRule(
+                    path = it.path,
+                    items = emptyList(),
+                )
+            }
+
+            in Rule.YorkieTypeRule.Type.entries.map { it.value } -> {
+                Rule.YorkieTypeRule(
                     path = it.path,
                     type = it.type,
                 )
             }
 
-            "yorkie.Text", "yorkie.Tree", "yorkie.Counter", "yorkie.Object", "yorkie.Array" -> {
-                Rule.YorkieTypeRule(
+            Rule.EnumRule.TYPE -> {
+                Rule.EnumRule(
                     path = it.path,
-                    type = it.type,
+                    values = emptyList(),
+                )
+            }
+
+            Rule.UnionRule.TYPE -> {
+                Rule.UnionRule(
+                    path = it.path,
                 )
             }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/schema/Rule.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/schema/Rule.kt
@@ -7,22 +7,76 @@ sealed interface Rule {
     data class PrimitiveRule(
         override val path: String,
         override val type: String,
-    ) : Rule
+    ) : Rule {
+        enum class Type(val value: String) {
+            BOOLEAN("boolean"),
+            INTEGER("integer"),
+            DOUBLE("double"),
+            LONG("long"),
+            STRING("string"),
+            DATE("date"),
+            BYTES("bytes"),
+            NULL("null"),
+        }
+    }
 
     data class ObjectRule(
         override val path: String,
-        override val type: String,
+        override val type: String = TYPE,
         val properties: List<String>,
         val optional: List<String>,
-    ) : Rule
+    ) : Rule {
+        companion object {
+            const val TYPE: String = "object"
+        }
+    }
 
     data class ArrayRule(
         override val path: String,
-        override val type: String,
-    ) : Rule
+        override val type: String = TYPE,
+        val items: List<Item>,
+    ) : Rule {
+        data class Item(
+            val type: String,
+            val properties: List<String>,
+        )
+
+        companion object {
+            const val TYPE = "array"
+        }
+    }
 
     data class YorkieTypeRule(
         override val path: String,
         override val type: String,
-    ) : Rule
+    ) : Rule {
+        enum class Type(val value: String) {
+            TEXT("yorkie.Text"),
+            TREE("yorkie.Tree"),
+            COUNTER("yorkie.Counter"),
+            OBJECT("yorkie.Object"),
+            ARRAY("yorkie.Array"),
+        }
+    }
+
+    data class EnumRule(
+        override val path: String,
+        override val type: String = TYPE,
+        // TODO: because can not define condition to choose type so temporarily place Any
+        //  need to define type like in JS (string, int, bool)
+        val values: List<Any>,
+    ) : Rule {
+        companion object {
+            const val TYPE = "enum"
+        }
+    }
+
+    data class UnionRule(
+        override val path: String,
+        override val type: String = TYPE,
+    ) : Rule {
+        companion object {
+            const val TYPE = "union"
+        }
+    }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/schema/RulesetValidator.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/schema/RulesetValidator.kt
@@ -98,7 +98,7 @@ internal fun getPrimitiveType(type: String): CrdtPrimitive.Type {
  */
 internal fun validateValue(value: Any?, rule: Rule): ValidationResult {
     when (rule.type) {
-        "string", "boolean", "integer", "double", "long", "date", "bytes", "null" -> {
+        in Rule.PrimitiveRule.Type.entries.map { it.value } -> {
             if (value !is CrdtPrimitive || value.type != getPrimitiveType(rule.type)) {
                 return ValidationResult(
                     valid = false,
@@ -111,8 +111,7 @@ internal fun validateValue(value: Any?, rule: Rule): ValidationResult {
                 )
             }
         }
-
-        "object" -> {
+        Rule.ObjectRule.TYPE -> {
             if (value !is CrdtObject) {
                 return ValidationResult(
                     valid = false,
@@ -125,8 +124,7 @@ internal fun validateValue(value: Any?, rule: Rule): ValidationResult {
                 )
             }
         }
-
-        "array" -> {
+        Rule.ArrayRule.TYPE -> {
             if (value !is CrdtArray) {
                 return ValidationResult(
                     valid = false,
@@ -139,8 +137,7 @@ internal fun validateValue(value: Any?, rule: Rule): ValidationResult {
                 )
             }
         }
-
-        "yorkie.Text" -> {
+        Rule.YorkieTypeRule.Type.TEXT.value -> {
             if (value !is CrdtText) {
                 return ValidationResult(
                     valid = false,
@@ -153,8 +150,7 @@ internal fun validateValue(value: Any?, rule: Rule): ValidationResult {
                 )
             }
         }
-
-        "yorkie.Tree" -> {
+        Rule.YorkieTypeRule.Type.TREE.value -> {
             if (value !is CrdtTree) {
                 return ValidationResult(
                     valid = false,
@@ -167,8 +163,7 @@ internal fun validateValue(value: Any?, rule: Rule): ValidationResult {
                 )
             }
         }
-
-        "yorkie.Counter" -> {
+        Rule.YorkieTypeRule.Type.COUNTER.value -> {
             if (value !is CrdtCounter) {
                 return ValidationResult(
                     valid = false,
@@ -181,7 +176,6 @@ internal fun validateValue(value: Any?, rule: Rule): ValidationResult {
                 )
             }
         }
-
         else -> {
             throw Exception("Unknown rule type: ${rule.type}")
         }

--- a/yorkie/src/test/kotlin/dev/yorkie/schema/RulesetValidatorTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/schema/RulesetValidatorTest.kt
@@ -171,6 +171,7 @@ class RulesetValidatorTest {
             Rule.ArrayRule(
                 path = "\$.items",
                 type = "array",
+                items = emptyList(),
             ),
         )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- [x] Support for object, array and enum in ruleset builder: https://github.com/yorkie-team/yorkie-js-sdk/pull/1025
- [ ] Add nextjs-quill example using Yorkie and Quill v2: https://github.com/yorkie-team/yorkie-js-sdk/pull/1032
- [ ] Migrate vanilla-quill example dependency to Quill v2: https://github.com/yorkie-team/yorkie-js-sdk/pull/1034

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://jira.navercorp.com/browse/RTCOLLABPLATFORM-384

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for Enum and Union schema rules.
  - Arrays now accept item definitions for richer schema validation.
  - Validation uses consistent, type-safe handling across primitive and Yorkie-specific types.

- Chores
  - Updated Yorkie service image to v0.6.21 in Docker configurations.
  - Bumped package formula and checksums to v0.6.21.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->