### PR TITLE
Expose Tree.Edit splitByPath/mergeByPath as public API

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
@@ -2801,6 +2801,123 @@ class JsonTreeTest {
         )
     }
 
+    // ===== Tree Split/Merge Public API Tests =====
+
+    @Test
+    fun test_tree_splitByPath_preserves_attributes_after_split() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        element("doc") {
+                            element("p") {
+                                attr { "bold" to "true" }
+                                text { "helloworld" }
+                            }
+                        },
+                    )
+                },
+                Updater(c2, d2),
+            )
+            assertTreesXmlEquals(
+                "<doc><p bold=\"true\">helloworld</p></doc>",
+                d1,
+                d2,
+            )
+
+            updateAndSync(
+                Updater(c1, d1) { root, _ ->
+                    root.rootTree().splitByPath(listOf(0, 5))
+                },
+                Updater(c2, d2),
+            )
+            assertTreesXmlEquals(
+                "<doc><p bold=\"true\">hello</p><p bold=\"true\">world</p></doc>",
+                d1,
+                d2,
+            )
+        }
+    }
+
+    @Test
+    fun test_tree_split_then_merge_roundtrip_restores_original() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        element("doc") {
+                            element("p") { text { "helloworld" } }
+                        },
+                    )
+                },
+                Updater(c2, d2),
+            )
+            assertTreesXmlEquals("<doc><p>helloworld</p></doc>", d1, d2)
+
+            // Split at offset 5
+            updateAndSync(
+                Updater(c1, d1) { root, _ ->
+                    root.rootTree().splitByPath(listOf(0, 5))
+                },
+                Updater(c2, d2),
+            )
+            assertTreesXmlEquals(
+                "<doc><p>hello</p><p>world</p></doc>",
+                d1,
+                d2,
+            )
+
+            // Merge back
+            updateAndSync(
+                Updater(c1, d1) { root, _ ->
+                    root.rootTree().mergeByPath(listOf(1))
+                },
+                Updater(c2, d2),
+            )
+            assertTreesXmlEquals("<doc><p>helloworld</p></doc>", d1, d2)
+        }
+    }
+
+    @Test
+    fun test_tree_concurrent_split_and_merge_on_same_boundary_converges() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        element("doc") {
+                            element("p") { text { "hello" } }
+                            element("p") { text { "world" } }
+                        },
+                    )
+                },
+                Updater(c2, d2),
+            )
+            assertTreesXmlEquals(
+                "<doc><p>hello</p><p>world</p></doc>",
+                d1,
+                d2,
+            )
+
+            // c1 splits first <p> at offset 3, c2 merges second <p> into first
+            updateAndSync(
+                Updater(c1, d1) { root, _ ->
+                    root.rootTree().splitByPath(listOf(0, 3))
+                },
+                Updater(c2, d2) { root, _ ->
+                    root.rootTree().mergeByPath(listOf(1))
+                },
+            )
+
+            // Both should converge to the same tree
+            val d1Xml = d1.getRoot().rootTree().toXml()
+            val d2Xml = d2.getRoot().rootTree().toXml()
+            assertEquals(d1Xml, d2Xml)
+        }
+    }
+
     // ===== Tree LWW Tests (from PR #1097) =====
 
     @Test

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonTree.kt
@@ -187,9 +187,15 @@ public class JsonTree internal constructor(
     }
 
     /**
-     * `splitByPath` splits the tree by the given [path].
+     * Splits the tree at the given [path].
+     *
+     * The node at [path] is split into two sibling nodes. Content after the
+     * split point moves into a new node inserted immediately after. Internally
+     * decomposes into one or two [edit] calls (delete tail + insert new node).
+     *
+     * @throws YorkieException if [path] is empty.
      */
