### PR TITLE
Rename Presence to Channel

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -28,7 +28,7 @@ curl -s -H "Authorization: Bearer $JIRA_PERSONAL_TOKEN" \
 
 ## Step 3: Write PR title and body
 
-Title: `[RTCOLLABPLATFORM-N] {Jira issue title}` (max 70 chars) or `{type}: {description}` if no ticket.
+Title: `{Jira issue title}` (max 70 chars) or `{type}: {description}` if no ticket. Do NOT prefix the ticket number.
 
 Body:
 ```markdown

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -1,6 +1,6 @@
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.35'
+    image: 'yorkieteam/yorkie:0.6.36'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.35'
+    image: 'yorkieteam/yorkie:0.6.36'
     container_name: 'yorkie'
     restart: always
     ports:

--- a/yorkie/proto/yorkie/v1/resources.proto
+++ b/yorkie/proto/yorkie/v1/resources.proto
@@ -430,15 +430,19 @@ message DocEvent {
   DocEventBody body = 3;
 }
 
-message PresenceEvent {
+message ChannelEvent {
   enum Type {
     TYPE_UNSPECIFIED = 0;
-    TYPE_COUNT_CHANGED = 1;
+    TYPE_PRESENCE = 1;
+    TYPE_BROADCAST = 2;
   }
 
   Type type = 1;
-  int64 count = 2;
-  int64 seq = 3;
+  string publisher = 2;
+  int64 count = 3;
+  int64 seq = 4;
+  string topic = 5;
+  bytes payload = 6;
 }
 
 message DataSize {

--- a/yorkie/proto/yorkie/v1/yorkie.proto
+++ b/yorkie/proto/yorkie/v1/yorkie.proto
@@ -36,10 +36,10 @@ service YorkieService {
 
   rpc WatchDocument (WatchDocumentRequest) returns (stream WatchDocumentResponse) {}
 
-  rpc AttachPresence (AttachPresenceRequest) returns (AttachPresenceResponse) {}
-  rpc DetachPresence (DetachPresenceRequest) returns (DetachPresenceResponse) {}
-  rpc RefreshPresence (RefreshPresenceRequest) returns (RefreshPresenceResponse) {}
-  rpc WatchPresence (WatchPresenceRequest) returns (stream WatchPresenceResponse) {}
+  rpc AttachChannel (AttachChannelRequest) returns (AttachChannelResponse) {}
+  rpc DetachChannel (DetachChannelRequest) returns (DetachChannelResponse) {}
+  rpc RefreshChannel (RefreshChannelRequest) returns (RefreshChannelResponse) {}
+  rpc WatchChannel (WatchChannelRequest) returns (stream WatchChannelResponse) {}
 
   rpc Broadcast (BroadcastRequest) returns (BroadcastResponse) {}
 }
@@ -122,50 +122,50 @@ message PushPullChangesResponse {
   ChangePack change_pack = 1;
 }
 
-message AttachPresenceRequest {
+message AttachChannelRequest {
   string client_id = 1;
-  string presence_key = 2;
+  string channel_key = 2;
 }
 
-message AttachPresenceResponse {
-  string presence_id = 1;
+message AttachChannelResponse {
+  string channel_id = 1;
   int64 count = 2;
 }
 
-message DetachPresenceRequest {
+message DetachChannelRequest {
   string client_id = 1;
-  string presence_id = 2;
-  string presence_key = 3;
+  string channel_id = 2;
+  string channel_key = 3;
 }
 
-message DetachPresenceResponse {
+message DetachChannelResponse {
   int64 count = 1;
 }
 
-message RefreshPresenceRequest {
+message RefreshChannelRequest {
   string client_id = 1;
-  string presence_id = 2;
-  string presence_key = 3;
+  string channel_id = 2;
+  string channel_key = 3;
 }
 
-message RefreshPresenceResponse {
+message RefreshChannelResponse {
   int64 count = 1;
 }
 
-message WatchPresenceRequest {
+message WatchChannelRequest {
   string client_id = 1;
-  string presence_key = 2;
+  string channel_key = 2;
 }
 
-message WatchPresenceResponse {
+message WatchChannelResponse {
   oneof body {
-    WatchPresenceInitialized initialized = 1;
+    WatchChannelInitialized initialized = 1;
     PresenceEvent event = 2;
     DocEvent broadcast = 3;
   }
 }
 
-message WatchPresenceInitialized {
+message WatchChannelInitialized {
   int64 count = 1;
   int64 seq = 2;
 }

--- a/yorkie/proto/yorkie/v1/yorkie.proto
+++ b/yorkie/proto/yorkie/v1/yorkie.proto
@@ -128,14 +128,14 @@ message AttachChannelRequest {
 }
 
 message AttachChannelResponse {
-  string channel_id = 1;
+  string session_id = 1;
   int64 count = 2;
 }
 
 message DetachChannelRequest {
   string client_id = 1;
-  string channel_id = 2;
-  string channel_key = 3;
+  string channel_key = 2;
+  string session_id = 3;
 }
 
 message DetachChannelResponse {
@@ -144,8 +144,8 @@ message DetachChannelResponse {
 
 message RefreshChannelRequest {
   string client_id = 1;
-  string channel_id = 2;
-  string channel_key = 3;
+  string channel_key = 2;
+  string session_id = 3;
 }
 
 message RefreshChannelResponse {
@@ -160,8 +160,7 @@ message WatchChannelRequest {
 message WatchChannelResponse {
   oneof body {
     WatchChannelInitialized initialized = 1;
-    PresenceEvent event = 2;
-    DocEvent broadcast = 3;
+    ChannelEvent event = 2;
   }
 }
 
@@ -172,10 +171,9 @@ message WatchChannelInitialized {
 
 message BroadcastRequest {
   string client_id = 1;
-  string document_id = 2;
+  string channel_key = 2;
   string topic = 3;
   bytes payload = 4;
-  string presence_key = 5;
 }
 
 message BroadcastResponse {

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt
@@ -145,19 +145,25 @@ class ChannelTest {
 
             // First client attaches
             c1.attachChannel(channel1).await()
-            delay(100)
+            withTimeout(GENERAL_TIMEOUT) {
+                while (events.isEmpty()) {
+                    delay(50)
+                }
+            }
 
             // Should receive initialized event
-            assertTrue(events.isNotEmpty())
             assertIs<ChannelEvent.Initialized>(events[0])
             assertEquals(1L, events[0].count)
 
             // Second client attaches
             c2.attachChannel(channel2).await()
-            delay(200)
+            withTimeout(GENERAL_TIMEOUT) {
+                while (events.size < 2) {
+                    delay(50)
+                }
+            }
 
             // Should receive count-changed event
-            assertTrue(events.size >= 2)
             assertIs<ChannelEvent.Changed>(events.last())
             assertEquals(2L, events.last().count)
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt
@@ -377,26 +377,40 @@ class ChannelTest {
             val ch1 = Channel(channelKey)
             val ch2 = Channel(channelKey)
 
-            c1.attachChannel(ch1).await()
-            c2.attachChannel(ch2).await()
-            delay(200)
-
-            // Collect broadcast events on ch1
-            val broadcastEvents = mutableListOf<ChannelEvent.Broadcast>()
+            // Collect all events on ch1 (including initialized) to confirm stream is ready
+            val allEvents = mutableListOf<ChannelEvent>()
             val collectJob = launch(start = CoroutineStart.UNDISPATCHED) {
-                ch1.eventStream
-                    .filterIsInstance<ChannelEvent.Broadcast>()
-                    .collect { broadcastEvents.add(it) }
+                ch1.eventStream.collect { allEvents.add(it) }
+            }
+
+            c1.attachChannel(ch1).await()
+
+            // Wait for ch1's watch stream to be established (initialized event)
+            withTimeout(GENERAL_TIMEOUT) {
+                while (allEvents.none { it is ChannelEvent.Initialized }) {
+                    delay(50)
+                }
+            }
+
+            c2.attachChannel(ch2).await()
+
+            // Wait for ch1 to receive the count change from ch2 joining
+            withTimeout(GENERAL_TIMEOUT) {
+                while (allEvents.none { it is ChannelEvent.Changed }) {
+                    delay(50)
+                }
             }
 
             // c2 broadcasts on the channel key
             c2.broadcast(channelKey, "hello", "world").await()
 
             withTimeout(GENERAL_TIMEOUT) {
-                while (broadcastEvents.isEmpty()) {
+                while (allEvents.none { it is ChannelEvent.Broadcast }) {
                     delay(50)
                 }
             }
+
+            val broadcastEvents = allEvents.filterIsInstance<ChannelEvent.Broadcast>()
 
             assertEquals(1, broadcastEvents.size)
             assertEquals("hello", broadcastEvents[0].topic)

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt
@@ -78,35 +78,43 @@ class ChannelTest {
 
             // First client attaches
             c1.attachChannel(channel1).await()
-            delay(100)
             assertEquals(1L, channel1.getCount())
 
             // Second client attaches
             c2.attachChannel(channel2).await()
-            delay(100)
             assertEquals(2L, channel2.getCount())
 
             // First client should receive the update
-            delay(100)
+            withTimeout(GENERAL_TIMEOUT) {
+                while (channel1.getCount() != 2L) {
+                    delay(50)
+                }
+            }
             assertEquals(2L, channel1.getCount())
 
             // Third client attaches
             c3.attachChannel(channel3).await()
-            delay(100)
             assertEquals(3L, channel3.getCount())
 
             // Wait for all clients to sync
-            delay(100)
+            withTimeout(GENERAL_TIMEOUT) {
+                while (channel1.getCount() != 3L || channel2.getCount() != 3L) {
+                    delay(50)
+                }
+            }
             assertEquals(3L, channel1.getCount())
             assertEquals(3L, channel2.getCount())
 
             // One client detaches
             c2.detachChannel(channel2).await()
-            delay(100)
             assertEquals(2L, channel2.getCount())
 
             // Other clients should see the count decrease
-            delay(100)
+            withTimeout(GENERAL_TIMEOUT) {
+                while (channel1.getCount() != 2L || channel3.getCount() != 2L) {
+                    delay(50)
+                }
+            }
             assertEquals(2L, channel1.getCount())
             assertEquals(2L, channel3.getCount())
 
@@ -194,20 +202,25 @@ class ChannelTest {
             // Both attach
             c1.attachChannel(channel1).await()
             c2.attachChannel(channel2).await()
-            delay(300)
 
+            withTimeout(GENERAL_TIMEOUT) {
+                while (channel1.getCount() != 2L || channel2.getCount() != 2L) {
+                    delay(50)
+                }
+            }
             assertEquals(2L, channel1.getCount())
             assertEquals(2L, channel2.getCount())
 
             // One detaches
             c1.detachChannel(channel1).await()
-            delay(300)
-
-            // Detached channel should show updated count
             assertEquals(1L, channel1.getCount())
 
             // Other channel should also see the decrease
-            delay(300)
+            withTimeout(GENERAL_TIMEOUT) {
+                while (channel2.getCount() != 1L) {
+                    delay(50)
+                }
+            }
             assertEquals(1L, channel2.getCount())
 
             // Cleanup

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt
@@ -320,7 +320,11 @@ class ChannelTest {
             assertEquals(2L, manualChannel.getCount())
 
             // c1's realtime channel should automatically receive the update
-            delay(500)
+            withTimeout(GENERAL_TIMEOUT) {
+                while (realtimeChannel.getCount() != 2L) {
+                    delay(50)
+                }
+            }
             assertEquals(2L, realtimeChannel.getCount())
 
             // c2's manual channel doesn't receive updates
@@ -331,7 +335,11 @@ class ChannelTest {
             assertEquals(3L, thirdChannel.getCount())
 
             // c1's realtime channel receives the update automatically
-            delay(500)
+            withTimeout(GENERAL_TIMEOUT) {
+                while (realtimeChannel.getCount() != 3L) {
+                    delay(50)
+                }
+            }
             assertEquals(3L, realtimeChannel.getCount())
 
             // c2's manual channel still doesn't update

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt
@@ -21,38 +21,38 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class PresenceTest {
+class ChannelTest {
 
     @Test
-    fun test_single_client_presence_counter() {
+    fun test_single_client_channel_counter() {
         runBlocking {
             val c1 = createClient()
             c1.activateAsync().await()
 
-            // Create presence counter
-            val presenceKey = "presence-${UUID.randomUUID()}".toDocKey()
-            val presence = Presence(presenceKey)
+            // Create channel counter
+            val channelKey = "channel-${UUID.randomUUID()}".toDocKey()
+            val channel = Channel(channelKey)
 
             // Test initial state
-            assertEquals(presenceKey, presence.getKey())
-            assertEquals(ResourceStatus.Detached, presence.getStatus())
-            assertFalse(presence.isAttached())
-            assertEquals(0L, presence.getCount())
+            assertEquals(channelKey, channel.getKey())
+            assertEquals(ResourceStatus.Detached, channel.getStatus())
+            assertFalse(channel.isAttached())
+            assertEquals(0L, channel.getCount())
 
-            // Attach presence counter
-            c1.attachPresence(presence).await()
+            // Attach channel counter
+            c1.attachChannel(channel).await()
 
             // Verify attached state
-            assertEquals(ResourceStatus.Attached, presence.getStatus())
-            assertTrue(presence.isAttached())
-            assertEquals(1L, presence.getCount())
+            assertEquals(ResourceStatus.Attached, channel.getStatus())
+            assertTrue(channel.isAttached())
+            assertEquals(1L, channel.getCount())
 
-            // Detach presence counter
-            c1.detachPresence(presence).await()
+            // Detach channel counter
+            c1.detachChannel(channel).await()
 
             // Verify detached state
-            assertEquals(ResourceStatus.Detached, presence.getStatus())
-            assertFalse(presence.isAttached())
+            assertEquals(ResourceStatus.Detached, channel.getStatus())
+            assertFalse(channel.isAttached())
 
             c1.deactivateAsync().await()
             c1.close()
@@ -60,7 +60,7 @@ class PresenceTest {
     }
 
     @Test
-    fun test_multiple_clients_presence_counter() {
+    fun test_multiple_clients_channel_counter() {
         runBlocking {
             val c1 = createClient()
             val c2 = createClient()
@@ -70,49 +70,49 @@ class PresenceTest {
             c2.activateAsync().await()
             c3.activateAsync().await()
 
-            // Create presence counters for the same room
-            val presenceKey = "presence-room-${UUID.randomUUID()}".toDocKey()
-            val presence1 = Presence(presenceKey)
-            val presence2 = Presence(presenceKey)
-            val presence3 = Presence(presenceKey)
+            // Create channel counters for the same room
+            val channelKey = "channel-room-${UUID.randomUUID()}".toDocKey()
+            val channel1 = Channel(channelKey)
+            val channel2 = Channel(channelKey)
+            val channel3 = Channel(channelKey)
 
             // First client attaches
-            c1.attachPresence(presence1).await()
+            c1.attachChannel(channel1).await()
             delay(100)
-            assertEquals(1L, presence1.getCount())
+            assertEquals(1L, channel1.getCount())
 
             // Second client attaches
-            c2.attachPresence(presence2).await()
+            c2.attachChannel(channel2).await()
             delay(100)
-            assertEquals(2L, presence2.getCount())
+            assertEquals(2L, channel2.getCount())
 
             // First client should receive the update
             delay(100)
-            assertEquals(2L, presence1.getCount())
+            assertEquals(2L, channel1.getCount())
 
             // Third client attaches
-            c3.attachPresence(presence3).await()
+            c3.attachChannel(channel3).await()
             delay(100)
-            assertEquals(3L, presence3.getCount())
+            assertEquals(3L, channel3.getCount())
 
             // Wait for all clients to sync
             delay(100)
-            assertEquals(3L, presence1.getCount())
-            assertEquals(3L, presence2.getCount())
+            assertEquals(3L, channel1.getCount())
+            assertEquals(3L, channel2.getCount())
 
             // One client detaches
-            c2.detachPresence(presence2).await()
+            c2.detachChannel(channel2).await()
             delay(100)
-            assertEquals(2L, presence2.getCount())
+            assertEquals(2L, channel2.getCount())
 
             // Other clients should see the count decrease
             delay(100)
-            assertEquals(2L, presence1.getCount())
-            assertEquals(2L, presence3.getCount())
+            assertEquals(2L, channel1.getCount())
+            assertEquals(2L, channel3.getCount())
 
             // Cleanup
-            c1.detachPresence(presence1).await()
-            c3.detachPresence(presence3).await()
+            c1.detachChannel(channel1).await()
+            c3.detachChannel(channel3).await()
             c1.deactivateAsync().await()
             c2.deactivateAsync().await()
             c3.deactivateAsync().await()
@@ -123,7 +123,7 @@ class PresenceTest {
     }
 
     @Test
-    fun test_presence_counter_event_subscription() {
+    fun test_channel_counter_event_subscription() {
         runBlocking {
             val c1 = createClient()
             val c2 = createClient()
@@ -131,40 +131,40 @@ class PresenceTest {
             c1.activateAsync().await()
             c2.activateAsync().await()
 
-            val presenceKey = "presence-events-${UUID.randomUUID()}".toDocKey()
-            val presence1 = Presence(presenceKey)
-            val presence2 = Presence(presenceKey)
+            val channelKey = "channel-events-${UUID.randomUUID()}".toDocKey()
+            val channel1 = Channel(channelKey)
+            val channel2 = Channel(channelKey)
 
-            // Track events on presence1
-            val events = mutableListOf<PresenceEvent>()
+            // Track events on channel1
+            val events = mutableListOf<ChannelEvent>()
             val collectJob = launch(start = CoroutineStart.UNDISPATCHED) {
-                presence1.eventStream.collect { event ->
+                channel1.eventStream.collect { event ->
                     events.add(event)
                 }
             }
 
             // First client attaches
-            c1.attachPresence(presence1).await()
+            c1.attachChannel(channel1).await()
             delay(100)
 
             // Should receive initialized event
             assertTrue(events.isNotEmpty())
-            assertIs<PresenceEvent.Initialized>(events[0])
+            assertIs<ChannelEvent.Initialized>(events[0])
             assertEquals(1L, events[0].count)
 
             // Second client attaches
-            c2.attachPresence(presence2).await()
+            c2.attachChannel(channel2).await()
             delay(200)
 
             // Should receive count-changed event
             assertTrue(events.size >= 2)
-            assertIs<PresenceEvent.Changed>(events.last())
+            assertIs<ChannelEvent.Changed>(events.last())
             assertEquals(2L, events.last().count)
 
             // Cleanup
             collectJob.cancel()
-            c1.detachPresence(presence1).await()
-            c2.detachPresence(presence2).await()
+            c1.detachChannel(channel1).await()
+            c2.detachChannel(channel2).await()
             c1.deactivateAsync().await()
             c2.deactivateAsync().await()
             c1.close()
@@ -173,7 +173,7 @@ class PresenceTest {
     }
 
     @Test
-    fun test_presence_counter_detach_reduces_count() {
+    fun test_channel_counter_detach_reduces_count() {
         runBlocking {
             val c1 = createClient()
             val c2 = createClient()
@@ -181,31 +181,31 @@ class PresenceTest {
             c1.activateAsync().await()
             c2.activateAsync().await()
 
-            val presenceKey = "presence-detach-${UUID.randomUUID()}".toDocKey()
-            val presence1 = Presence(presenceKey)
-            val presence2 = Presence(presenceKey)
+            val channelKey = "channel-detach-${UUID.randomUUID()}".toDocKey()
+            val channel1 = Channel(channelKey)
+            val channel2 = Channel(channelKey)
 
             // Both attach
-            c1.attachPresence(presence1).await()
-            c2.attachPresence(presence2).await()
+            c1.attachChannel(channel1).await()
+            c2.attachChannel(channel2).await()
             delay(300)
 
-            assertEquals(2L, presence1.getCount())
-            assertEquals(2L, presence2.getCount())
+            assertEquals(2L, channel1.getCount())
+            assertEquals(2L, channel2.getCount())
 
             // One detaches
-            c1.detachPresence(presence1).await()
+            c1.detachChannel(channel1).await()
             delay(300)
 
-            // Detached presence should show updated count
-            assertEquals(1L, presence1.getCount())
+            // Detached channel should show updated count
+            assertEquals(1L, channel1.getCount())
 
-            // Other presence should also see the decrease
+            // Other channel should also see the decrease
             delay(300)
-            assertEquals(1L, presence2.getCount())
+            assertEquals(1L, channel2.getCount())
 
             // Cleanup
-            c2.detachPresence(presence2).await()
+            c2.detachChannel(channel2).await()
             c1.deactivateAsync().await()
             c2.deactivateAsync().await()
             c1.close()
@@ -214,40 +214,40 @@ class PresenceTest {
     }
 
     @Test
-    fun test_presence_heartbeat_keeps_session_alive() {
+    fun test_channel_heartbeat_keeps_session_alive() {
         runBlocking {
             // 1 second heartbeat interval for faster testing
             val c1 = createClient(
                 options = dev.yorkie.core.Client.Options(
-                    presenceHeartbeatInterval = 1000.milliseconds,
+                    channelHeartbeatInterval = 1000.milliseconds,
                 ),
             )
             c1.activateAsync().await()
 
-            val presenceKey = "presence-heartbeat-${UUID.randomUUID()}".toDocKey()
-            val presence = Presence(presenceKey)
+            val channelKey = "channel-heartbeat-${UUID.randomUUID()}".toDocKey()
+            val channel = Channel(channelKey)
 
-            // Attach presence counter
-            c1.attachPresence(presence).await()
-            assertEquals(1L, presence.getCount())
+            // Attach channel counter
+            c1.attachChannel(channel).await()
+            assertEquals(1L, channel.getCount())
 
             // Wait for 3 heartbeat cycles (3 seconds)
-            // The presence should still be active because heartbeat refreshes TTL
+            // The channel should still be active because heartbeat refreshes TTL
             delay(3500)
 
-            // Verify presence is still active
-            assertTrue(presence.isAttached())
-            assertEquals(1L, presence.getCount())
+            // Verify channel is still active
+            assertTrue(channel.isAttached())
+            assertEquals(1L, channel.getCount())
 
             // Cleanup
-            c1.detachPresence(presence).await()
+            c1.detachChannel(channel).await()
             c1.deactivateAsync().await()
             c1.close()
         }
     }
 
     @Test
-    fun test_presence_manual_sync_mode() {
+    fun test_channel_manual_sync_mode() {
         runBlocking {
             val c1 = createClient()
             val c2 = createClient()
@@ -255,17 +255,17 @@ class PresenceTest {
             c1.activateAsync().await()
             c2.activateAsync().await()
 
-            // Create presences for the same room
-            val presenceKey = "presence-manual-${UUID.randomUUID()}".toDocKey()
-            val p1 = Presence(presenceKey)
-            val p2 = Presence(presenceKey)
+            // Create channels for the same room
+            val channelKey = "channel-manual-${UUID.randomUUID()}".toDocKey()
+            val p1 = Channel(channelKey)
+            val p2 = Channel(channelKey)
 
             // Attach client1 with manual sync mode (no watch stream)
-            c1.attachPresence(p1, isRealtime = false).await()
+            c1.attachChannel(p1, isRealtime = false).await()
             assertEquals(1L, p1.getCount())
 
             // Attach client2 with manual sync mode
-            c2.attachPresence(p2, isRealtime = false).await()
+            c2.attachChannel(p2, isRealtime = false).await()
             assertEquals(2L, p2.getCount())
 
             // In manual mode, p1's count doesn't update automatically
@@ -273,12 +273,12 @@ class PresenceTest {
             delay(500)
             assertEquals(1L, p1.getCount())
 
-            // Must call syncPresence() explicitly to refresh TTL and fetch latest count
+            // Must call syncAsync() explicitly to refresh TTL and fetch latest count
             c1.syncAsync(p1).await()
             assertEquals(2L, p1.getCount())
 
             // Detach p2 and verify p1 doesn't auto-update
-            c2.detachPresence(p2).await()
+            c2.detachChannel(p2).await()
             delay(500)
             assertEquals(2L, p1.getCount())
 
@@ -287,7 +287,7 @@ class PresenceTest {
             assertEquals(1L, p1.getCount())
 
             // Cleanup
-            c1.detachPresence(p1).await()
+            c1.detachChannel(p1).await()
             c1.deactivateAsync().await()
             c2.deactivateAsync().await()
             c1.close()
@@ -296,7 +296,7 @@ class PresenceTest {
     }
 
     @Test
-    fun test_presence_realtime_vs_manual_mode_comparison() {
+    fun test_channel_realtime_vs_manual_mode_comparison() {
         runBlocking {
             val c1 = createClient()
             val c2 = createClient()
@@ -306,41 +306,41 @@ class PresenceTest {
             c2.activateAsync().await()
             c3.activateAsync().await()
 
-            val presenceKey = "presence-mode-compare-${UUID.randomUUID()}".toDocKey()
-            val realtimePresence = Presence(presenceKey)
-            val manualPresence = Presence(presenceKey)
-            val thirdPresence = Presence(presenceKey)
+            val channelKey = "channel-mode-compare-${UUID.randomUUID()}".toDocKey()
+            val realtimeChannel = Channel(channelKey)
+            val manualChannel = Channel(channelKey)
+            val thirdChannel = Channel(channelKey)
 
             // c1: Attach with realtime mode (default)
-            c1.attachPresence(realtimePresence).await()
-            assertEquals(1L, realtimePresence.getCount())
+            c1.attachChannel(realtimeChannel).await()
+            assertEquals(1L, realtimeChannel.getCount())
 
             // c2: Attach with manual mode
-            c2.attachPresence(manualPresence, isRealtime = false).await()
-            assertEquals(2L, manualPresence.getCount())
+            c2.attachChannel(manualChannel, isRealtime = false).await()
+            assertEquals(2L, manualChannel.getCount())
 
-            // c1's realtime presence should automatically receive the update
+            // c1's realtime channel should automatically receive the update
             delay(500)
-            assertEquals(2L, realtimePresence.getCount())
+            assertEquals(2L, realtimeChannel.getCount())
 
-            // c2's manual presence doesn't receive updates
-            assertEquals(2L, manualPresence.getCount())
+            // c2's manual channel doesn't receive updates
+            assertEquals(2L, manualChannel.getCount())
 
             // c3: Attach another client
-            c3.attachPresence(thirdPresence, isRealtime = false).await()
-            assertEquals(3L, thirdPresence.getCount())
+            c3.attachChannel(thirdChannel, isRealtime = false).await()
+            assertEquals(3L, thirdChannel.getCount())
 
-            // c1's realtime presence receives the update automatically
+            // c1's realtime channel receives the update automatically
             delay(500)
-            assertEquals(3L, realtimePresence.getCount())
+            assertEquals(3L, realtimeChannel.getCount())
 
-            // c2's manual presence still doesn't update
-            assertEquals(2L, manualPresence.getCount())
+            // c2's manual channel still doesn't update
+            assertEquals(2L, manualChannel.getCount())
 
             // Cleanup
-            c1.detachPresence(realtimePresence).await()
-            c2.detachPresence(manualPresence).await()
-            c3.detachPresence(thirdPresence).await()
+            c1.detachChannel(realtimeChannel).await()
+            c2.detachChannel(manualChannel).await()
+            c3.detachChannel(thirdChannel).await()
             c1.deactivateAsync().await()
             c2.deactivateAsync().await()
             c3.deactivateAsync().await()
@@ -351,7 +351,7 @@ class PresenceTest {
     }
 
     @Test
-    fun test_presence_broadcast_received_by_subscriber() {
+    fun test_channel_broadcast_received_by_subscriber() {
         runBlocking {
             val c1 = createClient()
             val c2 = createClient()
@@ -359,24 +359,24 @@ class PresenceTest {
             c1.activateAsync().await()
             c2.activateAsync().await()
 
-            val presenceKey = "presence-broadcast-${UUID.randomUUID()}".toDocKey()
-            val p1 = Presence(presenceKey)
-            val p2 = Presence(presenceKey)
+            val channelKey = "channel-broadcast-${UUID.randomUUID()}".toDocKey()
+            val ch1 = Channel(channelKey)
+            val ch2 = Channel(channelKey)
 
-            c1.attachPresence(p1).await()
-            c2.attachPresence(p2).await()
+            c1.attachChannel(ch1).await()
+            c2.attachChannel(ch2).await()
             delay(200)
 
-            // Collect broadcast events on p1
-            val broadcastEvents = mutableListOf<PresenceEvent.Broadcast>()
+            // Collect broadcast events on ch1
+            val broadcastEvents = mutableListOf<ChannelEvent.Broadcast>()
             val collectJob = launch(start = CoroutineStart.UNDISPATCHED) {
-                p1.eventStream
-                    .filterIsInstance<PresenceEvent.Broadcast>()
+                ch1.eventStream
+                    .filterIsInstance<ChannelEvent.Broadcast>()
                     .collect { broadcastEvents.add(it) }
             }
 
-            // c2 broadcasts on the presence key
-            c2.broadcast(presenceKey, "hello", "world").await()
+            // c2 broadcasts on the channel key
+            c2.broadcast(channelKey, "hello", "world").await()
 
             withTimeout(GENERAL_TIMEOUT) {
                 while (broadcastEvents.isEmpty()) {
@@ -389,8 +389,8 @@ class PresenceTest {
             assertEquals("world", broadcastEvents[0].payload)
 
             collectJob.cancel()
-            c1.detachPresence(p1).await()
-            c2.detachPresence(p2).await()
+            c1.detachChannel(ch1).await()
+            c2.detachChannel(ch2).await()
             c1.deactivateAsync().await()
             c2.deactivateAsync().await()
             c1.close()
@@ -399,7 +399,7 @@ class PresenceTest {
     }
 
     @Test
-    fun test_presence_broadcast_does_not_arrive_on_document_event_stream() {
+    fun test_channel_broadcast_does_not_arrive_on_document_event_stream() {
         runBlocking {
             val c1 = createClient()
             val c2 = createClient()
@@ -407,12 +407,12 @@ class PresenceTest {
             c1.activateAsync().await()
             c2.activateAsync().await()
 
-            val presenceKey = "presence-broadcast-isolation-${UUID.randomUUID()}".toDocKey()
+            val channelKey = "channel-broadcast-isolation-${UUID.randomUUID()}".toDocKey()
             val docKey = "doc-broadcast-isolation-${UUID.randomUUID()}".toDocKey()
-            val p1 = Presence(presenceKey)
+            val ch1 = Channel(channelKey)
             val d2 = dev.yorkie.document.Document(docKey)
 
-            c1.attachPresence(p1).await()
+            c1.attachChannel(ch1).await()
             c2.attachDocument(d2).await()
             delay(200)
 
@@ -424,17 +424,17 @@ class PresenceTest {
                     .collect { docBroadcastEvents.add(it) }
             }
 
-            // c1 broadcasts on presence key — must NOT reach d2
-            c1.broadcast(presenceKey, "test-topic", "test-payload").await()
+            // c1 broadcasts on channel key — must NOT reach d2
+            c1.broadcast(channelKey, "test-topic", "test-payload").await()
             delay(500)
 
             assertTrue(
                 docBroadcastEvents.isEmpty(),
-                "Document event stream must not receive a presence-scoped broadcast",
+                "Document event stream must not receive a channel-scoped broadcast",
             )
 
             collectJob.cancel()
-            c1.detachPresence(p1).await()
+            c1.detachChannel(ch1).await()
             c2.detachDocument(d2).await()
             c1.deactivateAsync().await()
             c2.deactivateAsync().await()

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Attachable.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Attachable.kt
@@ -35,7 +35,7 @@ interface Attachable {
     /**
      * `hasLocalChanges` returns whether this resource has local changes to be synchronized.
      * Returns true for Document when there are uncommitted changes.
-     * Returns false for Presence as it is server-managed.
+     * Returns false for Channel as it is server-managed.
      */
     fun hasLocalChanges(): Boolean
 

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
@@ -45,12 +45,12 @@ internal class Attachment<R : Attachable>(
             return needRealTimeSync()
         }
 
-        // For Presence in Manual mode: never auto-sync
+        // For Channel in Manual mode: never auto-sync
         if (syncMode == Client.SyncMode.Manual) {
             return false
         }
 
-        // For Presence: check if heartbeat is needed
+        // For Channel: check if heartbeat is needed
         return System.currentTimeMillis() - lastHeartbeatTime >= heartbeatInterval
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -100,6 +100,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.OkHttpClient
+import dev.yorkie.api.v1.ChannelEvent.Type as PbChannelEventType
 
 /**
  * Client that can communicate with the server.
@@ -357,10 +358,10 @@ public class Client(
                     resource.mutex.withLock {
                         val request = refreshChannelRequest {
                             clientId = requireClientId()
-                            resource.getChannelId()?.let {
-                                channelId = it
-                            }
                             channelKey = resource.getKey()
+                            resource.getSessionId()?.let {
+                                sessionId = it
+                            }
                         }
                         val response = service.refreshChannel(
                             request,
@@ -721,22 +722,32 @@ public class Client(
                 )
             }
         } else if (response.hasEvent()) {
-            val count = response.event.count
-            val seq = response.event.seq
-            if (channel.updateCount(count, seq)) {
-                channel.publish(
-                    ChannelEvent.Changed(count = count),
-                )
+            val event = response.event
+            when (event.type) {
+                PbChannelEventType.TYPE_PRESENCE -> {
+                    val count = event.count
+                    val seq = event.seq
+                    if (channel.updateCount(count, seq)) {
+                        channel.publish(
+                            ChannelEvent.Changed(count = count),
+                        )
+                    }
+                }
+
+                PbChannelEventType.TYPE_BROADCAST -> {
+                    channel.publish(
+                        ChannelEvent.Broadcast(
+                            actorID = event.publisher.takeIf { it.isNotEmpty() },
+                            topic = event.topic,
+                            payload = event.payload.toStringUtf8(),
+                        ),
+                    )
+                }
+
+                else -> {
+                    // nothing to do
+                }
             }
-        } else if (response.hasBroadcast()) {
-            val broadcastEvent = response.broadcast
-            presence.publish(
-                PresenceEvent.Broadcast(
-                    actorID = broadcastEvent.publisher.takeIf { it.isNotEmpty() },
-                    topic = broadcastEvent.body.topic,
-                    payload = broadcastEvent.body.payload.toStringUtf8(),
-                ),
-            )
         }
     }
 
@@ -1020,7 +1031,7 @@ public class Client(
                     return@async Result.failure(it)
                 }
 
-                channel.setChannelId(response.channelId)
+                channel.setSessionId(response.sessionId)
                 channel.updateCount(response.count, 0L)
                 channel.applyStatus(ResourceStatus.Attached)
 
@@ -1032,7 +1043,7 @@ public class Client(
 
                 attachments[channelKey] = Attachment(
                     resource = channel,
-                    resourceId = response.channelId,
+                    resourceId = response.sessionId,
                     syncMode = syncMode,
                 )
 
@@ -1066,10 +1077,10 @@ public class Client(
 
             val request = detachChannelRequest {
                 clientId = requireClientId()
-                channel.getChannelId()?.let {
-                    channelId = it
-                }
                 this.channelKey = channelKey
+                channel.getSessionId()?.let {
+                    sessionId = it
+                }
             }
 
             val response = service.detachChannel(
@@ -1244,11 +1255,7 @@ public class Client(
 
             val request = broadcastRequest {
                 clientId = clientID
-                if (attachment.resource is Presence) {
-                    presenceKey = key
-                } else {
-                    documentId = attachment.resourceId
-                }
+                channelKey = key
                 this.topic = topic
                 this.payload = ByteString.copyFromUtf8(payload)
             }

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -17,21 +17,21 @@ import dev.yorkie.api.toChangePack
 import dev.yorkie.api.toPBChangePack
 import dev.yorkie.api.v1.ActivateClientRequest
 import dev.yorkie.api.v1.DocEventType
+import dev.yorkie.api.v1.WatchChannelResponse
 import dev.yorkie.api.v1.WatchDocumentResponse
-import dev.yorkie.api.v1.WatchPresenceResponse
 import dev.yorkie.api.v1.YorkieServiceClient
 import dev.yorkie.api.v1.YorkieServiceClientInterface
+import dev.yorkie.api.v1.attachChannelRequest
 import dev.yorkie.api.v1.attachDocumentRequest
-import dev.yorkie.api.v1.attachPresenceRequest
 import dev.yorkie.api.v1.broadcastRequest
 import dev.yorkie.api.v1.deactivateClientRequest
+import dev.yorkie.api.v1.detachChannelRequest
 import dev.yorkie.api.v1.detachDocumentRequest
-import dev.yorkie.api.v1.detachPresenceRequest
 import dev.yorkie.api.v1.pushPullChangesRequest
-import dev.yorkie.api.v1.refreshPresenceRequest
+import dev.yorkie.api.v1.refreshChannelRequest
 import dev.yorkie.api.v1.removeDocumentRequest
+import dev.yorkie.api.v1.watchChannelRequest
 import dev.yorkie.api.v1.watchDocumentRequest
-import dev.yorkie.api.v1.watchPresenceRequest
 import dev.yorkie.document.Document
 import dev.yorkie.document.Document.Event.AuthError
 import dev.yorkie.document.Document.Event.AuthError.AuthErrorMethod.PushPull
@@ -42,8 +42,9 @@ import dev.yorkie.document.Document.Event.SyncStatusChanged
 import dev.yorkie.document.presence.P
 import dev.yorkie.document.presence.PresenceInfo
 import dev.yorkie.document.presence.Presences.Companion.asPresences
+import dev.yorkie.presence.Channel
+import dev.yorkie.presence.ChannelEvent
 import dev.yorkie.presence.Presence
-import dev.yorkie.presence.PresenceEvent
 import dev.yorkie.util.Logger.Companion.log
 import dev.yorkie.util.Logger.Companion.logError
 import dev.yorkie.util.OperationResult
@@ -234,7 +235,7 @@ public class Client(
                     return@launch
                 }
                 for ((_, attachment) in attachments) {
-                    val heartbeatInterval = options.presenceHeartbeatInterval.inWholeMilliseconds
+                    val heartbeatInterval = options.channelHeartbeatInterval.inWholeMilliseconds
                     if (!attachment.needSync(heartbeatInterval)) {
                         continue
                     }
@@ -352,16 +353,16 @@ public class Client(
                             detachInternal(documentKey)
                         }
                     }
-                } else if (resource is Presence) {
+                } else if (resource is Channel) {
                     resource.mutex.withLock {
-                        val request = refreshPresenceRequest {
+                        val request = refreshChannelRequest {
                             clientId = requireClientId()
-                            resource.getPresenceId()?.let {
-                                presenceId = it
+                            resource.getChannelId()?.let {
+                                channelId = it
                             }
-                            presenceKey = resource.getKey()
+                            channelKey = resource.getKey()
                         }
-                        val response = service.refreshPresence(
+                        val response = service.refreshChannel(
                             request,
                             resource.getKey().attachmentBasedRequestHeader,
                         ).getOrThrow()
@@ -413,8 +414,8 @@ public class Client(
                         createDocumentWatchJob(attachment)
                     }
 
-                    is Presence -> {
-                        createPresenceWatchJob(attachment)
+                    is Channel -> {
+                        createChannelWatchJob(attachment)
                     }
 
                     else -> {
@@ -634,9 +635,9 @@ public class Client(
     }
 
     @OptIn(DelicateCoroutinesApi::class)
-    private fun createPresenceWatchJob(attachment: Attachment<out Attachable>): Job {
-        val presence = attachment.resource as Presence
-        val presenceKey = presence.getKey()
+    private fun createChannelWatchJob(attachment: Attachment<out Attachable>): Job {
+        val channel = attachment.resource as Channel
+        val channelKey = channel.getKey()
         var latestStream: ServerOnlyStreamInterface<*, *>? = null
         return scope.launch(activationJob) {
             var shouldContinue = true
@@ -645,22 +646,22 @@ public class Client(
                 latestStream.safeClose()
 
                 val stream = withTimeoutOrNull(streamTimeout) {
-                    service.watchPresence(
-                        presenceKey.attachmentBasedRequestHeader,
+                    service.watchChannel(
+                        channelKey.attachmentBasedRequestHeader,
                     ).also {
                         latestStream = it
                     }
                 } ?: continue
                 val streamJob = launch(start = CoroutineStart.UNDISPATCHED) {
-                    val channel = stream.responseChannel()
+                    val responseChannel = stream.responseChannel()
                     while (!stream.isReceiveClosed() &&
-                        !channel.isClosedForReceive && shouldContinue
+                        !responseChannel.isClosedForReceive && shouldContinue
                     ) {
                         withTimeoutOrNull(streamTimeout) {
-                            val receiveResult = channel.receiveCatching()
+                            val receiveResult = responseChannel.receiveCatching()
                             receiveResult.onSuccess {
-                                handleWatchPresenceResponse(
-                                    presence = presence,
+                                handleWatchChannelResponse(
+                                    channel = channel,
                                     response = it,
                                 )
                                 shouldContinue = true
@@ -670,13 +671,13 @@ public class Client(
                                     return@onFailure
                                 }
                                 shouldContinue =
-                                    handleWatchPresenceStreamFailure(
+                                    handleWatchChannelStreamFailure(
                                         stream = stream,
                                         cause = it,
                                         cancelled = attachment.cancelled,
                                     )
                             }.onClosed {
-                                handleWatchPresenceStreamFailure(
+                                handleWatchChannelStreamFailure(
                                     stream = stream,
                                     cause = it
                                         ?: ClosedReceiveChannelException("Channel was closed"),
@@ -684,7 +685,7 @@ public class Client(
                                 )
                             }
                         } ?: run {
-                            handleWatchPresenceStreamFailure(
+                            handleWatchChannelStreamFailure(
                                 stream = stream,
                                 cause = TimeoutException("channel timed out"),
                                 cancelled = attachment.cancelled,
@@ -694,9 +695,9 @@ public class Client(
                     }
                 }
                 stream.sendAndClose(
-                    watchPresenceRequest {
+                    watchChannelRequest {
                         clientId = requireClientId()
-                        this.presenceKey = presenceKey
+                        this.channelKey = channelKey
                     },
                 )
                 streamJob.join()
@@ -710,21 +711,21 @@ public class Client(
         }
     }
 
-    private fun handleWatchPresenceResponse(presence: Presence, response: WatchPresenceResponse) {
+    private fun handleWatchChannelResponse(channel: Channel, response: WatchChannelResponse) {
         if (response.hasInitialized()) {
             val count = response.initialized.count
             val seq = response.initialized.seq
-            if (presence.updateCount(count, seq)) {
-                presence.publish(
-                    PresenceEvent.Initialized(count = count),
+            if (channel.updateCount(count, seq)) {
+                channel.publish(
+                    ChannelEvent.Initialized(count = count),
                 )
             }
         } else if (response.hasEvent()) {
             val count = response.event.count
             val seq = response.event.seq
-            if (presence.updateCount(count, seq)) {
-                presence.publish(
-                    PresenceEvent.Changed(count = count),
+            if (channel.updateCount(count, seq)) {
+                channel.publish(
+                    ChannelEvent.Changed(count = count),
                 )
             }
         } else if (response.hasBroadcast()) {
@@ -740,10 +741,10 @@ public class Client(
     }
 
     /**
-     * handleWatchStreamFailure() handles the failure of the watch stream.
-     * return true if the stream should be reconnected, false otherwise.
+     * handleWatchChannelStreamFailure() handles the failure of the channel watch stream.
+     * Returns true if the stream should be reconnected, false otherwise.
      */
-    private suspend fun handleWatchPresenceStreamFailure(
+    private suspend fun handleWatchChannelStreamFailure(
         stream: ServerOnlyStreamInterface<*, *>,
         cause: Throwable?,
         cancelled: Boolean,
@@ -752,7 +753,7 @@ public class Client(
 
         cause?.let {
             sendWatchAttachmentResourceStreamException(
-                tag = "Client.WatchPresence",
+                tag = "Client.WatchChannel",
                 t = it,
             )
         }
@@ -973,16 +974,16 @@ public class Client(
     }
 
     /**
-     * `attach` attaches the given presence counter to this client.
-     * It tells the server that this client will track the presence count.
+     * `attachChannel` attaches the given channel counter to this client.
+     * It tells the server that this client will track the channel count.
      *
-     * @param presence The presence counter to attach.
-     * @param isRealtime If true (default), starts watching for presence changes in realtime.
-     *                   If false, uses manual sync mode where you must call [syncPresence] to
-     *                   refresh the presence count.
+     * @param channel The channel counter to attach.
+     * @param isRealtime If true (default), starts watching for channel changes in realtime.
+     *                   If false, uses manual sync mode where you must call [syncAsync] to
+     *                   refresh the channel count.
      */
-    public fun attachPresence(
-        presence: Presence,
+    public fun attachChannel(
+        channel: Channel,
         isRealtime: Boolean? = null,
     ): Deferred<OperationResult> {
         return scope.async {
@@ -992,22 +993,22 @@ public class Client(
             )
 
             checkYorkieError(
-                presence.getStatus() == ResourceStatus.Detached,
-                YorkieException(ErrDocumentNotDetached, "${presence.getKey()} is not detached"),
+                channel.getStatus() == ResourceStatus.Detached,
+                YorkieException(ErrDocumentNotDetached, "${channel.getKey()} is not detached"),
             )
 
-            presence.setActor(requireClientId())
+            channel.setActor(requireClientId())
 
-            presence.mutex.withLock {
-                val presenceKey = presence.getKey()
-                val request = attachPresenceRequest {
+            channel.mutex.withLock {
+                val channelKey = channel.getKey()
+                val request = attachChannelRequest {
                     clientId = requireClientId()
-                    this.presenceKey = presenceKey
+                    this.channelKey = channelKey
                 }
 
-                val response = service.attachPresence(
+                val response = service.attachChannel(
                     request,
-                    presenceKey.attachmentBasedRequestHeader,
+                    channelKey.attachmentBasedRequestHeader,
                 ).getOrElse {
                     ensureActive()
                     handleConnectException(it) { exception ->
@@ -1019,9 +1020,9 @@ public class Client(
                     return@async Result.failure(it)
                 }
 
-                presence.setPresenceId(response.presenceId)
-                presence.updateCount(response.count, 0L)
-                presence.applyStatus(ResourceStatus.Attached)
+                channel.setChannelId(response.channelId)
+                channel.updateCount(response.count, 0L)
+                channel.applyStatus(ResourceStatus.Attached)
 
                 val syncMode = if (isRealtime != false) {
                     SyncMode.Realtime
@@ -1029,15 +1030,15 @@ public class Client(
                     SyncMode.Manual
                 }
 
-                attachments[presenceKey] = Attachment(
-                    resource = presence,
-                    resourceId = response.presenceId,
+                attachments[channelKey] = Attachment(
+                    resource = channel,
+                    resourceId = response.channelId,
                     syncMode = syncMode,
                 )
 
                 // Only start watch loop for realtime mode
                 if (syncMode == SyncMode.Realtime) {
-                    runWatchLoop(presenceKey)
+                    runWatchLoop(channelKey)
                 }
             }
             SUCCESS
@@ -1045,35 +1046,35 @@ public class Client(
     }
 
     /**
-     * `detachPresence` detaches the given presence counter from this client.
-     * It tells the server that this client will no longer track the presence count.
+     * `detachChannel` detaches the given channel counter from this client.
+     * It tells the server that this client will no longer track the channel count.
      */
-    public fun detachPresence(presence: Presence): Deferred<OperationResult> {
+    public fun detachChannel(channel: Channel): Deferred<OperationResult> {
         return scope.async {
             checkYorkieError(
                 isActive,
                 YorkieException(ErrClientNotActivated, "client is not active"),
             )
 
-            attachments[presence.getKey()]
+            attachments[channel.getKey()]
                 ?: throw YorkieException(
                     ErrDocumentNotAttached,
-                    "${presence.getKey()} is not attached",
+                    "${channel.getKey()} is not attached",
                 )
 
-            val presenceKey = presence.getKey()
+            val channelKey = channel.getKey()
 
-            val request = detachPresenceRequest {
+            val request = detachChannelRequest {
                 clientId = requireClientId()
-                presence.getPresenceId()?.let {
-                    presenceId = it
+                channel.getChannelId()?.let {
+                    channelId = it
                 }
-                this.presenceKey = presenceKey
+                this.channelKey = channelKey
             }
 
-            val response = service.detachPresence(
+            val response = service.detachChannel(
                 request,
-                presenceKey.attachmentBasedRequestHeader,
+                channelKey.attachmentBasedRequestHeader,
             ).getOrElse {
                 ensureActive()
                 handleConnectException(it) { exception ->
@@ -1085,14 +1086,28 @@ public class Client(
                 return@async Result.failure(it)
             }
 
-            presence.updateCount(response.count, 0L)
-            presence.applyStatus(ResourceStatus.Detached)
+            channel.updateCount(response.count, 0L)
+            channel.applyStatus(ResourceStatus.Detached)
+            channel.close()
 
-            detachInternal(presenceKey)
+            detachInternal(channelKey)
 
             SUCCESS
         }
     }
+
+    @Deprecated(
+        "Renamed to attachChannel",
+        replaceWith = ReplaceWith("attachChannel(channel, isRealtime)"),
+    )
+    public fun attachPresence(presence: Presence, isRealtime: Boolean? = null) =
+        attachChannel(presence, isRealtime)
+
+    @Deprecated(
+        "Renamed to detachChannel",
+        replaceWith = ReplaceWith("detachChannel(channel)"),
+    )
+    public fun detachPresence(presence: Presence) = detachChannel(presence)
 
     private fun detachInternal(key: String) {
         val attachment = attachments[key] ?: return
@@ -1421,12 +1436,18 @@ public class Client(
          */
         public val reconnectStreamDelay: Duration = 1_000.milliseconds,
         /**
-         * `presenceHeartbeatInterval` is the interval of the presence heartbeat.
-         * The client sends a heartbeat to the server to refresh the presence TTL.
+         * `channelHeartbeatInterval` is the interval of the channel heartbeat.
+         * The client sends a heartbeat to the server to refresh the channel TTL.
          * The default value is `30000`(ms).
          */
-        public val presenceHeartbeatInterval: Duration = 30_000.milliseconds,
-    )
+        public val channelHeartbeatInterval: Duration = 30_000.milliseconds,
+    ) {
+        @Deprecated(
+            "Renamed to channelHeartbeatInterval",
+            replaceWith = ReplaceWith("channelHeartbeatInterval"),
+        )
+        public val presenceHeartbeatInterval: Duration get() = channelHeartbeatInterval
+    }
 
     /**
      * `DeactivateOptions` are user-settable options used when deactivating clients.

--- a/yorkie/src/main/kotlin/dev/yorkie/presence/Channel.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/presence/Channel.kt
@@ -49,7 +49,7 @@ class Channel(
     @Volatile
     private var status = ResourceStatus.Detached
     private var actorID: String? = null
-    private var channelId: String? = null
+    private var sessionId: String? = null
 
     @Volatile
     private var count = 0L
@@ -82,17 +82,17 @@ class Channel(
     }
 
     /**
-     * `getChannelId` returns the channel ID from the server.
+     * `getSessionId` returns the session ID from the server.
      */
-    fun getChannelId(): String? {
-        return channelId
+    fun getSessionId(): String? {
+        return sessionId
     }
 
     /**
-     * `setChannelId` sets the channel ID from the server.
+     * `setSessionId` sets the session ID from the server.
      */
-    fun setChannelId(channelId: String) {
-        this.channelId = channelId
+    fun setSessionId(sessionId: String) {
+        this.sessionId = sessionId
     }
 
     /**

--- a/yorkie/src/main/kotlin/dev/yorkie/presence/Channel.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/presence/Channel.kt
@@ -7,11 +7,12 @@ import dev.yorkie.util.createSingleThreadDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 
-sealed interface PresenceEvent : ResourceEvent {
+sealed interface ChannelEvent : ResourceEvent {
     /**
      * Current count value. Zero for non-count events.
      */
@@ -19,36 +20,36 @@ sealed interface PresenceEvent : ResourceEvent {
 
     data class Changed(
         override val count: Long,
-    ) : PresenceEvent
+    ) : ChannelEvent
 
     data class Initialized(
         override val count: Long,
-    ) : PresenceEvent
+    ) : ChannelEvent
 
     /**
-     * Broadcast event received from a remote client on this presence key.
+     * Broadcast event received from a remote client on this channel key.
      */
     data class Broadcast(
         val actorID: String?,
         val topic: String,
         val payload: String,
-    ) : PresenceEvent {
+    ) : ChannelEvent {
         override val count: Long = 0L
     }
 }
 
-class Presence(
+class Channel(
     private val key: String,
 ) : Attachable {
     private val dispatcher: CoroutineDispatcher =
-        createSingleThreadDispatcher("Presence($key)")
+        createSingleThreadDispatcher("Channel($key)")
 
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
 
     @Volatile
     private var status = ResourceStatus.Detached
     private var actorID: String? = null
-    private var presenceId: String? = null
+    private var channelId: String? = null
 
     @Volatile
     private var count = 0L
@@ -56,42 +57,42 @@ class Presence(
     @Volatile
     private var seq = 0L
 
-    private val _eventStream = MutableSharedFlow<PresenceEvent>()
+    private val _eventStream = MutableSharedFlow<ChannelEvent>()
     val eventStream = _eventStream.asSharedFlow()
 
     /**
-     * `applyStatus` applies the presence status into this presence counter.
+     * `applyStatus` applies the channel status into this channel counter.
      */
     override fun applyStatus(status: ResourceStatus) {
         this.status = status
     }
 
     /**
-     * `isAttached` returns whether this presence counter is attached or not.
+     * `isAttached` returns whether this channel counter is attached or not.
      */
     fun isAttached(): Boolean {
         return status == ResourceStatus.Attached
     }
 
     /**
-     * `getActorID` returns the actor ID of this presence counter.
+     * `getActorID` returns the actor ID of this channel counter.
      */
     fun getActorID(): String? {
         return actorID
     }
 
     /**
-     * `getPresenceID` returns the presence ID from the server.
+     * `getChannelId` returns the channel ID from the server.
      */
-    fun getPresenceId(): String? {
-        return presenceId
+    fun getChannelId(): String? {
+        return channelId
     }
 
     /**
-     * `setPresenceID` sets the presence ID from the server.
+     * `setChannelId` sets the channel ID from the server.
      */
-    fun setPresenceId(presenceId: String) {
-        this.presenceId = presenceId
+    fun setChannelId(channelId: String) {
+        this.channelId = channelId
     }
 
     /**
@@ -117,29 +118,29 @@ class Presence(
     }
 
     /**
-     * `getKey` returns the key of this presence counter.
+     * `getKey` returns the key of this channel counter.
      */
     override fun getKey(): String {
         return key
     }
 
     /**
-     * `getStatus` returns the status of this presence counter.
+     * `getStatus` returns the status of this channel counter.
      */
     override fun getStatus(): ResourceStatus {
         return status
     }
 
     /**
-     * `setActor` sets the actor ID into this presence counter.
+     * `setActor` sets the actor ID into this channel counter.
      */
     override fun setActor(actorID: String) {
         this.actorID = actorID
     }
 
     /**
-     * `hasLocalChanges` returns whether this presence has local changes or not.
-     * Presence is server-managed, so it always returns false.
+     * `hasLocalChanges` returns whether this channel has local changes or not.
+     * Channel is server-managed, so it always returns false.
      */
     override fun hasLocalChanges(): Boolean {
         return false
@@ -150,9 +151,28 @@ class Presence(
      */
     override fun publish(event: ResourceEvent) {
         scope.launch {
-            (event as? PresenceEvent)?.let {
+            (event as? ChannelEvent)?.let {
                 _eventStream.emit(it)
             }
         }
     }
+
+    /**
+     * `close` cancels the internal coroutine scope.
+     */
+    fun close() {
+        scope.cancel()
+    }
 }
+
+@Deprecated(
+    "Renamed to Channel",
+    replaceWith = ReplaceWith("Channel", "dev.yorkie.presence.Channel"),
+)
+typealias Presence = Channel
+
+@Deprecated(
+    "Renamed to ChannelEvent",
+    replaceWith = ReplaceWith("ChannelEvent", "dev.yorkie.presence.ChannelEvent"),
+)
+typealias PresenceEvent = ChannelEvent

--- a/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
@@ -349,7 +349,8 @@ class MockYorkieService(
         headers: Headers,
     ): ServerOnlyStreamInterface<WatchChannelRequest, WatchChannelResponse> {
         return object : ServerOnlyStreamInterface<WatchChannelRequest, WatchChannelResponse> {
-            private var responseChannel = kotlinx.coroutines.channels.Channel<WatchChannelResponse>()
+            private var responseChannel =
+                kotlinx.coroutines.channels.Channel<WatchChannelResponse>()
 
             override fun isClosed(): Boolean {
                 return responseChannel.isClosedForSend

--- a/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
@@ -46,14 +46,13 @@ import dev.yorkie.api.v1.attachDocumentResponse
 import dev.yorkie.api.v1.broadcastResponse
 import dev.yorkie.api.v1.change
 import dev.yorkie.api.v1.changePack
+import dev.yorkie.api.v1.channelEvent
 import dev.yorkie.api.v1.deactivateClientResponse
 import dev.yorkie.api.v1.detachChannelResponse
 import dev.yorkie.api.v1.detachDocumentResponse
 import dev.yorkie.api.v1.docEvent
-import dev.yorkie.api.v1.docEventBody
 import dev.yorkie.api.v1.jSONElementSimple
 import dev.yorkie.api.v1.operation
-import dev.yorkie.api.v1.presenceEvent
 import dev.yorkie.api.v1.pushPullChangesResponse
 import dev.yorkie.api.v1.refreshChannelResponse
 import dev.yorkie.api.v1.removeDocumentResponse
@@ -80,6 +79,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import dev.yorkie.api.v1.ChannelEvent.Type as PbChannelEventType
 
 class MockYorkieService(
     val customError: MutableMap<String, Code> = defaultError,
@@ -392,32 +392,36 @@ class MockYorkieService(
                         delay(50)
                         responseChannel.trySend(
                             watchChannelResponse {
-                                event = presenceEvent {}
+                                event = channelEvent {
+                                    type = PbChannelEventType.TYPE_PRESENCE
+                                }
                             },
                         )
                         delay(1_000)
                         responseChannel.trySend(
                             watchChannelResponse {
-                                event = presenceEvent {}
+                                event = channelEvent {
+                                    type = PbChannelEventType.TYPE_PRESENCE
+                                }
                             },
                         )
                         delay(2_000)
                         responseChannel.trySend(
                             watchChannelResponse {
-                                event = presenceEvent {}
+                                event = channelEvent {
+                                    type = PbChannelEventType.TYPE_PRESENCE
+                                }
                             },
                         )
                         delay(500)
                         responseChannel.trySend(
-                            watchPresenceResponse {
-                                broadcast = docEvent {
-                                    type = DocEventType.DOC_EVENT_TYPE_DOCUMENT_BROADCAST
+                            watchChannelResponse {
+                                event = channelEvent {
+                                    type = PbChannelEventType.TYPE_BROADCAST
                                     publisher = input.clientId
-                                    body = docEventBody {
-                                        topic = "test-topic"
-                                        payload =
-                                            ByteString.copyFromUtf8("test-payload")
-                                    }
+                                    topic = "test-topic"
+                                    payload =
+                                        ByteString.copyFromUtf8("test-payload")
                                 }
                             },
                         )

--- a/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
@@ -12,54 +12,54 @@ import dev.yorkie.api.toPBChange
 import dev.yorkie.api.toPBTimeTicket
 import dev.yorkie.api.v1.ActivateClientRequest
 import dev.yorkie.api.v1.ActivateClientResponse
+import dev.yorkie.api.v1.AttachChannelRequest
+import dev.yorkie.api.v1.AttachChannelResponse
 import dev.yorkie.api.v1.AttachDocumentRequest
 import dev.yorkie.api.v1.AttachDocumentResponse
-import dev.yorkie.api.v1.AttachPresenceRequest
-import dev.yorkie.api.v1.AttachPresenceResponse
 import dev.yorkie.api.v1.BroadcastRequest
 import dev.yorkie.api.v1.BroadcastResponse
 import dev.yorkie.api.v1.DeactivateClientRequest
 import dev.yorkie.api.v1.DeactivateClientResponse
+import dev.yorkie.api.v1.DetachChannelRequest
+import dev.yorkie.api.v1.DetachChannelResponse
 import dev.yorkie.api.v1.DetachDocumentRequest
 import dev.yorkie.api.v1.DetachDocumentResponse
-import dev.yorkie.api.v1.DetachPresenceRequest
-import dev.yorkie.api.v1.DetachPresenceResponse
 import dev.yorkie.api.v1.DocEventType
 import dev.yorkie.api.v1.OperationKt.remove
 import dev.yorkie.api.v1.OperationKt.set
 import dev.yorkie.api.v1.PushPullChangesRequest
 import dev.yorkie.api.v1.PushPullChangesResponse
-import dev.yorkie.api.v1.RefreshPresenceRequest
-import dev.yorkie.api.v1.RefreshPresenceResponse
+import dev.yorkie.api.v1.RefreshChannelRequest
+import dev.yorkie.api.v1.RefreshChannelResponse
 import dev.yorkie.api.v1.RemoveDocumentRequest
 import dev.yorkie.api.v1.RemoveDocumentResponse
 import dev.yorkie.api.v1.ValueType
+import dev.yorkie.api.v1.WatchChannelRequest
+import dev.yorkie.api.v1.WatchChannelResponse
 import dev.yorkie.api.v1.WatchDocumentRequest
 import dev.yorkie.api.v1.WatchDocumentResponse
 import dev.yorkie.api.v1.WatchDocumentResponseKt.initialization
-import dev.yorkie.api.v1.WatchPresenceRequest
-import dev.yorkie.api.v1.WatchPresenceResponse
 import dev.yorkie.api.v1.YorkieServiceClientInterface
 import dev.yorkie.api.v1.activateClientResponse
+import dev.yorkie.api.v1.attachChannelResponse
 import dev.yorkie.api.v1.attachDocumentResponse
-import dev.yorkie.api.v1.attachPresenceResponse
 import dev.yorkie.api.v1.broadcastResponse
 import dev.yorkie.api.v1.change
 import dev.yorkie.api.v1.changePack
 import dev.yorkie.api.v1.deactivateClientResponse
+import dev.yorkie.api.v1.detachChannelResponse
 import dev.yorkie.api.v1.detachDocumentResponse
-import dev.yorkie.api.v1.detachPresenceResponse
 import dev.yorkie.api.v1.docEvent
 import dev.yorkie.api.v1.docEventBody
 import dev.yorkie.api.v1.jSONElementSimple
 import dev.yorkie.api.v1.operation
 import dev.yorkie.api.v1.presenceEvent
 import dev.yorkie.api.v1.pushPullChangesResponse
-import dev.yorkie.api.v1.refreshPresenceResponse
+import dev.yorkie.api.v1.refreshChannelResponse
 import dev.yorkie.api.v1.removeDocumentResponse
+import dev.yorkie.api.v1.watchChannelInitialized
+import dev.yorkie.api.v1.watchChannelResponse
 import dev.yorkie.api.v1.watchDocumentResponse
-import dev.yorkie.api.v1.watchPresenceInitialized
-import dev.yorkie.api.v1.watchPresenceResponse
 import dev.yorkie.document.change.Change
 import dev.yorkie.document.change.ChangeID
 import dev.yorkie.document.crdt.CrdtPrimitive
@@ -311,45 +311,45 @@ class MockYorkieService(
         }
     }
 
-    override suspend fun attachPresence(
-        request: AttachPresenceRequest,
+    override suspend fun attachChannel(
+        request: AttachChannelRequest,
         headers: Headers,
-    ): ResponseMessage<AttachPresenceResponse> {
+    ): ResponseMessage<AttachChannelResponse> {
         return ResponseMessage.Success(
-            message = attachPresenceResponse {},
+            message = attachChannelResponse {},
             headers = emptyMap(),
             trailers = emptyMap(),
         )
     }
 
-    override suspend fun detachPresence(
-        request: DetachPresenceRequest,
+    override suspend fun detachChannel(
+        request: DetachChannelRequest,
         headers: Headers,
-    ): ResponseMessage<DetachPresenceResponse> {
+    ): ResponseMessage<DetachChannelResponse> {
         return ResponseMessage.Success(
-            message = detachPresenceResponse {},
+            message = detachChannelResponse {},
             headers = emptyMap(),
             trailers = emptyMap(),
         )
     }
 
-    override suspend fun refreshPresence(
-        request: RefreshPresenceRequest,
+    override suspend fun refreshChannel(
+        request: RefreshChannelRequest,
         headers: Headers,
-    ): ResponseMessage<RefreshPresenceResponse> {
+    ): ResponseMessage<RefreshChannelResponse> {
         return ResponseMessage.Success(
-            message = refreshPresenceResponse {},
+            message = refreshChannelResponse {},
             headers = emptyMap(),
             trailers = emptyMap(),
         )
     }
 
     @OptIn(DelicateCoroutinesApi::class)
-    override suspend fun watchPresence(
+    override suspend fun watchChannel(
         headers: Headers,
-    ): ServerOnlyStreamInterface<WatchPresenceRequest, WatchPresenceResponse> {
-        return object : ServerOnlyStreamInterface<WatchPresenceRequest, WatchPresenceResponse> {
-            private var responseChannel = Channel<WatchPresenceResponse>()
+    ): ServerOnlyStreamInterface<WatchChannelRequest, WatchChannelResponse> {
+        return object : ServerOnlyStreamInterface<WatchChannelRequest, WatchChannelResponse> {
+            private var responseChannel = kotlinx.coroutines.channels.Channel<WatchChannelResponse>()
 
             override fun isClosed(): Boolean {
                 return responseChannel.isClosedForSend
@@ -363,9 +363,10 @@ class MockYorkieService(
                 responseChannel.close()
             }
 
-            override fun responseChannel(): ReceiveChannel<WatchPresenceResponse> {
+            override fun responseChannel(): ReceiveChannel<WatchChannelResponse> {
                 return responseChannel.takeUnless { it.isClosedForReceive || it.isClosedForSend }
-                    ?: Channel<WatchPresenceResponse>().also { responseChannel = it }
+                    ?: kotlinx.coroutines.channels.Channel<WatchChannelResponse>()
+                        .also { responseChannel = it }
             }
 
             override fun responseHeaders(): Deferred<Headers> {
@@ -376,32 +377,32 @@ class MockYorkieService(
                 return CompletableDeferred(emptyMap())
             }
 
-            override suspend fun sendAndClose(input: WatchPresenceRequest): Result<Unit> {
+            override suspend fun sendAndClose(input: WatchChannelRequest): Result<Unit> {
                 return runCatching {
                     CoroutineScope(Dispatchers.Default).launch {
                         if (responseChannel.isClosedForSend) {
                             return@launch
                         }
                         responseChannel.trySend(
-                            watchPresenceResponse {
-                                initialized = watchPresenceInitialized {}
+                            watchChannelResponse {
+                                initialized = watchChannelInitialized {}
                             },
                         )
                         delay(50)
                         responseChannel.trySend(
-                            watchPresenceResponse {
+                            watchChannelResponse {
                                 event = presenceEvent {}
                             },
                         )
                         delay(1_000)
                         responseChannel.trySend(
-                            watchPresenceResponse {
+                            watchChannelResponse {
                                 event = presenceEvent {}
                             },
                         )
                         delay(2_000)
                         responseChannel.trySend(
-                            watchPresenceResponse {
+                            watchChannelResponse {
                                 event = presenceEvent {}
                             },
                         )

--- a/yorkie/src/test/kotlin/dev/yorkie/presence/ChannelTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/presence/ChannelTest.kt
@@ -1,0 +1,42 @@
+package dev.yorkie.presence
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class ChannelTest {
+
+    @Test
+    fun `updateCount ignores stale sequence number`() {
+        // given
+        val channel = Channel("key")
+        channel.updateCount(5L, 10L)
+
+        // when
+        val updated = channel.updateCount(3L, 9L)
+
+        // then
+        assertFalse(updated)
+        assertEquals(5L, channel.getCount())
+    }
+
+    @Test
+    fun `updateCount accepts seq zero as initialization bypass`() {
+        // given
+        val channel = Channel("key")
+        channel.updateCount(5L, 10L)
+
+        // when
+        val updated = channel.updateCount(2L, 0L)
+
+        // then
+        assertTrue(updated)
+        assertEquals(2L, channel.getCount())
+    }
+
+    @Test
+    fun `hasLocalChanges always returns false`() {
+        assertFalse(Channel("key").hasLocalChanges())
+    }
+}


### PR DESCRIPTION
> **RTCOLLABPLATFORM-627**: [[Android] sync: Rename Presence to Channel (yorkie-js-sdk#1103)](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-627)

## Summary
- Rename Presence to Channel across the SDK (classes, proto messages, API methods, tests)
- Align proto field numbers and names with server and JS SDK PR yorkie-team/yorkie-js-sdk#1103
- Bump Yorkie Docker image from 0.6.35 to 0.6.36

## Changes
- **Proto**: Rename `PresenceEvent` → `ChannelEvent` with `TYPE_PRESENCE`/`TYPE_BROADCAST`; unify `WatchChannelResponse` to single `ChannelEvent`; replace `document_id`/`presence_key` with `channel_key` in `BroadcastRequest`; fix field number alignment in `DetachChannelRequest`, `RefreshChannelRequest`, `AttachChannelResponse`
- **`Channel.kt`**: Rename from `Presence.kt`; rename `channelId` → `sessionId`; add `ChannelEvent.Broadcast`
- **`Client.kt`**: Rename all Presence API methods to Channel; handle `ChannelEvent.Type` dispatch; unify broadcast to use `channelKey`
- **`MockYorkieService.kt`**: Update to use `ChannelEvent` proto types
- **`ChannelTest.kt`**: Rename from `PresenceTest.kt` with all Channel naming + 2 broadcast tests
- **Docker**: Bump `yorkieteam/yorkie` from 0.6.35 to 0.6.36

## Test plan
- [ ] All 9 `ChannelTest` instrumented tests pass (including manual sync and broadcast)
- [ ] All existing `ClientTest` and document tests pass (no regression)
- [ ] Unit tests pass

> Items run automatically by CI (lint, unit tests, coverage) are excluded.