### PR TITLE
Refactor broadcast handling in Presence

### DIFF
--- a/.claude/agents/protobuf-converter-checker.md
+++ b/.claude/agents/protobuf-converter-checker.md
@@ -1,0 +1,120 @@
+---
+name: protobuf-converter-checker
+description: Verifies that proto changes in yorkie/proto/yorkie/v1/ are fully reflected in all *Converter.kt files. Triggered by team-review when .proto files are in the diff. Checks bidirectional coverage for Operation, JSONElement, PresenceChange, ValueType, and RuleType variants.
+model: sonnet
+tools: Glob, Grep, Read, Bash
+---
+
+# protobuf-converter-checker
+
+You verify that changes to `.proto` files are fully reflected in all `*Converter.kt` files.
+**Read the actual diff and the actual converter files. Do not trust summaries.**
+
+## Proto and converter locations
+
+**Proto files:**
+- `yorkie/proto/yorkie/v1/resources.proto` — core domain: Operation, JSONElement, TextNode, TreeNode, ValueType, PresenceChange, Rule
+- `yorkie/proto/yorkie/v1/yorkie.proto` — gRPC service RPCs and request/response messages
+
+**Converter files:**
+- `yorkie/src/main/kotlin/dev/yorkie/api/OperationConverter.kt` — Operation ↔ domain Operation subclasses
+- `yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt` — JSONElement ↔ CrdtElement subclasses, ValueType ↔ CrdtPrimitive.Type / CounterType
+- `yorkie/src/main/kotlin/dev/yorkie/api/ChangeConverter.kt` — Change, ChangeID, ChangePack
+- `yorkie/src/main/kotlin/dev/yorkie/api/PresenceConverter.kt` — PresenceChange variants
+- `yorkie/src/main/kotlin/dev/yorkie/api/RuleConverter.kt` — Schema Rule variants
+- `yorkie/src/main/kotlin/dev/yorkie/api/VersionVectorConverter.kt` — VersionVector map encoding
+- `yorkie/src/main/kotlin/dev/yorkie/api/TimeConverter.kt` — TimeTicket
+
+## Proto ↔ converter mapping
+
+Use this map to determine which converter to check for a given proto change:
+
+| Proto element | Converter file | When-branches to verify |
+|---|---|---|
+| `Operation` oneof variant (Set/Add/Move/Remove/Edit/Style/Increase/TreeEdit/TreeStyle/ArraySet) | `OperationConverter.kt` | `hasXxx()` in `toOperations()`, `is XxxOperation` in `toPBOperation()` |
+| `JSONElement` oneof variant (JSONObject/JSONArray/Text/Primitive/Counter/Tree) | `ElementConverter.kt` | `hasXxx()` in `toCrdtElement()`, `is CrdtXxx` in `toPBJsonElement()` |
+| `ValueType` enum value | `ElementConverter.kt` | `toPrimitiveType()`, `toCounterType()`, `PBJsonElementSimple.toCrdtElement()`, `CrdtElement.toPBJsonElementSimple()` |
+| `PresenceChange.ChangeType` enum value | `PresenceConverter.kt` | `toPresenceChange()`, `toPBPresenceChange()` |
+| `Rule` oneof variant | `RuleConverter.kt` | `fromSchemaRules()` when-branch |
+| New field on `Change` or `ChangeID` | `ChangeConverter.kt` | `toChanges()`, `toPBChange()`, `toChangeID()`, `toPBChangeID()` |
+| New field on `TextNode` | `ElementConverter.kt` | `toCrdtText()`, `toPBText()` |
+| New field on `TreeNode` | `ElementConverter.kt` | `toCrdtTree()`, `toPBTree()` |
+| New field on `TimeTicket` | `TimeConverter.kt` | `toTimeTicket()`, `toPBTimeTicket()` |
+| New field on `VersionVector` | `VersionVectorConverter.kt` | `toVersionVector()`, `toPBVersionVector()` |
+
+## How to check
+
+### Step 1 — Get the proto diff
+
+```bash
+git diff origin/develop...HEAD -- '*.proto'
+```
+
+If no proto files changed, output `No proto changes — nothing to check.` and stop.
+
+### Step 2 — Classify each proto change
+
+For each change in the diff, classify it as one of:
+
+| Change type | What to check |
+|---|---|
+| New `oneof` variant added to `Operation` | Both `toOperations()` and `toPBOperation()` in OperationConverter |
+| New `oneof` variant added to `JSONElement` | Both `toCrdtElement()` and `toPBJsonElement()` in ElementConverter, plus `PBJsonElementSimple.toCrdtElement()` and `CrdtElement.toPBJsonElementSimple()` |
+| New `ValueType` enum value | All four functions in ElementConverter: `toPrimitiveType()`, `toCounterType()`, and the two `JsonElementSimple` converters |
+| New `PresenceChange.ChangeType` | Both directions in PresenceConverter |
+| New `Rule` variant | `fromSchemaRules()` in RuleConverter |
+| New field on existing message | Corresponding converter's read and write functions |
+| Field number changed | Flag as **wire-breaking** — no converter update can fix this |
+| Field removed | Flag as **wire-breaking** |
+| New RPC on `YorkieService` | Check `YorkieService` interface in `core/` for the new stub call |
+
+### Step 3 — Read each affected converter
+
+For each affected converter file, read it and verify:
+
+1. **Bidirectional coverage**: every proto variant has a handler in both the proto→domain and domain→proto directions.
+2. **`else` branch safety**: if a `when` expression has an `else` branch, note what it does (throws, logs, silently drops). Silent drops are high severity.
+3. **Exhaustiveness**: Kotlin `when` on a sealed class is exhaustive — but `when` on a proto oneof (which is not a sealed class) is not. Check that new variants are not silently falling through to `else`.
+
+### Step 4 — Check domain model alignment
+
+If a new proto variant was added, check whether a corresponding domain class exists:
+
+- New `Operation` variant → does a new `XxxOperation` class exist under `document/operation/`?
+- New `JSONElement` variant → does a new `CrdtXxx` class exist under `document/crdt/`?
+
+If the proto was added but the domain class is missing, the converter cannot be correct — flag as **Blocked**.
+
+## Output format
+
+```
+### Proto Changes Detected
+- List each changed proto file and what changed
+
+### Coverage Check
+
+#### OperationConverter.kt
+- [OK] hasXxx() → XxxOperation (toOperations)
+- [MISSING] toPBOperation() has no branch for XxxOperation
+- ...
+
+#### ElementConverter.kt
+- [OK] ...
+- [MISSING] ...
+
+#### (other affected converters)
+
+### Wire-Breaking Changes
+- [Breaking] Field number N on MessageX changed from Y to Z — clients on old proto will misread this field
+
+### Blocked
+- Domain class `XxxOperation` not found — converter cannot be implemented until domain class exists
+
+### Summary
+- Missing branches: N
+- Wire-breaking: N
+- Blocked: N
+- Verdict: Approved / Needs fixes / Blocked
+```
+
+Only list converters that are relevant to the diff. Skip converters with no related proto changes.