-    fun splitByPath(path: List<Int>) {
+    public fun splitByPath(path: List<Int>) {
         if (path.isEmpty()) {
             throw YorkieException(
                 code = YorkieException.Code.ErrInvalidArgument,
@@ -218,9 +224,17 @@ public class JsonTree internal constructor(
     }
 
     /**
-     * `mergeByPath` merges the tree by the given [path].
+     * Merges the element node at the given [path] into its left sibling.
+     *
+     * The children of the node at [path] are moved into the preceding sibling,
+     * then the now-empty node is deleted. Only element nodes can be merged;
+     * merging a text node throws [YorkieException]. The node must have a left
+     * sibling (i.e., it cannot be the first child).
+     *
+     * @throws YorkieException if [path] is empty, resolves to a text node, or
+     *   resolves to the first child (no left sibling).
      */
-    fun mergeByPath(path: List<Int>) {
+    public fun mergeByPath(path: List<Int>) {
         if (path.isEmpty()) {
             throw YorkieException(
                 code = YorkieException.Code.ErrInvalidArgument,
@@ -233,6 +247,13 @@ public class JsonTree internal constructor(
             throw YorkieException(
                 code = YorkieException.Code.ErrInvalidArgument,
                 errorMessage = "text node cannot be merged",
+            )
+        }
+
+        if (treePos.offset == 0) {
+            throw YorkieException(
+                code = YorkieException.Code.ErrInvalidArgument,
+                errorMessage = "the first child cannot be merged (no left sibling)",
             )
         }
 

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
@@ -13,8 +13,10 @@ import dev.yorkie.document.operation.OperationInfo.TreeEditOpInfo
 import dev.yorkie.document.operation.OperationInfo.TreeStyleOpInfo
 import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
 import dev.yorkie.util.IndexTreeNode.Companion.DEFAULT_ROOT_TYPE
+import dev.yorkie.util.YorkieException
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.asFlow
@@ -25,7 +27,6 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertThrows
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -911,6 +912,97 @@ class JsonTreeTest {
             "<doc><tc><p><tn>12345678</tn></p></tc></doc>",
             document.getRoot().tree().toXml(),
         )
+    }
+
+    @Test
+    fun `splitByPath with empty path throws YorkieException`() = runTest {
+        val document = Document("")
+        fun JsonObject.tree() = getAs<JsonTree>("t")
+
+        document.updateAsync { root, _ ->
+            root.setNewTree(
+                "t",
+                element("doc") {
+                    element("p") { text { "hello" } }
+                },
+            )
+        }.await()
+
+        val result = document.updateAsync { root, _ ->
+            root.tree().splitByPath(emptyList())
+        }.await()
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull() as YorkieException
+        assertEquals(YorkieException.Code.ErrInvalidArgument, exception.code)
+    }
+
+    @Test
+    fun `mergeByPath with empty path throws YorkieException`() = runTest {
+        val document = Document("")
+        fun JsonObject.tree() = getAs<JsonTree>("t")
+
+        document.updateAsync { root, _ ->
+            root.setNewTree(
+                "t",
+                element("doc") {
+                    element("p") { text { "hello" } }
+                    element("p") { text { "world" } }
+                },
+            )
+        }.await()
+
+        val result = document.updateAsync { root, _ ->
+            root.tree().mergeByPath(emptyList())
+        }.await()
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull() as YorkieException
+        assertEquals(YorkieException.Code.ErrInvalidArgument, exception.code)
+    }
+
+    @Test
+    fun `mergeByPath on text node throws YorkieException`() = runTest {
+        val document = Document("")
+        fun JsonObject.tree() = getAs<JsonTree>("t")
+
+        document.updateAsync { root, _ ->
+            root.setNewTree(
+                "t",
+                element("doc") {
+                    element("p") { text { "hello" } }
+                    element("p") { text { "world" } }
+                },
+            )
+        }.await()
+
+        val result = document.updateAsync { root, _ ->
+            root.tree().mergeByPath(listOf(0, 0))
+        }.await()
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull() as YorkieException
+        assertEquals(YorkieException.Code.ErrInvalidArgument, exception.code)
+    }
+
+    @Test
+    fun `mergeByPath on first child throws YorkieException`() = runTest {
+        val document = Document("")
+        fun JsonObject.tree() = getAs<JsonTree>("t")
+
+        document.updateAsync { root, _ ->
+            root.setNewTree(
+                "t",
+                element("doc") {
+                    element("p") { text { "hello" } }
+                    element("p") { text { "world" } }
+                },
+            )
+        }.await()
+
+        val result = document.updateAsync { root, _ ->
+            root.tree().mergeByPath(listOf(0))
+        }.await()
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull() as YorkieException
+        assertEquals(YorkieException.Code.ErrInvalidArgument, exception.code)
     }
 
     companion object {

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
> **RTCOLLABPLATFORM-630**: [[Android] Expose Tree.Edit splitByPath/mergeByPath as public API](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-630)

## Summary
- Expose existing `splitByPath()` and `mergeByPath()` as explicit public API on `JsonTree`
- Fix offset-0 crash bug in `mergeByPath` (unguarded `ArrayIndexOutOfBoundsException` when merging first child)
- Add error-path unit tests and high-value instrumented tests

## Changes
- **`JsonTree.kt`**: Add explicit `public` modifier, improved KDoc with `@throws` tags, offset-0 guard in `mergeByPath`
- **Unit tests**: 4 error-path tests (empty path, text node merge, first-child merge)
- **Instrumented tests**: 3 tests (attributes preserved after split, split-then-merge roundtrip, concurrent split+merge convergence)

## Test plan
- [ ] 4 unit tests for error paths pass
- [ ] 3 new instrumented tests pass
- [ ] Existing split/merge tests still pass (no regression)
- [ ] All existing JsonTreeTest suite passes

> Items run automatically by CI (lint, unit tests, coverage) are excluded.