### PR TITLE
Sync android-sdk with js-sdk: Implement updates to v0.6.25

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/GCTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/GCTest.kt
@@ -12,6 +12,7 @@ import dev.yorkie.document.json.JsonTree
 import dev.yorkie.document.json.JsonTree.TextNode
 import dev.yorkie.document.json.TreeBuilder.element
 import dev.yorkie.document.json.TreeBuilder.text
+import dev.yorkie.document.time.ActorID.Companion.INITIAL_ACTOR_ID
 import dev.yorkie.document.time.VersionVector.Companion.INITIAL_VERSION_VECTOR
 import dev.yorkie.gson
 import dev.yorkie.helper.maxVectorOf
@@ -1075,6 +1076,7 @@ class GCTest {
                     arrayOf(
                         Pair(client1.requireClientId().value, 1998L),
                         Pair(client2.requireClientId().value, 2000L),
+                        Pair(INITIAL_ACTOR_ID.value, 2002L),
                         Pair(client3.requireClientId().value, 2003L),
                     ),
                 ),

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
@@ -7,6 +7,7 @@ internal data class Attachment(
     val documentID: String,
     val syncMode: Client.SyncMode = Client.SyncMode.Realtime,
     val remoteChangeEventReceived: Boolean = false,
+    val cancelled: Boolean = false,
 ) {
 
     fun needRealTimeSync(): Boolean {

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -461,7 +461,8 @@ public class Client(
                                 handleWatchStreamFailure(
                                     document = attachment.document,
                                     stream = stream,
-                                    cause = it ?: ClosedReceiveChannelException("Channel was closed"),
+                                    cause = it
+                                        ?: ClosedReceiveChannelException("Channel was closed"),
                                     cancelled = attachment.cancelled,
                                 )
                             }

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -452,22 +452,25 @@ public class Client(
                                 }
                                 shouldContinue =
                                     handleWatchStreamFailure(
-                                        attachment.document,
-                                        stream,
-                                        it,
+                                        document = attachment.document,
+                                        stream = stream,
+                                        cause = it,
+                                        cancelled = attachment.cancelled,
                                     )
                             }.onClosed {
                                 handleWatchStreamFailure(
-                                    attachment.document,
-                                    stream,
-                                    it ?: ClosedReceiveChannelException("Channel was closed"),
+                                    document = attachment.document,
+                                    stream = stream,
+                                    cause = it ?: ClosedReceiveChannelException("Channel was closed"),
+                                    cancelled = attachment.cancelled,
                                 )
                             }
                         } ?: run {
                             handleWatchStreamFailure(
-                                attachment.document,
-                                stream,
-                                TimeoutException("channel timed out"),
+                                document = attachment.document,
+                                stream = stream,
+                                cause = TimeoutException("channel timed out"),
+                                cancelled = attachment.cancelled,
                             )
                             shouldContinue = true
                         }
@@ -499,13 +502,14 @@ public class Client(
         document: Document,
         stream: ServerOnlyStreamInterface<*, *>,
         cause: Throwable?,
+        cancelled: Boolean,
     ): Boolean {
         onWatchStreamCanceled(document)
         stream.safeClose()
 
         cause?.let(::sendWatchStreamException)
 
-        if (handleAuthenticationError(cause, document, WatchDocuments)) {
+        if (handleAuthenticationError(cause, document, WatchDocuments) && !cancelled) {
             coroutineContext.ensureActive()
             delay(options.reconnectStreamDelay.inWholeMilliseconds)
             return true
@@ -992,13 +996,18 @@ public class Client(
                 ErrDocumentNotAttached,
                 "document(${document.key}) is not attached",
             )
+        val cancelled = syncMode == SyncMode.Manual
         attachments.value += document.key to if (syncMode == SyncMode.Realtime) {
             attachment.copy(
                 syncMode = syncMode,
                 remoteChangeEventReceived = true,
+                cancelled = cancelled,
             )
         } else {
-            attachment.copy(syncMode = syncMode)
+            attachment.copy(
+                syncMode = syncMode,
+                cancelled = cancelled,
+            )
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/ChangeID.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/ChangeID.kt
@@ -83,7 +83,6 @@ public data class ChangeID(
      */
     fun setClocks(otherLamport: Long, vector: VersionVector): ChangeID {
         val lamport = if (otherLamport > lamport) otherLamport + 1 else lamport + 1
-        vector.unset(INITIAL_ACTOR_ID.value)
 
         val maxVersionVector = this.versionVector.max(vector)
         maxVersionVector.set(actor.value, lamport)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- [x] Prevent watch stream creation after cancellation: https://github.com/yorkie-team/yorkie-js-sdk/pull/1056
- [ ] Modernize and align with React TodoMVC: https://github.com/yorkie-team/yorkie-js-sdk/pull/1057
- [ ] Connect tldraw undo/redo to History API: https://github.com/yorkie-team/yorkie-js-sdk/pull/1060
- [x] Fix incorrect deletion of compacted documents: https://github.com/yorkie-team/yorkie-js-sdk/pull/1061

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://jira.navercorp.com/browse/RTCOLLABPLATFORM-388

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added cancellation support for document attachments, enabling intentional stop of realtime syncing when switching to Manual mode.

* Improvements
  * Sync behavior is now cancellation-aware, preventing unnecessary reconnection attempts after a user-initiated cancel.
  * More predictable behavior when toggling between Manual and Realtime modes.

* Bug Fixes
  * Resolved unintended auto-reconnects after switching to Manual mode.
  * Improved handling of timeouts and closed connections to respect cancellation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->