### PR TITLE
Sync android-sdk with js-sdk: Implement updates to v0.6.22

### DIFF
--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -1,6 +1,6 @@
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.21'
+    image: 'yorkieteam/yorkie:0.6.22'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.21'
+    image: 'yorkieteam/yorkie:0.6.22'
     container_name: 'yorkie'
     restart: always
     ports:

--- a/yorkie.rb
+++ b/yorkie.rb
@@ -1,8 +1,8 @@
 class Yorkie < Formula
   desc "Document store for collaborative applications"
   homepage "https://yorkie.dev/"
-  url "https://github.com/yorkie-team/yorkie/archive/refs/tags/v0.6.21.tar.gz"
-  sha256 "d67508c6bde8f948cf6f3fdaddfa9f7a710746408ec29fa41b9344a7aa7c04f7"
+  url "https://github.com/yorkie-team/yorkie/archive/refs/tags/v0.6.22.tar.gz"
+  sha256 "bc8cb4c56b02e262a70b1acdd9161c9c6079b91ad912b09d5980eb88ac1f03d4"
   license "Apache-2.0"
   head "https://github.com/yorkie-team/yorkie.git", branch: "main"
 
@@ -12,12 +12,12 @@ class Yorkie < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5b59b336e30f5baf644699c47ca730cbc80e9fbb3c75829f5d0f664c6dd74b4e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "41a0f08761abebd16a2b78ffbe1e31349d91ce9cfe4e97ed2d934341a319dda2"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "1ed00126bde5998fd0247d6c5e9ff5d8ad0a3e1e9d9ae5af6dba580d803cb1c0"
-    sha256 cellar: :any_skip_relocation, sonoma:        "d9a350023e557a462ebea4143ed27cc1f5c33a2e1b28d6941f7263e7c1d7c5d8"
-    sha256 cellar: :any_skip_relocation, ventura:       "2ac8b59a278e9f4fe51b73d9710cf3c96ae07daec9626a00f78a4fffe0557280"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a5b26d271fd78d4e6f867050a760e49835276c98f29f008b465dcc3ed0425183"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "142932eed1e6a3da30a6cf36af6cbde487f3c7242517b241d4dbe30a6e63ecb1"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7089e4e0ebbd695c18fb6d0f8f7baebf9f5490c9f1841319accac8e3772964b8"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "4944df782840236ca86d5cd0a98165c168c1ae7617d386d9edf4a59c1193b0ac"
+    sha256 cellar: :any_skip_relocation, sonoma:        "2962687a66098dec0d0f3259fe1353e8287dc9cd778c7c0b8ea24568f9c74bd5"
+    sha256 cellar: :any_skip_relocation, ventura:       "b07f1623168473e52dc2e722853a3408886b793deff652a63ef6d270cdc64d80"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d5b3a2b7442a28efc372b1e4827b265231ba81337edb6cee05198dc92cd47d05"
   end
 
   depends_on "go" => :build

--- a/yorkie/src/main/kotlin/dev/yorkie/api/ConverterUtil.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/ConverterUtil.kt
@@ -1,0 +1,46 @@
+package dev.yorkie.api
+
+import android.util.Base64
+import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteString
+import dev.yorkie.document.time.ActorID
+
+internal fun ByteString.toActorID(): ActorID {
+    return ActorID(bytesToHex(toByteArray()))
+}
+
+internal fun ActorID.toByteString(): ByteString {
+    return hexToBytes(value.lowercase()).toByteString()
+}
+
+/**
+ * Converts a Base64 string to ByteArray.
+ */
+fun base64ToByteArray(base64: String): ByteArray {
+    return Base64.decode(base64, Base64.DEFAULT)
+}
+
+/**
+ * Converts a hex string to ByteArray.
+ */
+fun hexToBytes(hex: String): ByteArray {
+    require(hex.length % 2 == 0) { "Hex string must have an even length" }
+    return ByteArray(hex.length / 2) { i ->
+        ((hex.substring(2 * i, 2 * i + 2)).toInt(16)).toByte()
+    }
+}
+
+/**
+ * `uint8ArrayToBase64` converts the given Uint8Array to base64 string.
+ */
+fun uint8ArrayToBase64(byteArray: ByteArray): String {
+    return Base64.encodeToString(byteArray, Base64.NO_WRAP)
+}
+
+/**
+ * Converts a ByteArray to hex string.
+ */
+fun bytesToHex(bytes: ByteArray?): String {
+    if (bytes == null) return ""
+    return bytes.joinToString("") { "%02x".format(it) }
+}

--- a/yorkie/src/main/kotlin/dev/yorkie/api/TimeConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/TimeConverter.kt
@@ -1,10 +1,6 @@
 package dev.yorkie.api
 