--- a/.claude/agents/yorkie-js-researcher.md
+++ b/.claude/agents/yorkie-js-researcher.md
@@ -1,0 +1,112 @@
+---
+name: yorkie-js-researcher
+description: Researches the Yorkie JS SDK codebase to answer questions about JS-side implementations, CRDT logic, API design, and sync protocols. Use when porting features from JS to Android or comparing implementations.
+model: sonnet
+tools: Glob, Grep, Read, Bash
+---
+
+# yorkie-js-researcher
+
+You research the Yorkie JS SDK to answer questions about its implementation.
+The JS SDK is the reference implementation — the Android SDK ports features from it.
+
+## Setup — clone and checkout
+
+Before doing any research, ensure the JS SDK is available locally:
+
+```bash
+JS_SDK_DIR="/tmp/yorkie-js-sdk"
+if [ ! -d "$JS_SDK_DIR/.git" ]; then
+  git clone https://github.com/yorkie-team/yorkie-js-sdk.git "$JS_SDK_DIR"
+else
+  git -C "$JS_SDK_DIR" fetch origin
+  git -C "$JS_SDK_DIR" checkout main && git -C "$JS_SDK_DIR" reset --hard origin/main
+fi
+```
+
+### PR mode
+
+When a specific PR number is provided (e.g. `yorkie-js-sdk#1099`), check out that PR's branch:
+
+```bash
+# Fetch the PR's head ref and create a local branch
+git -C "$JS_SDK_DIR" fetch origin pull/{PR_N}/head:pr-{PR_N}
+git -C "$JS_SDK_DIR" checkout pr-{PR_N}
+```
+
+Then also fetch the full diff for quick reference:
+
+```bash
+# Get the PR diff summary and changed files
+gh pr view {PR_N} --repo yorkie-team/yorkie-js-sdk --json title,body,files
+gh pr diff {PR_N} --repo yorkie-team/yorkie-js-sdk
+```
+
+This lets you read both the final state of files on the PR branch AND the diff of what changed.
+
+Run setup once at the start of every research session. All paths below are relative to `$JS_SDK_DIR`.
+
+## Key directories
+
+| Path | Purpose |
+|------|---------|
+| `packages/sdk/src/` | Main SDK source |
+| `packages/sdk/src/document/` | Document, CRDT types, JSON wrappers, operations, change tracking |
+| `packages/sdk/src/document/crdt/` | CRDT implementations (RGA, RHT, CRDTTree, CRDTText, etc.) |
+| `packages/sdk/src/document/json/` | User-facing JSON API wrappers (JsonObject, JsonArray, Tree, Text) |
+| `packages/sdk/src/document/operation/` | Operation types (Set, Add, Remove, Edit, TreeEdit, etc.) |
+| `packages/sdk/src/client/` | Client connection, sync loop, attach/detach |
+| `packages/sdk/src/api/` | Protobuf converters (converter.ts) |
+| `packages/sdk/src/util/` | Utilities (IndexTree, SplayTree, LLRBTree, etc.) |
+| `packages/sdk/test/` | Unit and integration tests |
+| `packages/schema/` | Schema validation package |
+
+## Android SDK counterpart
+
+The Android SDK is the current working directory (the repo this agent lives in).
+Its structure mirrors the JS SDK:
+
+| JS SDK path | Android SDK path |
+|-------------|-----------------|
+| `packages/sdk/src/document/crdt/` | `yorkie/src/main/kotlin/dev/yorkie/document/crdt/` |
+| `packages/sdk/src/document/json/` | `yorkie/src/main/kotlin/dev/yorkie/document/json/` |
+| `packages/sdk/src/document/operation/` | `yorkie/src/main/kotlin/dev/yorkie/document/operation/` |
+| `packages/sdk/src/api/converter.ts` | `yorkie/src/main/kotlin/dev/yorkie/api/*Converter.kt` |
+| `packages/sdk/src/client/client.ts` | `yorkie/src/main/kotlin/dev/yorkie/core/Client.kt` |
+| `packages/sdk/src/document/document.ts` | `yorkie/src/main/kotlin/dev/yorkie/document/Document.kt` |
+
+## How to research
+
+1. **Run the setup step** — clone or update, and if a PR number is given, check out the PR branch.
+2. **Search and read JS SDK files** at `/tmp/yorkie-js-sdk/...`.
+3. **For PR tasks** — read the PR diff first to understand the scope, then read full files for context.
+4. **Compare with Android SDK** — if asked, read the Android counterpart from the current working directory.
+5. **Be precise** — cite file paths and line numbers. Quote relevant code snippets.
+6. **Check git history** when needed — `git -C /tmp/yorkie-js-sdk log --oneline -20` or `git -C /tmp/yorkie-js-sdk log --oneline --all -- <path>`.
+
+## Common research tasks
+
+- **Feature parity**: "How does JS implement X?" → find the JS implementation, summarize the logic, note any Android gaps.
+- **CRDT internals**: "How does CRDTTree handle split/merge?" → read the JS CRDT code and explain the algorithm.
+- **API design**: "What parameters does Tree.edit() accept in JS?" → read the JSON wrapper and document the API.
+- **Converter mapping**: "How does JS convert TreeEdit operations to protobuf?" → read `converter.ts` for the relevant section.
+- **Test patterns**: "How does JS test concurrent tree edits?" → search test files for relevant test cases.
+- **PR analysis**: "What does yorkie-js-sdk#1099 change?" → checkout the PR branch, read the diff, explain what changed and what needs porting to Android.
+
+## Output format
+
+Keep answers focused and structured:
+
+```
+### Question
+<restate what was asked>
+
+### JS Implementation
+<file paths, key code snippets, explanation>
+
+### Android Comparison (if requested)
+<differences, missing pieces, implementation notes>
+
+### References
+<list of files read with line ranges>
+```

