### PR TITLE
Plain Text Collaborative Edit (Upstream) (Editor → Yorkie.Tree)

### DIFF
--- a/collaborative-editing/src/main/kotlin/dev/yorkie/collaborative/editing/EditorAdapter.kt
+++ b/collaborative-editing/src/main/kotlin/dev/yorkie/collaborative/editing/EditorAdapter.kt
@@ -9,8 +9,12 @@ import dev.yorkie.document.operation.OperationInfo
  * This adapter bridges the gap between the editor's internal data model and
  * Yorkie's Tree data structure, enabling bidirectional synchronization.
  *
- * For Milestone 1, this provides the basic structure for event subscription.
- * Future milestones will add operation conversion methods.
+ * ## Milestone 1 Features:
+ * - Basic structure for event subscription
+ *
+ * ## Milestone 2 Features:
+ * - Editor content access for conversion
+ * - Local operation handling
  */
 public interface EditorAdapter {
 
@@ -54,24 +58,50 @@ public interface EditorAdapter {
      * Unsubscribe from editor change events.
      */
     public fun unsubscribeFromChanges()
+
+    // ========== Milestone 2: Content Access Methods ==========
+
+    /**
+     * Get the current editor content as plain text.
+     *
+     * This method is used by the plugin to:
+     * - Initialize the Yorkie tree with editor content
+     * - Verify consistency between editor and Yorkie tree
+     *
+     * @return The current content of the editor
+     */
+    public fun getContent(): EditorContent
+
+    /**
+     * Set the editor content from the given EditorContent.
+     *
+     * This is called when the tree needs to be synchronized to the editor,
+     * such as on initialization or snapshot.
+     *
+     * @param content The content to set in the editor
+     */
+    public fun setContent(content: EditorContent)
 }
 
 /**
  * Listener interface for editor change events.
  *
  * Editors implement this to notify the plugin about local changes.
+ *
+ * ## Milestone 2 Features:
+ * - Typed operation handling with EditorOperation
  */
 public interface EditorChangeListener {
 
     /**
      * Called when the user makes a local edit to the document.
      *
-     * For Milestone 1, this is a placeholder. Milestone 2 will implement
-     * the actual operation conversion from editor operations to Yorkie operations.
+     * For Milestone 2, this handles typed EditorOperation for conversion
+     * to Yorkie tree operations.
      *
-     * @param changeInfo Information about the change (editor-specific format)
+     * @param operation The operation representing the local change
      */
-    public fun onLocalChange(changeInfo: Any)
+    public suspend fun onLocalChange(operation: EditorOperation)
 
     /**
      * Called when the user's selection or cursor position changes.

--- a/collaborative-editing/src/main/kotlin/dev/yorkie/collaborative/editing/EditorOperation.kt
+++ b/collaborative-editing/src/main/kotlin/dev/yorkie/collaborative/editing/EditorOperation.kt
@@ -1,0 +1,101 @@
+package dev.yorkie.collaborative.editing
+
+/**
+ * Represents editor operations that can be converted to Yorkie Tree operations.
+ *
+ * These operations are used to capture local editor changes and convert them
+ * to Yorkie Tree operations for synchronization.
+ *
+ * ## Milestone 2 Features:
+ * - Plain text edit operations (insert, delete, replace)
+ * - Path-based operations for tree structure
+ */
+public sealed class EditorOperation {
+
+    /**
+     * Represents an edit operation on the editor content.
+     *
+     * For plain text editing (Milestone 2), this captures text insertions,
+     * deletions, and replacements using index-based positions.
+     *
+     * @property from The start index of the edit range
+     * @property to The end index of the edit range
+     * @property content The content to insert (empty for deletions)
+     */
+    public data class Edit(
+        val from: Int,
+        val to: Int,
+        val content: String,
+    ) : EditorOperation() {
+
+        /**
+         * Whether this operation is an insertion (no content being replaced).
+         */
+        val isInsertion: Boolean
+            get() = from == to && content.isNotEmpty()
+
+        /**
+         * Whether this operation is a deletion (no content being inserted).
+         */
+        val isDeletion: Boolean
+            get() = from != to && content.isEmpty()
+
+        /**
+         * Whether this operation is a replacement (content being replaced).
+         */
+        val isReplacement: Boolean
+            get() = from != to && content.isNotEmpty()
+    }
+
+    /**
+     * Represents an edit operation using path-based addressing.
+     *
+     * Path-based operations are useful for tree-structured editors where
+     * positions are specified as paths through the tree hierarchy.
+     *
+     * @property fromPath The path to the start position
+     * @property toPath The path to the end position
+     * @property content The content to insert (empty for deletions)
+     */
+    public data class EditByPath(
+        val fromPath: List<Int>,
+        val toPath: List<Int>,
+        val content: String,
+    ) : EditorOperation()
+
+    /**
+     * Represents a batch of operations to be applied atomically.
+     *
+     * This is useful for editors that generate multiple operations
+     * for a single user action (e.g., composition, autocomplete).
+     *
+     * @property operations The list of operations to apply
+     * @property message Optional message describing the batch
+     */
+    public data class Batch(
+        val operations: List<EditorOperation>,
+        val message: String? = null,
+    ) : EditorOperation()
+}
+
+/**
+ * Represents the editor's text content for conversion to Yorkie Tree.
+ *
+ * This is a simple representation of plain text content that can be
+ * converted to a Yorkie Tree structure.
+ *
+ * @property text The plain text content
+ * @property rootType The type of the root element (default: "root")
+ * @property paragraphType The type of paragraph elements (default: "p")
+ */
+public data class EditorContent(
+    val text: String,
+    val rootType: String = "root",
+    val paragraphType: String = "p",
+) {
+    /**
+     * Split the text into paragraphs (by newline).
+     */
+    public val paragraphs: List<String>
+        get() = text.split("\n")
+}

--- a/collaborative-editing/src/main/kotlin/dev/yorkie/collaborative/editing/TreeConverter.kt
+++ b/collaborative-editing/src/main/kotlin/dev/yorkie/collaborative/editing/TreeConverter.kt
@@ -1,0 +1,361 @@
+package dev.yorkie.collaborative.editing
+
+import dev.yorkie.document.json.JsonTree
+import dev.yorkie.document.json.JsonTree.ElementNode
+import dev.yorkie.document.json.JsonTree.TextNode
+import dev.yorkie.document.json.JsonTree.TreeNode
+import timber.log.Timber
+
+/**
+ * Converter for transforming editor data and operations to Yorkie Tree format.
+ *
+ * This converter handles the bidirectional transformation between
+ * the editor's internal representation and Yorkie's Tree data structure.
+ *
+ * ## Milestone 2 Features:
+ * - Convert editor content to Yorkie tree data
+ * - Convert editor operations to Yorkie tree operations
+ * - Verify editor and tree data consistency
+ *
+ * ## Tree Structure:
+ * For plain text editing, we use a simple tree structure:
+ * ```
+ * <root>
+ *   <p>paragraph 1 text</p>
+ *   <p>paragraph 2 text</p>
+ * </root>
+ * ```
+ *
+ * ## Index Mapping:
+ * The index in the editor corresponds to positions in the flattened tree.
+ * For a tree like `<root><p>hello</p></root>`:
+ * - Index 0: before 'h' (inside <p>)
+ * - Index 1: after 'h'
+ * - Index 2: after 'e'
+ * - etc.
+ *
+ * The Yorkie tree uses a different indexing that includes element boundaries:
+ * - Index 0: before <p>
+ * - Index 1: before 'h' (inside <p>)
+ * - Index 2-6: character positions
+ * - Index 7: after </p>
+ */
+public class TreeConverter(
+    private val config: TreeConverterConfig = TreeConverterConfig(),
+) {
+
+    /**
+     * Convert editor content to a Yorkie tree structure.
+     *
+     * @param content The editor content to convert
+     * @return The root element node of the tree
+     */
+    public fun editorContentToTree(content: EditorContent): ElementNode {
+        val paragraphs = content.paragraphs
+        val children = paragraphs.map { paragraphText ->
+            if (paragraphText.isEmpty()) {
+                // Empty paragraph with empty text node
+                ElementNode(
+                    type = config.paragraphType,
+                    children = listOf(TextNode("")),
+                )
+            } else {
+                ElementNode(
+                    type = config.paragraphType,
+                    children = listOf(TextNode(paragraphText)),
+                )
+            }
+        }
+
+        return ElementNode(
+            type = config.rootType,
+            children = children,
+        )
+    }
+
+    /**
+     * Convert a Yorkie tree to plain text content.
+     *
+     * @param tree The Yorkie tree to convert
+     * @return The plain text content
+     */
+    public fun treeToEditorContent(tree: JsonTree?): EditorContent {
+        if (tree == null) {
+            return EditorContent("")
+        }
+
+        val text = extractTextFromTree(tree.rootTreeNode)
+        return EditorContent(
+            text = text,
+            rootType = config.rootType,
+            paragraphType = config.paragraphType,
+        )
+    }
+
+    /**
+     * Recursively extract text from a tree node.
+     */
+    private fun extractTextFromTree(node: TreeNode): String {
+        return when (node) {
+            is TextNode -> node.value
+            is ElementNode -> {
+                val childTexts = node.children.map { extractTextFromTree(it) }
+                if (node.type == config.paragraphType) {
+                    // Join paragraph children and add newline at the end
+                    childTexts.joinToString("")
+                } else {
+                    // For root and other elements, join with newlines between paragraphs
+                    childTexts.joinToString("\n")
+                }
+            }
+            else -> ""
+        }
+    }
+
+    /**
+     * Convert editor index to Yorkie tree index.
+     *
+     * The editor uses a flat index (character position in text).
+     * The Yorkie tree uses an index that accounts for element boundaries.
+     *
+     * For a simple structure `<root><p>hello</p></root>`:
+     * - Editor index 0 -> Tree index 1 (inside <p>, before 'h')
+     * - Editor index 5 -> Tree index 6 (inside <p>, after 'o')
+     *
+     * @param editorIndex The editor's character index
+     * @param tree The current tree state
+     * @return The corresponding Yorkie tree index
+     */
+    public fun editorIndexToTreeIndex(editorIndex: Int, tree: JsonTree): Int {
+        // For a simple single-paragraph structure, add 1 for the opening <p> tag
+        // For multi-paragraph, we need to account for additional element boundaries
+        return editorIndexToTreeIndexInternal(editorIndex, tree.rootTreeNode, 0).first
+    }
+
+    /**
+     * Internal recursive function to convert editor index to tree index.
+     *
+     * @return Pair of (treeIndex, consumedEditorChars)
+     */
+    private fun editorIndexToTreeIndexInternal(
+        targetEditorIndex: Int,
+        node: TreeNode,
+        currentTreeIndex: Int,
+    ): Pair<Int, Int> {
+        when (node) {
+            is TextNode -> {
+                val textLength = node.value.length
+                // Each character in text node maps 1:1 with tree index
+                return if (targetEditorIndex <= textLength) {
+                    (currentTreeIndex + targetEditorIndex) to textLength
+                } else {
+                    (currentTreeIndex + textLength) to textLength
+                }
+            }
+            is ElementNode -> {
+                var treeIdx = currentTreeIndex + 1 // Account for opening tag
+                var editorCharsConsumed = 0
+
+                for ((index, child) in node.children.withIndex()) {
+                    val remainingEditorIndex = targetEditorIndex - editorCharsConsumed
+
+                    if (remainingEditorIndex < 0) {
+                        break
+                    }
+
+                    val (childTreeIndex, childConsumed) = editorIndexToTreeIndexInternal(
+                        remainingEditorIndex,
+                        child,
+                        treeIdx,
+                    )
+
+                    if (remainingEditorIndex <= childConsumed) {
+                        return childTreeIndex to (editorCharsConsumed + remainingEditorIndex)
+                    }
+
+                    editorCharsConsumed += childConsumed
+
+                    // Add newline between paragraphs in editor representation
+                    if (node.type == config.rootType &&
+                        child is ElementNode &&
+                        child.type == config.paragraphType &&
+                        index < node.children.size - 1
+                    ) {
+                        editorCharsConsumed += 1 // Newline character
+                    }
+
+                    treeIdx = childTreeIndex + if (child is ElementNode) 1 else 0 // Closing tag
+                }
+
+                return treeIdx to editorCharsConsumed
+            }
+            else -> return currentTreeIndex to 0
+        }
+    }
+
+    /**
+     * Convert an editor operation to tree edit parameters.
+     *
+     * @param operation The editor operation
+     * @param tree The current tree state
+     * @return Triple of (fromIndex, toIndex, content nodes) for tree.edit()
+     */
+    public fun editorOperationToTreeEdit(
+        operation: EditorOperation.Edit,
+        tree: JsonTree,
+    ): TreeEditParams {
+        val fromTreeIndex = editorIndexToTreeIndex(operation.from, tree)
+        val toTreeIndex = editorIndexToTreeIndex(operation.to, tree)
+
+        val contentNodes = if (operation.content.isNotEmpty()) {
+            listOf(TextNode(operation.content))
+        } else {
+            emptyList()
+        }
+
+        return TreeEditParams(
+            fromIndex = fromTreeIndex,
+            toIndex = toTreeIndex,
+            contents = contentNodes,
+        )
+    }
+
+    /**
+     * Apply an editor operation to the Yorkie tree.
+     *
+     * This method converts the editor operation and applies it to the tree.
+     *
+     * @param operation The editor operation to apply
+     * @param tree The Yorkie tree to edit
+     */
+    public fun applyOperationToTree(operation: EditorOperation, tree: JsonTree) {
+        when (operation) {
+            is EditorOperation.Edit -> {
+                val params = editorOperationToTreeEdit(operation, tree)
+                Timber.d(
+                    "TreeConverter: Applying edit - from=${params.fromIndex}, " +
+                        "to=${params.toIndex}, content=${params.contents}",
+                )
+
+                if (params.contents.isEmpty()) {
+                    // Deletion
+                    tree.edit(params.fromIndex, params.toIndex)
+                } else {
+                    // Insertion or replacement
+                    tree.edit(
+                        params.fromIndex,
+                        params.toIndex,
+                        *params.contents.toTypedArray(),
+                    )
+                }
+            }
+
+            is EditorOperation.EditByPath -> {
+                val contentNodes = if (operation.content.isNotEmpty()) {
+                    arrayOf<TreeNode>(TextNode(operation.content))
+                } else {
+                    emptyArray()
+                }
+
+                Timber.d(
+                    "TreeConverter: Applying edit by path - from=${operation.fromPath}, " +
+                        "to=${operation.toPath}, content=$contentNodes",
+                )
+
+                tree.editByPath(
+                    operation.fromPath,
+                    operation.toPath,
+                    *contentNodes,
+                )
+            }
+
+            is EditorOperation.Batch -> {
+                Timber.d("TreeConverter: Applying batch of ${operation.operations.size} operations")
+                operation.operations.forEach { op ->
+                    applyOperationToTree(op, tree)
+                }
+            }
+        }
+    }
+
+    /**
+     * Verify that the editor content matches the Yorkie tree content.
+     *
+     * This is useful for debugging and ensuring synchronization is correct.
+     *
+     * @param editorContent The current editor content
+     * @param tree The current Yorkie tree
+     * @return VerificationResult indicating match or mismatch details
+     */
+    public fun verifyConsistency(
+        editorContent: EditorContent,
+        tree: JsonTree?,
+    ): VerificationResult {
+        if (tree == null) {
+            return if (editorContent.text.isEmpty()) {
+                VerificationResult.Match
+            } else {
+                VerificationResult.Mismatch(
+                    expected = editorContent.text,
+                    actual = "",
+                    message = "Tree is null but editor has content",
+                )
+            }
+        }
+
+        val treeContent = treeToEditorContent(tree)
+
+        return if (editorContent.text == treeContent.text) {
+            VerificationResult.Match
+        } else {
+            VerificationResult.Mismatch(
+                expected = editorContent.text,
+                actual = treeContent.text,
+                message = "Editor content does not match tree content",
+            )
+        }
+    }
+
+    public companion object {
+        private const val TAG = "TreeConverter"
+    }
+}
+
+/**
+ * Configuration for the TreeConverter.
+ *
+ * @property rootType The type name for the root element
+ * @property paragraphType The type name for paragraph elements
+ */
+public data class TreeConverterConfig(
+    val rootType: String = "root",
+    val paragraphType: String = "p",
+)
+
+/**
+ * Parameters for a tree edit operation.
+ */
+public data class TreeEditParams(
+    val fromIndex: Int,
+    val toIndex: Int,
+    val contents: List<TreeNode>,
+)
+
+/**
+ * Result of verifying consistency between editor and tree.
+ */
+public sealed class VerificationResult {
+    /**
+     * Editor and tree content match.
+     */
+    public data object Match : VerificationResult()
+
+    /**
+     * Editor and tree content do not match.
+     */
+    public data class Mismatch(
+        val expected: String,
+        val actual: String,
+        val message: String,
+    ) : VerificationResult()
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- Implements upstream synchronization for the collaborative editing plugin - converting editor operations to Yorkie Tree operations.
- Key Features
  - Convert editor content to Yorkie Tree structure
  - Convert editor operations to Tree edit operations
  - Verify editor/tree consistency after local updates
  - Prevent infinite loops during remote updates

#### Any background context you want to provide?

#### What are the relevant tickets?

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://jira.navercorp.com/browse/RTCOLLABPLATFORM-586

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
