### PR TITLE
Sync android-sdk with js-sdk: Implement updates to v0.6.23

### DIFF
--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -1,6 +1,6 @@
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.22'
+    image: 'yorkieteam/yorkie:0.6.23'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.22'
+    image: 'yorkieteam/yorkie:0.6.23'
     container_name: 'yorkie'
     restart: always
     ports:

--- a/yorkie.rb
+++ b/yorkie.rb
@@ -1,8 +1,8 @@
 class Yorkie < Formula
   desc "Document store for collaborative applications"
   homepage "https://yorkie.dev/"
-  url "https://github.com/yorkie-team/yorkie/archive/refs/tags/v0.6.22.tar.gz"
-  sha256 "bc8cb4c56b02e262a70b1acdd9161c9c6079b91ad912b09d5980eb88ac1f03d4"
+  url "https://github.com/yorkie-team/yorkie/archive/refs/tags/v0.6.23.tar.gz"
+  sha256 "0da8c83633a52d5f6beafec98fa1087f02bf1da89eef5319cad71c5ea628bc35"
   license "Apache-2.0"
   head "https://github.com/yorkie-team/yorkie.git", branch: "main"
 
@@ -12,12 +12,12 @@ class Yorkie < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "142932eed1e6a3da30a6cf36af6cbde487f3c7242517b241d4dbe30a6e63ecb1"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7089e4e0ebbd695c18fb6d0f8f7baebf9f5490c9f1841319accac8e3772964b8"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "4944df782840236ca86d5cd0a98165c168c1ae7617d386d9edf4a59c1193b0ac"
-    sha256 cellar: :any_skip_relocation, sonoma:        "2962687a66098dec0d0f3259fe1353e8287dc9cd778c7c0b8ea24568f9c74bd5"
-    sha256 cellar: :any_skip_relocation, ventura:       "b07f1623168473e52dc2e722853a3408886b793deff652a63ef6d270cdc64d80"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d5b3a2b7442a28efc372b1e4827b265231ba81337edb6cee05198dc92cd47d05"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "70d18ab5b8af62489c54f1601eca1ea2cf822fe36fee24a4992c79160dbad5bb"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c5b59af409e4f7c8ab6af266108e19746106a24159efb465451aa281e16bc0bf"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "2ff281ed20b133b9889e8d1c4a527572eff229456bdee3311a15ca6a581b818f"
+    sha256 cellar: :any_skip_relocation, sonoma:        "05f641c3c039f3c18c1014f81908561ca6bc6440d4dc4736bc4381e24b107de8"
+    sha256 cellar: :any_skip_relocation, ventura:       "d8ade777030399dced97dc8cbe680b126f5268d986b8523f3d2c34e2028943a5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0085187522761ff653f24cf92511554480fde231cc31096a7f13498674475cab"
   end
 
   depends_on "go" => :build

--- a/yorkie/proto/yorkie/v1/resources.proto
+++ b/yorkie/proto/yorkie/v1/resources.proto
@@ -101,16 +101,6 @@ message Operation {
     TimeTicket executed_at = 6;
     map<string, string> attributes = 7;
   }