--- a/.claude/skills/solve-jira/SKILL.md
+++ b/.claude/skills/solve-jira/SKILL.md
@@ -35,9 +35,27 @@ argument-hint: "[issue-number] [--from baseBranch] [--exec-model opus|sonnet|hai
 
 2. Check assignee (`GET /rest/api/2/myself`). Stop if assigned to someone else.
 
-3. Check current status from issue `fields.status.name`:
+3. **JS sync check** — if the issue title contains a reference to `yorkie-js-sdk#` (e.g. `(yorkie-js-sdk#1099)`):
+   - Fetch the PR's changed files:
+     ```bash
+     curl -s "https://api.github.com/repos/yorkie-team/yorkie-js-sdk/pulls/{PR_N}/files" \
+       | python3 -c "import sys,json; [print(f['filename']) for f in json.load(sys.stdin)]"
+     ```
+   - If **all** changed files are outside `packages/sdk/src/` (e.g. only `packages/react/`, `examples/`, docs):
+     - Inform the user: "This issue only touches the JS UI/integration layer — no Android SDK changes needed."
+     - Transition issue to **Closed** (id: `61`) with resolution **Won't Fix** (id: `10500`):
+       ```bash
+       curl -s -X POST -H "Authorization: Bearer $JIRA_PERSONAL_TOKEN" \
+         -H "Content-Type: application/json" \
+         -d '{"transition":{"id":"61"},"fields":{"resolution":{"id":"10500"}}}' \
+         "https://jira.navercorp.com/rest/api/2/issue/RTCOLLABPLATFORM-{N}/transitions"
+       ```
+     - **Stop here.** Do not create a branch or proceed further.
+   - If any changed files are under `packages/sdk/src/` → continue normally.
+
+4. Check current status from issue `fields.status.name`:
    - `"In Progress"` → skip, no transition needed