-import com.google.common.io.BaseEncoding
-import com.google.protobuf.ByteString
-import com.google.protobuf.kotlin.toByteString
 import dev.yorkie.api.v1.timeTicket
-import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket
 
 internal typealias PBTimeTicket = dev.yorkie.api.v1.TimeTicket
@@ -24,12 +20,4 @@ internal fun TimeTicket.toPBTimeTicket(): PBTimeTicket {
         delimiter = timeTicket.delimiter.toInt()
         actorId = timeTicket.actorID.toByteString()
     }
-}
-
-internal fun ByteString.toActorID(): ActorID {
-    return ActorID(BaseEncoding.base16().lowerCase().encode(toByteArray()))
-}
-
-internal fun ActorID.toByteString(): ByteString {
-    return BaseEncoding.base16().lowerCase().decode(value).toByteString()
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/api/VersionVectorConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/VersionVectorConverter.kt
@@ -7,12 +7,17 @@ internal typealias PBVersionVector = dev.yorkie.api.v1.VersionVector
 
 internal fun PBVersionVector.toVersionVector(): VersionVector {
     return VersionVector(
-        vectorMap = vectorMap,
+        vectorMap = vectorMap.mapKeys {
+            bytesToHex(base64ToByteArray(it.key))
+        },
     )
 }
 
 internal fun VersionVector.toPBVersionVector(): PBVersionVector {
     return versionVector {
-        vector.putAll(vectorMap)
+        vectorMap.forEach { (actorID, lamport) ->
+            val base64ActorID = uint8ArrayToBase64(hexToBytes(actorID))
+            vector.put(base64ActorID, lamport)
+        }
     }
 }

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -1,5 +1,6 @@
 package dev.yorkie.core
 
+import android.util.Base64
 import com.connectrpc.Code
 import com.connectrpc.ConnectException
 import dev.yorkie.api.PBChangePack
@@ -41,8 +42,11 @@ import dev.yorkie.util.YorkieException.Code.ErrDocumentNotAttached
 import dev.yorkie.util.createSingleThreadDispatcher
 import dev.yorkie.util.handleConnectException
 import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.spyk
+import io.mockk.unmockkStatic
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
@@ -192,6 +196,9 @@ class ClientTest {
 
     @Test
     fun `should emit according event when watch stream fails`() = runTest {
+        mockkStatic(Base64::class)
+        every { Base64.encodeToString(any(), any()) } returns "mockk"
+
         val document = Document(Key(WATCH_SYNC_ERROR_DOCUMENT_KEY))
         target.activateAsync().await()
         target.attachAsync(document).await()
@@ -211,6 +218,8 @@ class ClientTest {
 
         target.detachAsync(document).await()
         target.deactivateAsync().await()
+
+        unmockkStatic(Base64::class)
     }
 
     @Test

--- a/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
@@ -7,7 +7,6 @@ import com.connectrpc.ResponseMessage
 import com.connectrpc.ServerOnlyStreamInterface
 import com.google.protobuf.kotlin.toByteString
 import com.google.rpc.ErrorInfo
-import dev.yorkie.api.PBTimeTicket
 import dev.yorkie.api.toPBChange
 import dev.yorkie.api.toPBTimeTicket
 import dev.yorkie.api.v1.ActivateClientRequest
@@ -137,7 +136,6 @@ class MockYorkieService(
                             ),
                         ).toPBChange(),
                     )
-                    minSyncedTicket = PBTimeTicket.getDefaultInstance()
                 }
                 documentId = changePack.documentKey
             },
@@ -176,7 +174,6 @@ class MockYorkieService(
         return ResponseMessage.Success(
             pushPullChangesResponse {
                 changePack = changePack {
-                    minSyncedTicket = InitialTimeTicket.toPBTimeTicket()
                     changes.add(
                         change {
                             operations.add(createSetOperation())
@@ -313,7 +310,6 @@ class MockYorkieService(
         return ResponseMessage.Success(
             removeDocumentResponse {
                 changePack = changePack {
-                    minSyncedTicket = InitialTimeTicket.toPBTimeTicket()
                     changes.add(
                         change {
                             operations.add(createSetOperation())


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- [x] Change VersionVector actorID encoding from hex to base64: https://github.com/yorkie-team/yorkie-js-sdk/pull/1030
- [ ] Fix eslint cleanup SDK: https://github.com/yorkie-team/yorkie-js-sdk/pull/1023

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://jira.navercorp.com/browse/RTCOLLABPLATFORM-385

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added data encoding utilities for base64/hex to simplify binary interoperability.

- Refactor
  - Centralized actor ID ↔ binary conversions and standardized internal hex vs serialized base64 encoding.

- Tests
  - Made unit tests deterministic by mocking base64 encoding.

- Chores
  - Updated Yorkie server image to 0.6.22 in Docker Compose/CI and bumped Homebrew package to 0.6.22 with refreshed checksums.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->