-  // NOTE(hackerwins): Select Operation is not used in the current version.
-  // In the previous version, it was used to represent selection of Text.
-  // However, it has been replaced by Presence now. It is retained for backward
-  // compatibility purposes.
-  message Select {
-    TimeTicket parent_created_at = 1;
-    TextNodePos from = 2;
-    TextNodePos to = 3;
-    TimeTicket executed_at = 4;
-  }
   message Style {
     TimeTicket parent_created_at = 1;
     TextNodePos from = 2;
@@ -155,7 +145,6 @@ message Operation {
     Move move = 3;
     Remove remove = 4;
     Edit edit = 5;
-    Select select = 6;
     Style style = 7;
     Increase increase = 8;
     TreeEdit tree_edit = 9;
@@ -341,13 +330,14 @@ message UpdatableProjectFields {
 message DocumentSummary {
   string id = 1;
   string key = 2;
-  string snapshot = 3;
+  string root = 3;
   google.protobuf.Timestamp created_at = 4;
   google.protobuf.Timestamp accessed_at = 5;
   google.protobuf.Timestamp updated_at = 6;
   int32 attached_clients = 7;
   DocSize document_size = 8;
   string schema_key = 9;
+  map<string, Presence> presences = 10;
 }
 
 message PresenceChange {

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonArrayTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonArrayTest.kt
@@ -1,0 +1,1022 @@
+package dev.yorkie.document.json
+
+import dev.yorkie.core.Client
+import dev.yorkie.core.withTwoClientsAndDocuments
+import dev.yorkie.document.Document
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class JsonArrayTest {
+    @Test
+    fun can_handle_concurrent_insertAfter_operations() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+            var prev: JsonElement? = null
+            document1.updateAsync { root, _ ->
+                val k1 = root.setNewArray("k1").apply {
+                    put(1)
+                    put(2)
+                    put(3)
+                    put(4)
+                }
+                prev = k1[1]
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                k1.remove(prev!!.id)
+                assertEquals(
+                    expected = "{\"k1\":[1,3,4]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                k1.put(2, prev!!.id)
+                assertEquals(
+                    expected = "{\"k1\":[1,2,2,3,4]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            client1.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+            assertEquals(
+                expected = "{\"k1\":[1,2,3,4]}",
+                actual = document1.toJson(),
+            )
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                k1.put("2.1", k1[1]!!.id)
+                assertEquals(
+                    expected = "{\"k1\":[1,2,\"2.1\",3,4]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                k1.put("2.2", k1[1]!!.id)
+                assertEquals(
+                    expected = "{\"k1\":[1,2,\"2.2\",3,4]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            client1.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+        }
+    }
+
+    @Test
+    fun can_handle_concurrent_moveBefore_operations_with_same_position() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+            document1.updateAsync { root, _ ->
+                root.setNewArray("k1").apply {
+                    put(0)
+                    put(1)
+                    put(2)
+                }
+                assertEquals(
+                    expected = "{\"k1\":[0,1,2]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val next = k1[0]!!
+                val item = k1[2]!!
+                k1.moveBefore(next.id, item.id)
+                assertEquals(
+                    expected = "{\"k1\":[2,0,1]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val next = k1[0]!!
+                val item = k1[2]!!
+                k1.moveBefore(next.id, item.id)
+                assertEquals(
+                    expected = "{\"k1\":[1,2,0]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val next = k1[0]!!
+                val item = k1[1]!!
+                k1.moveBefore(next.id, item.id)
+                assertEquals(
+                    expected = "{\"k1\":[1,0,2]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val next = k1[0]!!
+                val item = k1[1]!!
+                k1.moveBefore(next.id, item.id)
+                assertEquals(
+                    expected = "{\"k1\":[0,1,2]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            client1.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+        }
+    }
+
+    @Test
+    fun can_handle_concurrent_moveBefore_operations_from_different_position() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+            document1.updateAsync { root, _ ->
+                root.setNewArray("k1").apply {
+                    put(0)
+                    put(1)
+                    put(2)
+                }
+                assertEquals(
+                    expected = "{\"k1\":[0,1,2]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val next = k1[0]!!
+                val item = k1[1]!!
+                k1.moveBefore(next.id, item.id)
+                assertEquals(
+                    expected = "{\"k1\":[1,0,2]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val next = k1[1]!!
+                val item = k1[2]!!
+                k1.moveBefore(next.id, item.id)
+                assertEquals(
+                    expected = "{\"k1\":[0,2,1]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            client1.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+        }
+    }
+
+    @Test
+    fun can_handle_concurrent_moveFront_operations_with_different_index() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+            document1.updateAsync { root, _ ->
+                root.setNewArray("k1").apply {
+                    put(0)
+                    put(1)
+                    put(2)
+                }
+                assertEquals(
+                    expected = "{\"k1\":[0,1,2]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val item = k1[2]!!
+                k1.moveFront(item.id)
+                assertEquals(
+                    expected = "{\"k1\":[2,0,1]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val item = k1[2]!!
+                k1.moveFront(item.id)
+                assertEquals(
+                    expected = "{\"k1\":[1,2,0]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val item = k1[1]!!
+                k1.moveFront(item.id)
+                assertEquals(
+                    expected = "{\"k1\":[1,0,2]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val item = k1[1]!!
+                k1.moveFront(item.id)
+                assertEquals(
+                    expected = "{\"k1\":[0,1,2]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            client1.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+        }
+    }
+
+    @Test
+    fun can_handle_concurrent_moveFront_operations_with_same_index() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+            document1.updateAsync { root, _ ->
+                root.setNewArray("k1").apply {
+                    put(0)
+                    put(1)
+                    put(2)
+                }
+                assertEquals(
+                    expected = "{\"k1\":[0,1,2]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val item = k1[2]!!
+                k1.moveFront(item.id)
+                assertEquals(
+                    expected = "{\"k1\":[2,0,1]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val item = k1[2]!!
+                k1.moveFront(item.id)
+                assertEquals(
+                    expected = "{\"k1\":[2,0,1]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            client1.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+        }
+    }
+
+    @Test
+    fun can_handle_concurrent_moveAfter_operations() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+            document1.updateAsync { root, _ ->
+                root.setNewArray("k1").apply {
+                    put(0)
+                    put(1)
+                    put(2)
+                }
+                assertEquals(
+                    expected = "{\"k1\":[0,1,2]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val item = k1[1]!!
+                k1.moveLast(item.id)
+                assertEquals(
+                    expected = "{\"k1\":[0,2,1]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val item = k1[0]!!
+                k1.moveLast(item.id)
+                assertEquals(
+                    expected = "{\"k1\":[1,2,0]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            client1.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+        }
+    }
+
+    @Test
+    fun can_handle_concurrent_insertAfter_and_moveBefore_operations() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+            var prev: JsonElement? = null
+            document1.updateAsync { root, _ ->
+                val k1 = root.setNewArray("k1").apply {
+                    put(0)
+                }
+                prev = k1[0]
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                k1.put(1, prev!!.id)
+                assertEquals(
+                    expected = "{\"k1\":[0,1]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                k1.put(2, prev!!.id)
+                assertEquals(
+                    expected = "{\"k1\":[0,2]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            client1.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val next = k1[0]!!
+                val item = k1[1]!!
+                k1.moveBefore(next.id, item.id)
+            }.await()
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val next = k1[0]!!
+                val item = k1[2]!!
+                k1.moveBefore(next.id, item.id)
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            client1.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+        }
+    }
+
+    @Test
+    fun can_handle_concurrent_moveAfter() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+            document1.updateAsync { root, _ ->
+                root.setNewArray("k1").apply {
+                    put(0)
+                    put(1)
+                    put(2)
+                }
+                assertEquals(
+                    expected = "{\"k1\":[0,1,2]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val prev = k1[0]!!
+                val item = k1[1]!!
+                k1.moveAfter(prev.id, item.id)
+                assertEquals(
+                    expected = "{\"k1\":[0,1,2]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val prev = k1[0]!!
+                val item = k1[2]!!
+                k1.moveAfter(prev.id, item.id)
+                assertEquals(
+                    expected = "{\"k1\":[0,2,1]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            client1.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+        }
+    }
+
+    @Test
+    fun can_handle_concurrent_add_operations() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+            document1.updateAsync { root, _ ->
+                root.setNewArray("k1").apply {
+                    put("1")
+                }
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                k1.put("2")
+            }.await()
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                k1.put("3")
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            client1.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+        }
+    }
+
+    @Test
+    fun can_handle_concurrent_delete_operations() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+            var prev: JsonElement? = null
+            document1.updateAsync { root, _ ->
+                root.setNewArray("k1").apply {
+                    put(1)
+                    put(2)
+                    put(3)
+                    put(4)
+                }
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                prev = k1[2]
+                k1.remove(prev!!.id)
+            }.await()
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                prev = k1[2]
+                k1.remove(prev!!.id)
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            client1.syncAsync().await()
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                assertEquals(3, k1.size)
+            }.await()
+        }
+    }
+
+    @Test
+    fun can_handle_concurrent_insertBefore_and_delete_operations() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+            var prev: JsonElement? = null
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.setNewArray("k1").apply {
+                    put(1)
+                }
+                prev = k1[0]
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                k1.remove(prev!!.id)
+                assertEquals(
+                    expected = "{\"k1\":[]}",
+                    actual = root.toJson(),
+                )
+                assertEquals(0, k1.size)
+            }.await()
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                // Insert before by adding element and moving it before the target
+                k1.put(2)
+                val element2 = k1[k1.size - 1]!!
+                k1.moveBefore(prev!!.id, element2.id)
+                assertEquals(
+                    expected = "{\"k1\":[2,1]}",
+                    actual = root.toJson(),
+                )
+                assertEquals(2, k1.size)
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            client1.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                assertEquals(
+                    expected = "{\"k1\":[2]}",
+                    actual = root.toJson(),
+                )
+                assertEquals(1, k1.size)
+            }.await()
+        }
+    }
+
+    @Test
+    fun can_handle_complex_concurrent_insertBefore_and_delete_operations() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+            var prev: JsonElement? = null
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.setNewArray("k1").apply {
+                    put(1)
+                    put(2)
+                    put(3)
+                    put(4)
+                }
+                prev = k1[1]
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                k1.remove(prev!!.id)
+                assertEquals(
+                    expected = "{\"k1\":[1,3,4]}",
+                    actual = root.toJson(),
+                )
+                assertEquals(3, k1.size)
+            }.await()
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                k1.insertBefore(prev!!.id, 5)
+                assertEquals(
+                    expected = "{\"k1\":[1,5,2,3,4]}",
+                    actual = root.toJson(),
+                )
+                assertEquals(5, k1.size)
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            client1.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+            assertEquals(
+                expected = "{\"k1\":[1,5,3,4]}",
+                actual = document1.toJson(),
+            )
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val targetElement = k1[3]!!
+                assertEquals(4, k1.size)
+                k1.insertBefore(targetElement.id, 6)
+                assertEquals(
+                    expected = "{\"k1\":[1,5,3,6,4]}",
+                    actual = root.toJson(),
+                )
+                assertEquals(5, k1.size)
+            }.await()
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                val targetElement = k1[0]!!
+                assertEquals(4, k1.size)
+                k1.insertBefore(targetElement.id, 7)
+                assertEquals(
+                    expected = "{\"k1\":[7,1,5,3,4]}",
+                    actual = root.toJson(),
+                )
+                assertEquals(5, k1.size)
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            client1.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                assertEquals(
+                    expected = "{\"k1\":[7,1,5,3,6,4]}",
+                    actual = root.toJson(),
+                )
+                assertEquals(6, k1.size)
+            }.await()
+        }
+    }
+
+    @Test
+    fun can_handle_simple_array_set_operations() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+            document1.updateAsync { root, _ ->
+                root.setNewArray("k1").apply {
+                    put(-1)
+                    put(-2)
+                    put(-3)
+                }
+                assertEquals(
+                    expected = "{\"k1\":[-1,-2,-3]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                k1.setInteger(1, -4)
+                assertEquals(
+                    expected = "{\"k1\":[-1,-4,-3]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                k1.setInteger(0, -5)
+                assertEquals(
+                    expected = "{\"k1\":[-5,-2,-3]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            client1.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+        }
+    }
+
+    // Generate all (op1, op2) combination tests
+    @Test
+    fun array_concurrency_table_test_insert_prev_vs_insert_prev() {
+        testConcurrentOperations(concurrencyOperations[0], concurrencyOperations[0])
+    }
+
+    @Test
+    fun array_concurrency_table_test_insert_prev_vs_insert_prev_next() {
+        testConcurrentOperations(concurrencyOperations[0], concurrencyOperations[1])
+    }
+
+    @Test
+    fun array_concurrency_table_test_insert_prev_vs_move_prev() {
+        testConcurrentOperations(concurrencyOperations[0], concurrencyOperations[2])
+    }
+
+    @Test
+    fun array_concurrency_table_test_insert_prev_vs_move_prev_next() {
+        testConcurrentOperations(concurrencyOperations[0], concurrencyOperations[3])
+    }
+
+    @Test
+    fun array_concurrency_table_test_insert_prev_vs_move_target() {
+        testConcurrentOperations(concurrencyOperations[0], concurrencyOperations[4])
+    }
+
+    @Test
+    fun array_concurrency_table_test_insert_prev_vs_set_target() {
+        testConcurrentOperations(concurrencyOperations[0], concurrencyOperations[5])
+    }
+
+    @Test
+    fun array_concurrency_table_test_insert_prev_vs_remove_target() {
+        testConcurrentOperations(concurrencyOperations[0], concurrencyOperations[6])
+    }
+
+    @Test
+    fun array_concurrency_table_test_set_target_vs_move_target() {
+        testConcurrentOperations(concurrencyOperations[5], concurrencyOperations[4])
+    }
+
+    // Can handle complicated concurrent array operations
+    data class ComplicatedArrayOp(
+        val opName: String,
+        val executor: (arr: JsonArray) -> Unit,
+    )
+
+    @Test
+    fun complicated_concurrent_array_operations_insert() {
+        testComplicatedConcurrentOperation(complicatedOperations[0])
+    }
+
+    @Test
+    fun complicated_concurrent_array_operations_set() {
+        testComplicatedConcurrentOperation(complicatedOperations[2])
+    }
+
+    @Test
+    fun complicated_concurrent_array_operations_remove() {
+        testComplicatedConcurrentOperation(complicatedOperations[3])
+    }
+
+    @Test
+    fun array_set_by_index_test() {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+            document1.updateAsync { root, _ ->
+                root.setNewArray("k1").apply {
+                    put(-1)
+                    put(-2)
+                    put(-3)
+                }
+                assertEquals(
+                    expected = "{\"k1\":[-1,-2,-3]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+            assertEquals(document1.toJson(), document2.toJson())
+
+            document2.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                k1.setInteger(1, -4)
+                assertEquals(
+                    expected = "{\"k1\":[-1,-4,-3]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            document1.updateAsync { root, _ ->
+                val k1 = root.getAs<JsonArray>("k1")
+                k1.setInteger(0, -5)
+                assertEquals(
+                    expected = "{\"k1\":[-5,-2,-3]}",
+                    actual = root.toJson(),
+                )
+            }.await()
+
+            val result = syncClientsThenCheckEqual(
+                listOf(
+                    ClientAndDocPair(client1, document1),
+                    ClientAndDocPair(client2, document2),
+                ),
+            )
+            assertTrue(result)
+        }
+    }
+
+    // Helper functions
+    private fun testConcurrentOperations(op1: ArrayOp, op2: ArrayOp) {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+            document1.updateAsync { root, _ ->
+                val a = root.setNewArray("a")
+                initArr.forEach { a.put(it) }
+                assertEquals(INIT_MARSHALL, root.toJson())
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+
+            // Verify initial state
+            assertEquals(document1.toJson(), document2.toJson())
+
+            // Apply operations concurrently
+            document1.updateAsync { root, _ ->
+                val a = root.getAs<JsonArray>("a")
+                op1.executor(a, 0)
+            }.await()
+
+            document2.updateAsync { root, _ ->
+                val a = root.getAs<JsonArray>("a")
+                op2.executor(a, 1)
+            }.await()
+
+            // Sync and verify convergence
+            val result = syncClientsThenCheckEqual(
+                listOf(
+                    ClientAndDocPair(client1, document1),
+                    ClientAndDocPair(client2, document2),
+                ),
+            )
+            assertTrue(result)
+        }
+    }
+
+    private fun testComplicatedConcurrentOperation(op: ComplicatedArrayOp) {
+        withTwoClientsAndDocuments { client1, client2, document1, document2, key ->
+            // Reset documents for each test case
+            document1.updateAsync { root, _ ->
+                val a = root.setNewArray("a")
+                initArr.forEach { a.put(it) }
+                assertEquals(INIT_MARSHALL, root.toJson())
+            }.await()
+
+            client1.syncAsync().await()
+            client2.syncAsync().await()
+
+            // Verify initial state
+            assertEquals(document1.toJson(), document2.toJson())
+
+            // Client 1 performs the test operation
+            document1.updateAsync { root, _ ->
+                val a = root.getAs<JsonArray>("a")
+                op.executor(a)
+            }.await()
+
+            // Client 2 performs two move operations
+            document2.updateAsync { root, _ ->
+                val a = root.getAs<JsonArray>("a")
+                // Move element at index 2 after element at oneIdx
+                a.moveAfter(
+                    a[COMPLICATED_ONE_IDX]!!.id,
+                    a[2]!!.id,
+                )
+
+                // Move element at index 3 after element at index 2
+                a.moveAfter(
+                    a[2]!!.id,
+                    a[3]!!.id,
+                )
+            }.await()
+
+            // Sync and verify convergence
+            val result = syncClientsThenCheckEqual(
+                listOf(
+                    ClientAndDocPair(client1, document1),
+                    ClientAndDocPair(client2, document2),
+                ),
+            )
+            assertTrue(result)
+        }
+    }
+
+    private suspend fun syncClientsThenCheckEqual(pairs: List<ClientAndDocPair>): Boolean {
+        assertTrue(pairs.size > 1)
+
+        // Save own changes and get previous changes
+        for (i in pairs.indices) {
+            val pair = pairs[i]
+            pair.client.syncAsync().await()
+        }
+
+        // Get last client changes
+        // Last client get all precede changes in above loop
+        for (pair in pairs.dropLast(1)) {
+            pair.client.syncAsync().await()
+        }
+
+        // Assert start
+        val expected = pairs[0].doc.toJson()
+        for (i in 1 until pairs.size) {
+            val v = pairs[i].doc.toJson()
+            if (expected != v) {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    // Array Concurrency Table Tests
+    data class ArrayOp(
+        val opName: String,
+        val executor: (arr: JsonArray, cid: Int) -> Unit,
+    )
+
+    // Helper class for syncing clients and checking equality
+    data class ClientAndDocPair(
+        val client: Client,
+        val doc: Document,
+    )
+
+    companion object {
+        // Array Concurrency Table Tests constants
+        private val initArr = listOf(1, 2, 3, 4)
+        private const val INIT_MARSHALL = "{\"a\":[1,2,3,4]}"
+        private const val ONE_IDX = 1
+        private val otherIdxs = listOf(2, 3)
+        private val newValues = listOf(5, 6)
+
+        private val concurrencyOperations = listOf(
+            // insert
+            ArrayOp("insert.prev") { arr, cid ->
+                arr.insertIntegerAfter(ONE_IDX, newValues[cid])
+            },
+            ArrayOp("insert.prev.next") { arr, cid ->
+                arr.insertIntegerAfter(ONE_IDX - 1, newValues[cid])
+            },
+            // move
+            ArrayOp("move.prev") { arr, cid ->
+                arr.moveAfterByIndex(ONE_IDX, otherIdxs[cid])
+            },
+            ArrayOp("move.prev.next") { arr, cid ->
+                arr.moveAfterByIndex(ONE_IDX - 1, otherIdxs[cid])
+            },
+            ArrayOp("move.target") { arr, cid ->
+                arr.moveAfterByIndex(otherIdxs[cid], ONE_IDX)
+            },
+            // set by index
+            ArrayOp("set.target") { arr, cid ->
+                arr.setInteger(ONE_IDX, newValues[cid])
+            },
+            // remove
+            ArrayOp("remove.target") { arr, _ ->
+                arr.removeAt(ONE_IDX)
+            },
+        )
+
+        // Complicated concurrent array operations constants
+        private const val COMPLICATED_ONE_IDX = 1
+        private const val COMPLICATED_OTHER_IDX = 0
+        private const val COMPLICATED_NEW_VALUE = 5
+
+        private val complicatedOperations = listOf(
+            // insert
+            ComplicatedArrayOp("insert") { arr ->
+                arr.put(COMPLICATED_NEW_VALUE, arr[COMPLICATED_ONE_IDX]!!.id)
+            },
+            // move
+            ComplicatedArrayOp("move") { arr ->
+                arr.moveAfter(
+                    arr[COMPLICATED_OTHER_IDX]!!.id,
+                    arr[COMPLICATED_ONE_IDX]!!.id,
+                )
+            },
+            // set (implemented as delete + insert)
+            ComplicatedArrayOp("set") { arr ->
+                val targetElement = arr[COMPLICATED_ONE_IDX]!!
+                arr.remove(targetElement.id)
+                if (COMPLICATED_ONE_IDX > 0) {
+                    arr.put(COMPLICATED_NEW_VALUE, arr[COMPLICATED_ONE_IDX - 1]!!.id)
+                } else {
+                    val firstElement = arr[0]!!
+                    arr.insertBefore(firstElement.id, COMPLICATED_NEW_VALUE)
+                }
+            },
+            // remove
+            ComplicatedArrayOp("remove") { arr ->
+                arr.remove(arr[COMPLICATED_ONE_IDX]!!.id)
+            },
+        )
+    }
+}

--- a/yorkie/src/main/kotlin/dev/yorkie/api/OperationConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/OperationConverter.kt
@@ -71,8 +71,6 @@ internal fun List<PBOperation>.toOperations(): List<Operation> {
                     ?: mapOf(),
             )
 
-            it.hasSelect() -> null
-
             it.hasStyle() -> StyleOperation(
                 fromPos = it.style.from.toRgaTreeSplitNodePos(),
                 toPos = it.style.to.toRgaTreeSplitNodePos(),

--- a/yorkie/src/main/kotlin/dev/yorkie/api/OperationConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/OperationConverter.kt
@@ -1,6 +1,7 @@
 package dev.yorkie.api
 
 import dev.yorkie.api.v1.OperationKt.add
+import dev.yorkie.api.v1.OperationKt.arraySet
 import dev.yorkie.api.v1.OperationKt.edit
 import dev.yorkie.api.v1.OperationKt.increase
 import dev.yorkie.api.v1.OperationKt.move
@@ -11,6 +12,7 @@ import dev.yorkie.api.v1.OperationKt.treeEdit
 import dev.yorkie.api.v1.OperationKt.treeStyle
 import dev.yorkie.api.v1.operation
 import dev.yorkie.document.operation.AddOperation
+import dev.yorkie.document.operation.ArraySetOperation
 import dev.yorkie.document.operation.EditOperation
 import dev.yorkie.document.operation.IncreaseOperation
 import dev.yorkie.document.operation.MoveOperation
@@ -95,6 +97,13 @@ internal fun List<PBOperation>.toOperations(): List<Operation> {
                 attributes = it.treeStyle.attributesMap,
                 executedAt = it.treeStyle.executedAt.toTimeTicket(),
                 attributesToRemove = it.treeStyle.attributesToRemoveList,
+            )
+
+            it.hasArraySet() -> ArraySetOperation(
+                createdAt = it.arraySet.createdAt.toTimeTicket(),
+                value = it.arraySet.value.toCrdtElement(),
+                parentCreatedAt = it.arraySet.parentCreatedAt.toTimeTicket(),
+                executedAt = it.arraySet.executedAt.toTimeTicket(),
             )
 
             else -> throw YorkieException(ErrUnimplemented, "unimplemented operations")
@@ -206,6 +215,17 @@ internal fun Operation.toPBOperation(): PBOperation {
                         attributes[key] = value
                     }
                     operation.attributesToRemove?.forEach { attributesToRemove.add(it) }
+                }
+            }
+        }
+
+        is ArraySetOperation -> {
+            operation {
+                arraySet = arraySet {
+                    parentCreatedAt = operation.parentCreatedAt.toPBTimeTicket()
+                    createdAt = operation.createdAt.toPBTimeTicket()
+                    value = operation.value.toPBJsonElementSimple()
+                    executedAt = operation.executedAt.toPBTimeTicket()
                 }
             }
         }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtArray.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtArray.kt
@@ -32,17 +32,21 @@ internal data class CrdtArray(
     }
 
     /**
-     * Physically deletes the given [element].
+     * `delete` deletes the element of the given creation time.
      */
-    override fun delete(element: CrdtElement) {
-        elements.delete(element)
+    override fun delete(createdAt: TimeTicket, executedAt: TimeTicket): CrdtElement {
+        return elements.delete(createdAt, executedAt)
     }
 
     /**
      * Adds a new node with [value] after the node created at [prevCreatedAt].
      */
-    fun insertAfter(prevCreatedAt: TimeTicket, value: CrdtElement) {
-        elements.insertAfter(prevCreatedAt, value)
+    fun insertAfter(
+        prevCreatedAt: TimeTicket,
+        value: CrdtElement,
+        executedAt: TimeTicket = value.createdAt,
+    ) {
+        elements.insertAfter(prevCreatedAt, value, executedAt)
     }
 
     /**
@@ -74,6 +78,17 @@ internal data class CrdtArray(
     }
 
     /**
+     * `set` sets the given element at the given position of the creation time.
+     */
+    fun set(
+        createdAt: TimeTicket,
+        value: CrdtElement,
+        executedAt: TimeTicket,
+    ): CrdtElement {
+        return elements.set(createdAt, value, executedAt)
+    }
+
+    /**
      * Returns a creation time of the previous node.
      */
     fun getPrevCreatedAt(createdAt: TimeTicket): TimeTicket {
@@ -81,10 +96,10 @@ internal data class CrdtArray(
     }
 
     /**
-     * Removes the node of the given [createdAt].
+     * `purge` physically purges element.
      */
-    override fun remove(createdAt: TimeTicket, executedAt: TimeTicket): CrdtElement {
-        return elements.remove(createdAt, executedAt)
+    override fun purge(element: CrdtElement) {
+        elements.purge(element)
     }
 
     /**

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtContainer.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtContainer.kt
@@ -9,9 +9,9 @@ internal abstract class CrdtContainer : CrdtElement() {
 
     abstract fun subPathOf(createdAt: TimeTicket): String?
 
-    abstract fun delete(element: CrdtElement)
+    abstract fun purge(element: CrdtElement)
 
-    abstract fun remove(createdAt: TimeTicket, executedAt: TimeTicket): CrdtElement
+    abstract fun delete(createdAt: TimeTicket, executedAt: TimeTicket): CrdtElement
 
     abstract fun getDescendants(callback: (CrdtElement, CrdtContainer) -> Boolean)
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtElement.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtElement.kt
@@ -20,7 +20,7 @@ abstract class CrdtElement {
 
     var movedAt: TimeTicket?
         get() = _movedAt
-        private set(value) {
+        set(value) {
             _movedAt = value
         }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtObject.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtObject.kt
@@ -32,8 +32,8 @@ internal data class CrdtObject(
     /**
      * Physically deletes the given [element].
      */
-    override fun delete(element: CrdtElement) {
-        rht.delete(element)
+    override fun purge(element: CrdtElement) {
+        rht.purge(element)
     }
 
     /**
@@ -46,8 +46,8 @@ internal data class CrdtObject(
     /**
      * Removes the element of the given key.
      */
-    override fun remove(createdAt: TimeTicket, executedAt: TimeTicket): CrdtElement {
-        return rht.remove(createdAt, executedAt)
+    override fun delete(createdAt: TimeTicket, executedAt: TimeTicket): CrdtElement {
+        return rht.delete(createdAt, executedAt)
     }
 
     /**

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtRoot.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtRoot.kt
@@ -202,7 +202,7 @@ internal class CrdtRoot(val rootObject: CrdtObject) {
             val pair = elementPairMapByCreatedAt[createdAt] ?: return@forEach
             val removedAt = pair.element.removedAt
             if (removedAt != null && minSyncedVersionVector.afterOrEqual(removedAt)) {
-                pair.parent?.delete(pair.element)
+                pair.parent?.purge(pair.element)
                 count += garbageCollectInternal(pair.element)
             }
         }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/ArraySetOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/ArraySetOperation.kt
@@ -1,0 +1,53 @@
+package dev.yorkie.document.operation
+
+import dev.yorkie.document.crdt.CrdtArray
+import dev.yorkie.document.crdt.CrdtElement
+import dev.yorkie.document.crdt.CrdtRoot
+import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.document.time.VersionVector
+import dev.yorkie.util.YorkieException
+
+/**
+ * `ArraySetOperation` is an operation representing setting an element in Array.
+ */
+internal data class ArraySetOperation(
+    val createdAt: TimeTicket,
+    val value: CrdtElement,
+    override val parentCreatedAt: TimeTicket,
+    override var executedAt: TimeTicket,
+) : Operation() {
+    override val effectedCreatedAt: TimeTicket
+        get() = createdAt
+
+    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
+        val parentObject = root.findByCreatedAt(parentCreatedAt)
+            ?: throw YorkieException(
+                code = YorkieException.Code.ErrInvalidArgument,
+                errorMessage = "fail to find $parentCreatedAt",
+            )
+
+        if (parentObject !is CrdtArray) {
+            throw YorkieException(
+                code = YorkieException.Code.ErrInvalidArgument,
+                errorMessage = "fail to execute, only array can execute set",
+            )
+        }
+
+        val value = value.deepCopy()
+        parentObject.insertAfter(createdAt, value, executedAt)
+        parentObject.delete(createdAt, executedAt)
+
+        // TODO(junseo): GC logic is not implemented here
+        // because there is no way to distinguish between old and new element with same `createdAt`.
+        root.registerElement(value, null)
+
+        // TODO(emplam27): The reverse operation is not implemented yet.
+        val reverseOp = null
+
+        return listOf(
+            OperationInfo.ArraySetOpInfo(
+                path = root.createPath(parentCreatedAt),
+            ),
+        )
+    }
+}

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/OperationInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/OperationInfo.kt
@@ -98,6 +98,10 @@ public sealed class OperationInfo {
         override var path: String = INITIAL_PATH,
     ) : OperationInfo(), TreeOperationInfo
 
+    public data class ArraySetOpInfo(
+        override var path: String = INITIAL_PATH,
+    ) : OperationInfo(), ArrayOperationInfo
+
     companion object {
         private const val INITIAL_PATH = "initial path"
     }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/RemoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/RemoveOperation.kt
@@ -29,7 +29,7 @@ internal data class RemoveOperation(
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtContainer) {
             val key = parentObject.subPathOf(createdAt)
-            val element = parentObject.remove(createdAt, executedAt)
+            val element = parentObject.delete(createdAt, executedAt)
             root.registerRemovedElement(element)
             val index = if (parentObject is CrdtArray) key?.toInt() else null
             listOf(OperationInfo.RemoveOpInfo(key, index, root.createPath(parentCreatedAt)))

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtArrayTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtArrayTest.kt
@@ -31,13 +31,13 @@ class CrdtArrayTest {
         crdtElements.forEach { target.insertAfter(target.last.createdAt, it) }
         assertEquals(crdtElements.size, target.length)
 
-        target.remove(timeTickets[1], timeTickets[2])
+        target.delete(timeTickets[1], timeTickets[2])
         assertEquals("ACDEFG", target.toTestString())
-        target.remove(timeTickets[2], timeTickets[3])
+        target.delete(timeTickets[2], timeTickets[3])
         assertEquals("ADEFG", target.toTestString())
-        target.remove(timeTickets[3], timeTickets[4])
+        target.delete(timeTickets[3], timeTickets[4])
         assertEquals("AEFG", target.toTestString())
-        target.remove(timeTickets[6], timeTickets[5])
+        target.delete(timeTickets[6], timeTickets[5])
         assertEquals("AEFG", target.toTestString())
 
         assertEquals(crdtElements.size - 3, target.length)
@@ -50,13 +50,13 @@ class CrdtArrayTest {
         crdtElements.forEach { target.insertAfter(target.last.createdAt, it) }
         assertEquals(crdtElements.size, target.length)
 
-        target.delete(crdtElements[0])
+        target.purge(crdtElements[0])
         assertEquals(crdtElements.size - 1, target.length)
         assertEquals("BCDEFG", target.toTestString())
-        target.delete(crdtElements[1])
+        target.purge(crdtElements[1])
         assertEquals(crdtElements.size - 2, target.length)
         assertEquals("CDEFG", target.toTestString())
-        target.delete(crdtElements[2])
+        target.purge(crdtElements[2])
         assertEquals(crdtElements.size - 3, target.length)
         assertEquals("DEFG", target.toTestString())
     }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtObjectTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtObjectTest.kt
@@ -2,6 +2,7 @@ package dev.yorkie.document.crdt
 
 import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.util.YorkieException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
@@ -58,11 +59,10 @@ class CrdtObjectTest {
         setTargetSampleValues()
         assertEquals(5, target.memberNodes.toList().size)
 
-        target.delete(crdtElements[0])
+        target.purge(crdtElements[0])
         assertEquals("B1C2D3E4", getTestString())
-        target.delete(crdtElements[3])
+        target.purge(crdtElements[3])
         assertEquals("B1C2E4", getTestString())
-        target.delete(CrdtPrimitive(100, TimeTicket.InitialTimeTicket))
     }
 
     @Test
@@ -70,12 +70,12 @@ class CrdtObjectTest {
         setTargetSampleValues()
         assertEquals(5, target.memberNodes.toList().size)
 
-        target.remove(timeTickets[0], timeTickets[1])
+        target.delete(timeTickets[0], timeTickets[1])
         assertEquals("B1C2D3E4", getTestString())
-        target.remove(timeTickets[2], timeTickets[1])
+        target.delete(timeTickets[2], timeTickets[1])
         assertEquals("B1C2D3E4", getTestString())
-        assertThrows(NoSuchElementException::class.java) {
-            target.remove(TimeTicket.InitialTimeTicket, TimeTicket.InitialTimeTicket)
+        assertThrows(YorkieException::class.java) {
+            target.delete(TimeTicket.InitialTimeTicket, TimeTicket.InitialTimeTicket)
         }
     }
 

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/ElementRhtTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/ElementRhtTest.kt
@@ -2,6 +2,7 @@ package dev.yorkie.document.crdt
 
 import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.util.YorkieException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -100,17 +101,17 @@ class ElementRhtTest {
         val primitive1 = CrdtPrimitive("value1", TimeTicket.InitialTimeTicket)
         elementRht["test1"] = primitive1
         val removedPrimitive =
-            elementRht.remove(TimeTicket.InitialTimeTicket, TimeTicket.InitialTimeTicket)
+            elementRht.delete(TimeTicket.InitialTimeTicket, TimeTicket.InitialTimeTicket)
         assertEquals(primitive1, removedPrimitive)
 
-        assertThrows(NoSuchElementException::class.java) {
-            elementRht.remove(
+        assertThrows(YorkieException::class.java) {
+            elementRht.delete(
                 generateTimeTicket(99, 99, "3"),
                 generateTimeTicket(100, 100, "3"),
             )
         }
-        assertThrows(NoSuchElementException::class.java) {
-            elementRht.remove(
+        assertThrows(YorkieException::class.java) {
+            elementRht.delete(
                 generateTimeTicket(101, 101, "4"),
                 TimeTicket.InitialTimeTicket,
             )
@@ -163,7 +164,7 @@ class ElementRhtTest {
         val primitive3 = CrdtPrimitive("value3", ticket3)
         elementRht["test3"] = primitive3
 
-        elementRht.delete(primitive2)
+        elementRht.purge(primitive2)
         assertThrows(NoSuchElementException::class.java) {
             elementRht["test2"]
         }
@@ -182,7 +183,7 @@ class ElementRhtTest {
         elementRht["test1"] = primitive1
         assertTrue(elementRht.has("test1"))
 
-        elementRht.remove(ticket1, generateTimeTicket(1, 2, "11"))
+        elementRht.delete(ticket1, generateTimeTicket(1, 2, "11"))
         assertFalse(elementRht.has("test1"))
     }
 

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/RgaTreeListTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/RgaTreeListTest.kt
@@ -2,6 +2,7 @@ package dev.yorkie.document.crdt
 
 import dev.yorkie.document.time.ActorID
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.util.YorkieException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertThrows
@@ -49,21 +50,21 @@ class RgaTreeListTest {
 
     @Test
     fun `should handle remove operations`() {
-        assertThrows(NoSuchElementException::class.java) {
-            target.remove(timeTickets[0], timeTickets[1])
+        assertThrows(YorkieException::class.java) {
+            target.delete(timeTickets[0], timeTickets[1])
         }
 
         assertEquals(0, target.length)
 
         crdtElements.forEach(target::insert)
 
-        target.remove(timeTickets[1], timeTickets[2])
+        target.delete(timeTickets[1], timeTickets[2])
         assertEquals("A1B0C1D1E1F1G1", target.toTestString())
-        target.remove(timeTickets[2], timeTickets[3])
+        target.delete(timeTickets[2], timeTickets[3])
         assertEquals("A1B0C0D1E1F1G1", target.toTestString())
-        target.remove(timeTickets[3], timeTickets[4])
+        target.delete(timeTickets[3], timeTickets[4])
         assertEquals("A1B0C0D0E1F1G1", target.toTestString())
-        target.remove(timeTickets[6], timeTickets[5])
+        target.delete(timeTickets[6], timeTickets[5])
         assertEquals("A1B0C0D0E1F1G1", target.toTestString())
 
         assertEquals(crdtElements.size - 3, target.length)
@@ -91,8 +92,8 @@ class RgaTreeListTest {
 
     @Test
     fun `should handle delete operations`() {
-        assertThrows(NoSuchElementException::class.java) {
-            target.delete(crdtElements[0])
+        assertThrows(YorkieException::class.java) {
+            target.purge(crdtElements[0])
         }
 
         assertEquals(0, target.length)
@@ -100,13 +101,13 @@ class RgaTreeListTest {
         crdtElements.forEach(target::insert)
         assertEquals(crdtElements.size, target.length)
 
-        target.delete(crdtElements[0])
+        target.purge(crdtElements[0])
         assertEquals(crdtElements.size - 1, target.length)
         assertEquals("B1C1D1E1F1G1", target.toTestString())
-        target.delete(crdtElements[1])
+        target.purge(crdtElements[1])
         assertEquals(crdtElements.size - 2, target.length)
         assertEquals("C1D1E1F1G1", target.toTestString())
-        target.delete(crdtElements[2])
+        target.purge(crdtElements[2])
         assertEquals(crdtElements.size - 3, target.length)
         assertEquals("D1E1F1G1", target.toTestString())
     }
@@ -124,7 +125,7 @@ class RgaTreeListTest {
 
     @Test
     fun `should handle moving an element after the given element`() {
-        assertThrows(NoSuchElementException::class.java) {
+        assertThrows(YorkieException::class.java) {
             target.moveAfter(timeTickets[0], timeTickets[1], timeTickets[1])
         }
 

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonArrayTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonArrayTest.kt
@@ -8,6 +8,7 @@ import dev.yorkie.document.crdt.CrdtPrimitive
 import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.crdt.ElementRht
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.util.YorkieException
 import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -100,7 +101,7 @@ class JsonArrayTest {
         target.remove(obj.target.createdAt)
         assertTrue(target.isEmpty())
 
-        assertThrows(NoSuchElementException::class.java) {
+        assertThrows(YorkieException::class.java) {
             target.remove(TimeTicket.MaxTimeTicket)
         }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- [ ] Cleanup ESLint packages/react: https://github.com/yorkie-team/yorkie-js-sdk/pull/1027
- [x] Remove deprecated SelectOperation: https://github.com/yorkie-team/yorkie-js-sdk/pull/1038
- [x] Resolve convergence issues in Array.Move and Array.Set: https://github.com/yorkie-team/yorkie-js-sdk/pull/1037

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://jira.navercorp.com/browse/RTCOLLABPLATFORM-386

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added integer-specific operations for arrays (set by index, insert after index).
  - Introduced array “set” behavior improving in-place element updates.

- Refactor
  - Standardized deletion semantics (rename to delete/purge) and unified error type for invalid operations.
  - Protocol updates: renamed a document summary field, added presence info, and removed an unused operation, affecting client integrations.

- Tests
  - Expanded Android test suite with extensive concurrent array operation coverage.

- Chores
  - Upgraded Yorkie runtime to v0.6.23 in containers and package distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->