-   - `"To Do"` → transition to "In Progress" (id: `21`):
+   - `"To Do"` or `"Open"` → transition to "In Progress" (id: `21`):
      ```bash
      curl -s -X POST -H "Authorization: Bearer $JIRA_PERSONAL_TOKEN" \
        -H "Content-Type: application/json" \
@@ -46,9 +64,9 @@ argument-hint: "[issue-number] [--from baseBranch] [--exec-model opus|sonnet|hai
      ```
    - Any other status → ask user before transitioning.
 
-4. Branch naming: Bug → `fix/RTCOLLABPLATFORM-{N}`, all others → `feat/RTCOLLABPLATFORM-{N}`
+5. Branch naming: Bug → `fix/RTCOLLABPLATFORM-{N}`, all others → `feat/RTCOLLABPLATFORM-{N}`
 
-5. Create branch from `--from` base (default: `origin/develop`):
+6. Create branch from `--from` base (default: `origin/develop`):
    ```bash
    git fetch origin develop
    git checkout -b {branch} --no-track origin/develop
@@ -59,9 +77,15 @@ argument-hint: "[issue-number] [--from baseBranch] [--exec-model opus|sonnet|hai
 
 Both phases run in a single planning subagent (`run_in_background: true`, `mode: "plan"`).
 
-**Phase 2:** Subagent explores codebase and writes a prompt describing what to implement. Show to user, wait for approval.
+**Phase 2a — JS SDK research (if applicable):** If the issue references a JS SDK PR (`yorkie-js-sdk#N`), or the feature exists in the JS SDK, spawn `yorkie-js-researcher` to research the JS implementation before planning. Include in the prompt:
+- The JS PR number or feature name
+- "Show the relevant JS implementation, key files, algorithm, and API surface"
 
-**Phase 3:** Resume subagent with approved prompt to write detailed plan. Plan must include: absolute file paths, specific locations (class/function/line), exact code snippets, new files, test cases, change order.
+Attach the researcher's output to the planning subagent's context.
+
+**Phase 2b:** Subagent explores codebase and writes a prompt describing what to implement. Show to user, wait for approval.
+
+**Phase 3:** Resume subagent with approved prompt to write detailed plan. Plan must include: absolute file paths, specific locations (class/function/line), exact code snippets, new files, test cases, change order. If JS research was done, reference the JS implementation and note any intentional deviations.
 
 Save plan to: `docs/superpowers/plans/RTCOLLABPLATFORM-{N}.md`
 

--- a/.claude/skills/team-review/SKILL.md
+++ b/.claude/skills/team-review/SKILL.md
@@ -2,7 +2,8 @@
 name: team-review
 description: |
   Multi-agent review for yorkie-android-sdk. Runs critic-reviewer and test-writer in parallel;
-  adds api-compat-checker when Client, Document, JsonObject/Array/Text/Tree, or .proto files are in the diff.
+  adds api-compat-checker when Client, Document, JsonObject/Array/Text/Tree, or .proto files are in the diff;
+  adds protobuf-converter-checker when .proto files are in the diff.
   Triggered by "team review", "review changes", "review this", "review PR", "code review".
 argument-hint: "[--target plan|changes|branch] [--method subagent|team] [--base main]"
 ---
@@ -36,10 +37,14 @@ For plan mode, pass the plan content and referenced source file paths.
 
 Always run: `critic-reviewer`, `test-writer`
 
+Also run `yorkie-js-researcher` if the JIRA issue or PR description references a JS SDK PR (`yorkie-js-sdk#N`), or if the diff touches CRDT/operation logic under `document/crdt/` or `document/operation/`. Prompt it to compare the Android implementation against the JS SDK reference and flag any divergences.
+
 Also run `api-compat-checker` if any of these appear in the changed file list:
 - `Client.kt`, `Document.kt`
 - `JsonObject.kt`, `JsonArray.kt`, `JsonText.kt`, `JsonTree.kt`
 - Any file matching `*.proto`
+
+Also run `protobuf-converter-checker` if any file matching `*.proto` appears in the changed file list.
 
 ## Step 5: Project context (include in every agent prompt)
 
@@ -74,6 +79,7 @@ Dispatch all selected agents as Task agents simultaneously. Wait for all. If one
 - **critic-reviewer**: summary
 - **test-writer**: summary
 - **api-compat-checker** (if run): summary
+- **protobuf-converter-checker** (if run): summary
 
 ### Recommended Actions
 1. Must fix before merge

--- a/yorkie/proto/yorkie/v1/yorkie.proto
+++ b/yorkie/proto/yorkie/v1/yorkie.proto
@@ -161,6 +161,7 @@ message WatchPresenceResponse {
   oneof body {
     WatchPresenceInitialized initialized = 1;
     PresenceEvent event = 2;
+    DocEvent broadcast = 3;
   }
 }
 
@@ -174,6 +175,7 @@ message BroadcastRequest {
   string document_id = 2;
   string topic = 3;
   bytes payload = 4;
+  string presence_key = 5;
 }
 
 message BroadcastResponse {

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/presence/PresenceTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/presence/PresenceTest.kt
@@ -1,6 +1,7 @@
 package dev.yorkie.presence
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.yorkie.core.GENERAL_TIMEOUT
 import dev.yorkie.core.ResourceStatus
 import dev.yorkie.core.createClient
 import dev.yorkie.core.toDocKey
@@ -12,8 +13,10 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -344,6 +347,99 @@ class PresenceTest {
             c1.close()
             c2.close()
             c3.close()
+        }
+    }
+
+    @Test
+    fun test_presence_broadcast_received_by_subscriber() {
+        runBlocking {
+            val c1 = createClient()
+            val c2 = createClient()
+
+            c1.activateAsync().await()
+            c2.activateAsync().await()
+
+            val presenceKey = "presence-broadcast-${UUID.randomUUID()}".toDocKey()
+            val p1 = Presence(presenceKey)
+            val p2 = Presence(presenceKey)
+
+            c1.attachPresence(p1).await()
+            c2.attachPresence(p2).await()
+            delay(200)
+
+            // Collect broadcast events on p1
+            val broadcastEvents = mutableListOf<PresenceEvent.Broadcast>()
+            val collectJob = launch(start = CoroutineStart.UNDISPATCHED) {
+                p1.eventStream
+                    .filterIsInstance<PresenceEvent.Broadcast>()
+                    .collect { broadcastEvents.add(it) }
+            }
+
+            // c2 broadcasts on the presence key
+            c2.broadcast(presenceKey, "hello", "world").await()
+
+            withTimeout(GENERAL_TIMEOUT) {
+                while (broadcastEvents.isEmpty()) {
+                    delay(50)
+                }
+            }
+
+            assertEquals(1, broadcastEvents.size)
+            assertEquals("hello", broadcastEvents[0].topic)
+            assertEquals("world", broadcastEvents[0].payload)
+
+            collectJob.cancel()
+            c1.detachPresence(p1).await()
+            c2.detachPresence(p2).await()
+            c1.deactivateAsync().await()
+            c2.deactivateAsync().await()
+            c1.close()
+            c2.close()
+        }
+    }
+
+    @Test
+    fun test_presence_broadcast_does_not_arrive_on_document_event_stream() {
+        runBlocking {
+            val c1 = createClient()
+            val c2 = createClient()
+
+            c1.activateAsync().await()
+            c2.activateAsync().await()
+
+            val presenceKey = "presence-broadcast-isolation-${UUID.randomUUID()}".toDocKey()
+            val docKey = "doc-broadcast-isolation-${UUID.randomUUID()}".toDocKey()
+            val p1 = Presence(presenceKey)
+            val d2 = dev.yorkie.document.Document(docKey)
+
+            c1.attachPresence(p1).await()
+            c2.attachDocument(d2).await()
+            delay(200)
+
+            val docBroadcastEvents =
+                mutableListOf<dev.yorkie.document.Document.Event.Broadcast>()
+            val collectJob = launch(start = CoroutineStart.UNDISPATCHED) {
+                d2.events
+                    .filterIsInstance<dev.yorkie.document.Document.Event.Broadcast>()
+                    .collect { docBroadcastEvents.add(it) }
+            }
+
+            // c1 broadcasts on presence key — must NOT reach d2
+            c1.broadcast(presenceKey, "test-topic", "test-payload").await()
+            delay(500)
+
+            assertTrue(
+                docBroadcastEvents.isEmpty(),
+                "Document event stream must not receive a presence-scoped broadcast",
+            )
+
+            collectJob.cancel()
+            c1.detachPresence(p1).await()
+            c2.detachDocument(d2).await()
+            c1.deactivateAsync().await()
+            c2.deactivateAsync().await()
+            c1.close()
+            c2.close()
         }
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -727,6 +727,15 @@ public class Client(
                     PresenceEvent.Changed(count = count),
                 )
             }
+        } else if (response.hasBroadcast()) {
+            val broadcastEvent = response.broadcast
+            presence.publish(
+                PresenceEvent.Broadcast(
+                    actorID = broadcastEvent.publisher.takeIf { it.isNotEmpty() },
+                    topic = broadcastEvent.body.topic,
+                    payload = broadcastEvent.body.payload.toStringUtf8(),
+                ),
+            )
         }
     }
 
@@ -1220,7 +1229,11 @@ public class Client(
 
             val request = broadcastRequest {
                 clientId = clientID
-                documentId = attachment.resourceId
+                if (attachment.resource is Presence) {
+                    presenceKey = key
+                } else {
+                    documentId = attachment.resourceId
+                }
                 this.topic = topic
                 this.payload = ByteString.copyFromUtf8(payload)
             }
@@ -1239,12 +1252,14 @@ public class Client(
                         errorCodeOf(err) == ErrUnauthenticated.codeString
                     ) {
                         shouldRefreshToken = true
-                        attachment.resource.publish(
-                            event = AuthError(
-                                errorMetadataOf(err)?.get("reason") ?: "AuthError",
-                                Document.Event.AuthError.AuthErrorMethod.Broadcast,
-                            ),
-                        )
+                        if (attachment.resource is Document) {
+                            attachment.resource.publish(
+                                event = AuthError(
+                                    errorMetadataOf(err)?.get("reason") ?: "AuthError",
+                                    Document.Event.AuthError.AuthErrorMethod.Broadcast,
+                                ),
+                            )
+                        }
                     }
                     retryCount++
                     if (retryCount > maxRetries) {

--- a/yorkie/src/main/kotlin/dev/yorkie/presence/Presence.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/presence/Presence.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.launch
 
 sealed interface PresenceEvent : ResourceEvent {
     /**
-     * `count` is the current count value.
+     * Current count value. Zero for non-count events.
      */
     val count: Long
 
@@ -24,6 +24,17 @@ sealed interface PresenceEvent : ResourceEvent {
     data class Initialized(
         override val count: Long,
     ) : PresenceEvent
+
+    /**
+     * Broadcast event received from a remote client on this presence key.
+     */
+    data class Broadcast(
+        val actorID: String?,
+        val topic: String,
+        val payload: String,
+    ) : PresenceEvent {
+        override val count: Long = 0L
+    }
 }
 
 class Presence(

--- a/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
@@ -5,6 +5,7 @@ import com.connectrpc.ConnectException
 import com.connectrpc.Headers
 import com.connectrpc.ResponseMessage
 import com.connectrpc.ServerOnlyStreamInterface
+import com.google.protobuf.ByteString
 import com.google.protobuf.kotlin.toByteString
 import com.google.rpc.ErrorInfo
 import dev.yorkie.api.toPBChange
@@ -49,6 +50,7 @@ import dev.yorkie.api.v1.deactivateClientResponse
 import dev.yorkie.api.v1.detachDocumentResponse
 import dev.yorkie.api.v1.detachPresenceResponse
 import dev.yorkie.api.v1.docEvent
+import dev.yorkie.api.v1.docEventBody
 import dev.yorkie.api.v1.jSONElementSimple
 import dev.yorkie.api.v1.operation
 import dev.yorkie.api.v1.presenceEvent
@@ -401,6 +403,20 @@ class MockYorkieService(
                         responseChannel.trySend(
                             watchPresenceResponse {
                                 event = presenceEvent {}
+                            },
+                        )
+                        delay(500)
+                        responseChannel.trySend(
+                            watchPresenceResponse {
+                                broadcast = docEvent {
+                                    type = DocEventType.DOC_EVENT_TYPE_DOCUMENT_BROADCAST
+                                    publisher = input.clientId
+                                    body = docEventBody {
+                                        topic = "test-topic"
+                                        payload =
+                                            ByteString.copyFromUtf8("test-payload")
+                                    }
+                                }
                             },
                         )
                     }


### PR DESCRIPTION
> **RTCOLLABPLATFORM-626**: [[Android] sync: Refactor broadcast handling in Presence (yorkie-js-sdk#1102)](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-626)

## Summary
- Add broadcast support for Presence (subscriber-counter) attachments, porting JS SDK PR #1102
- Extend proto with `presence_key` on `BroadcastRequest` and `broadcast` on `WatchPresenceResponse`
- Add `PresenceEvent.Broadcast` data class and route broadcasts by resource type in `Client`

## Changes
- **`yorkie.proto`**: Add `presence_key = 5` to `BroadcastRequest`; add `DocEvent broadcast = 3` to `WatchPresenceResponse.oneof body`
- **`Presence.kt`**: Add `PresenceEvent.Broadcast(actorID, topic, payload)` with `count = 0L`
- **`Client.kt`**: Route `broadcast()` to set `presenceKey` for Presence resources vs `documentId` for Documents; guard `AuthError` publish to Document only; handle `hasBroadcast()` in `handleWatchPresenceResponse()`
- **`MockYorkieService.kt`**: Emit broadcast response in `watchPresence` stream for unit tests
- **`PresenceTest.kt`**: Add 2 instrumented tests (broadcast received by subscriber; broadcast isolation from document stream)
- **`.claude/`**: Improve solve-jira/team-review skills; add protobuf-converter-checker and yorkie-js-researcher agents

## Test plan
- [ ] Verify `PresenceEvent.Broadcast` emits on `eventStream` when a remote client broadcasts on a Presence key
- [ ] Verify presence-scoped broadcasts do not leak to Document event streams
- [ ] Verify document-scoped `broadcast()` still works unchanged (no regression)

> Items run automatically by CI (lint, unit tests, coverage) are excluded.