### PR TITLE
Add OpSource, ExecutionResult, and reverse ops to operations

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -213,7 +213,7 @@ public class Document(
                 return@async result
             }
             val change = context.toChange()
-            val (operationInfos, newPresences) = change.execute(root, _presences.value)
+            val (operationInfos, newPresences, _) = change.execute(root, _presences.value)
 
             localChanges += change
             changeID = context.getNextId()
@@ -370,7 +370,7 @@ public class Document(
     private suspend fun applyChanges(changes: List<Change>) {
         val clone = ensureClone()
         changes.forEach { change ->
-            change.execute(clone.root, clone.presences).also { (_, newPresences) ->
+            change.execute(clone.root, clone.presences).also { (_, newPresences, _) ->
                 this.clone = clone.copy(presences = newPresences ?: return@also)
             }
             val actorID = change.id.actor
@@ -403,7 +403,7 @@ public class Document(
                 }
             }
 
-            val (opInfos, newPresences) = change.execute(root, _presences.value)
+            val (opInfos, newPresences, _) = change.execute(root, _presences.value)
             if (opInfos.isNotEmpty()) {
                 eventStream.emit(Event.RemoteChange(change.toChangeInfo(opInfos)))
             }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/Change.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/Change.kt
@@ -1,6 +1,7 @@
 package dev.yorkie.document.change
 
 import dev.yorkie.document.crdt.CrdtRoot
+import dev.yorkie.document.operation.OpSource
 import dev.yorkie.document.operation.Operation
 import dev.yorkie.document.operation.OperationInfo
 import dev.yorkie.document.presence.PresenceChange
@@ -32,13 +33,23 @@ public data class Change internal constructor(
     internal fun execute(
         root: CrdtRoot,
         presences: Presences,
-    ): Pair<List<OperationInfo>, Presences?> {
+        source: OpSource = OpSource.Local,
+    ): Triple<List<OperationInfo>, Presences?, List<Operation>> {
         val newPresences = presenceChange?.let {
             when (presenceChange) {
                 is PresenceChange.Put -> presences + (id.actor to presenceChange.presence)
                 is PresenceChange.Clear -> presences - id.actor
             }
         }
-        return operations.flatMap { it.execute(root, id.versionVector) } to newPresences
+        val allOpInfos = mutableListOf<OperationInfo>()
+        val reverseOps = mutableListOf<Operation>()
+
+        for (op in operations) {
+            val result = op.execute(root, source, id.versionVector)
+            allOpInfos.addAll(result.opInfos)
+            result.reverseOp?.let { reverseOps.add(0, it) }
+        }
+
+        return Triple(allOpInfos, newPresences, reverseOps)
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
@@ -11,7 +11,7 @@ import dev.yorkie.util.Logger.Companion.logError
  * [AddOperation] is an operation representing adding an element to an [CrdtArray].
  */
 internal data class AddOperation(
-    val prevCreatedAt: TimeTicket,
+    var prevCreatedAt: TimeTicket,
     val value: CrdtElement,
     override val parentCreatedAt: TimeTicket,
     override var executedAt: TimeTicket,
@@ -26,22 +26,36 @@ internal data class AddOperation(
     /**
      * Executes this [AddOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
+    override fun execute(
+        root: CrdtRoot,
+        source: OpSource,
+        versionVector: VersionVector?,
+    ): ExecutionResult {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtArray) {
             val copiedValue = value.deepCopy()
             parentObject.insertAfter(prevCreatedAt, copiedValue)
             root.registerElement(copiedValue, parentObject)
-            listOf(
-                OperationInfo.AddOpInfo(
-                    parentObject.subPathOf(effectedCreatedAt).toInt(),
-                    root.createPath(parentCreatedAt),
+
+            val reverseOp = RemoveOperation(
+                createdAt = copiedValue.createdAt,
+                parentCreatedAt = parentCreatedAt,
+                executedAt = executedAt,
+            )
+
+            ExecutionResult(
+                opInfos = listOf(
+                    OperationInfo.AddOpInfo(
+                        parentObject.subPathOf(effectedCreatedAt).toInt(),
+                        root.createPath(parentCreatedAt),
+                    ),
                 ),
+                reverseOp = reverseOp,
             )
         } else {
             parentObject ?: logError(TAG, "fail to find $parentCreatedAt")
             logError(TAG, "fail to execute, only array can execute add")
-            emptyList()
+            ExecutionResult(opInfos = emptyList())
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/ArraySetOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/ArraySetOperation.kt
@@ -11,7 +11,7 @@ import dev.yorkie.util.YorkieException
  * `ArraySetOperation` is an operation representing setting an element in Array.
  */
 internal data class ArraySetOperation(
-    val createdAt: TimeTicket,
+    var createdAt: TimeTicket,
     val value: CrdtElement,
     override val parentCreatedAt: TimeTicket,
     override var executedAt: TimeTicket,
@@ -19,7 +19,11 @@ internal data class ArraySetOperation(
     override val effectedCreatedAt: TimeTicket
         get() = createdAt
 
-    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
+    override fun execute(
+        root: CrdtRoot,
+        source: OpSource,
+        versionVector: VersionVector?,
+    ): ExecutionResult {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
             ?: throw YorkieException(
                 code = YorkieException.Code.ErrInvalidArgument,
@@ -33,21 +37,29 @@ internal data class ArraySetOperation(
             )
         }
 
+        val previousValue = parentObject[createdAt]
         val value = value.deepCopy()
         parentObject.insertAfter(createdAt, value, executedAt)
         parentObject.delete(createdAt, executedAt)
 
-        // TODO(junseo): GC logic is not implemented here
-        // because there is no way to distinguish between old and new element with same `createdAt`.
         root.registerElement(value, null)
 
-        // TODO(emplam27): The reverse operation is not implemented yet.
-        val reverseOp = null
+        val reverseOp = previousValue?.let {
+            ArraySetOperation(
+                createdAt = createdAt,
+                value = it.deepCopy(),
+                parentCreatedAt = parentCreatedAt,
+                executedAt = executedAt,
+            )
+        }
 
-        return listOf(
-            OperationInfo.ArraySetOpInfo(
-                path = root.createPath(parentCreatedAt),
+        return ExecutionResult(
+            opInfos = listOf(
+                OperationInfo.ArraySetOpInfo(
+                    path = root.createPath(parentCreatedAt),
+                ),
             ),
+            reverseOp = reverseOp,
         )
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/EditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/EditOperation.kt
@@ -27,7 +27,11 @@ internal data class EditOperation(
     override val effectedCreatedAt: TimeTicket
         get() = parentCreatedAt
 
-    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
+    override fun execute(
+        root: CrdtRoot,
+        source: OpSource,
+        versionVector: VersionVector?,
+    ): ExecutionResult {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtText) {
             val result = parentObject.edit(
@@ -41,20 +45,22 @@ internal data class EditOperation(
             root.acc(result.dataSize)
 
             result.gcPairs.forEach(root::registerGCPair)
-            result.textChanges.map { (_, _, from, to, content, attributes) ->
-                OperationInfo.EditOpInfo(
-                    from,
-                    to,
-                    TextWithAttributes(content.orEmpty() to attributes.orEmpty()),
-                    root.createPath(parentCreatedAt),
-                )
-            }
+            ExecutionResult(
+                opInfos = result.textChanges.map { (_, _, from, to, content, attributes) ->
+                    OperationInfo.EditOpInfo(
+                        from,
+                        to,
+                        TextWithAttributes(content.orEmpty() to attributes.orEmpty()),
+                        root.createPath(parentCreatedAt),
+                    )
+                },
+            )
         } else {
             if (parentObject == null) {
                 logError(TAG, "fail to find $parentCreatedAt")
             }
             logError(TAG, "fail to execute, only Text can execute edit")
-            emptyList()
+            ExecutionResult(opInfos = emptyList())
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/IncreaseOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/IncreaseOperation.kt
@@ -28,7 +28,11 @@ internal data class IncreaseOperation(
     /**
      * Executes this [IncreaseOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
+    override fun execute(
+        root: CrdtRoot,
+        source: OpSource,
+        versionVector: VersionVector?,
+    ): ExecutionResult {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtCounter) {
             val copiedValue = value.deepCopy() as CrdtPrimitive
@@ -38,11 +42,31 @@ internal data class IncreaseOperation(
             } else {
                 copiedValue.value as Long
             }
-            listOf(OperationInfo.IncreaseOpInfo(increasedValue, root.createPath(parentCreatedAt)))
+
+            val negatedValue = if (copiedValue.type == Type.Integer) {
+                CrdtPrimitive(-(copiedValue.value as Int), copiedValue.createdAt)
+            } else {
+                CrdtPrimitive(-(copiedValue.value as Long), copiedValue.createdAt)
+            }
+            val reverseOp = IncreaseOperation(
+                value = negatedValue,
+                parentCreatedAt = parentCreatedAt,
+                executedAt = executedAt,
+            )
+
+            ExecutionResult(
+                opInfos = listOf(
+                    OperationInfo.IncreaseOpInfo(
+                        increasedValue,
+                        root.createPath(parentCreatedAt),
+                    ),
+                ),
+                reverseOp = reverseOp,
+            )
         } else {
             parentObject ?: logError(TAG, "fail to find $parentCreatedAt")
             logError(TAG, "fail to execute, only Counter can execute increase")
-            emptyList()
+            ExecutionResult(opInfos = emptyList())
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
@@ -10,8 +10,8 @@ import dev.yorkie.util.Logger.Companion.logError
  * [MoveOperation] is an operation representing moving an element to an [CrdtArray].
  */
 internal data class MoveOperation(
-    val prevCreatedAt: TimeTicket,
-    val createdAt: TimeTicket,
+    var prevCreatedAt: TimeTicket,
+    var createdAt: TimeTicket,
     override val parentCreatedAt: TimeTicket,
     override var executedAt: TimeTicket,
 ) : Operation() {
@@ -25,23 +25,39 @@ internal data class MoveOperation(
     /**
      * Executes this [MoveOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
+    override fun execute(
+        root: CrdtRoot,
+        source: OpSource,
+        versionVector: VersionVector?,
+    ): ExecutionResult {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtArray) {
+            val prevCreatedAtBefore = parentObject.getPrevCreatedAt(createdAt)
             val previousIndex = parentObject.subPathOf(createdAt).toInt()
             parentObject.moveAfter(prevCreatedAt, createdAt, executedAt)
             val index = parentObject.subPathOf(createdAt).toInt()
-            listOf(
-                OperationInfo.MoveOpInfo(
-                    previousIndex = previousIndex,
-                    index = index,
-                    path = root.createPath(parentCreatedAt),
+
+            val reverseOp = MoveOperation(
+                prevCreatedAt = prevCreatedAtBefore,
+                createdAt = createdAt,
+                parentCreatedAt = parentCreatedAt,
+                executedAt = executedAt,
+            )
+
+            ExecutionResult(
+                opInfos = listOf(
+                    OperationInfo.MoveOpInfo(
+                        previousIndex = previousIndex,
+                        index = index,
+                        path = root.createPath(parentCreatedAt),
+                    ),
                 ),
+                reverseOp = reverseOp,
             )
         } else {
             parentObject ?: logError(TAG, "fail to find $parentCreatedAt")
             logError(TAG, "fail to execute, only array can execute move")
-            emptyList()
+            ExecutionResult(opInfos = emptyList())
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/OpSource.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/OpSource.kt
@@ -1,0 +1,11 @@
+package dev.yorkie.document.operation
+
+/**
+ * Represents the source of an operation. Used to handle corner cases
+ * in undo/redo (e.g., allowing removed elements to be restored).
+ */
+internal enum class OpSource {
+    Local,
+    Remote,
+    UndoRedo,
+}

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/Operation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/Operation.kt
@@ -5,6 +5,14 @@ import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.VersionVector
 
 /**
+ * Result of executing an [Operation].
+ */
+internal data class ExecutionResult(
+    val opInfos: List<OperationInfo>,
+    val reverseOp: Operation? = null,
+)
+
+/**
  * Represents an operation to be executed on a document.
  * [parentCreatedAt] is the creation time of the target element to execute the operation.
  * [executedAt] is the execution time of this operation.
@@ -22,7 +30,11 @@ internal abstract class Operation {
     /**
      * Executes this [Operation] on the given [root].
      */
-    abstract fun execute(root: CrdtRoot, versionVector: VersionVector? = null): List<OperationInfo>
+    abstract fun execute(
+        root: CrdtRoot,
+        source: OpSource = OpSource.Local,
+        versionVector: VersionVector? = null,
+    ): ExecutionResult
 
     /**
      * Sets the given actorId to this [Operation].

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/RemoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/RemoveOperation.kt
@@ -2,6 +2,7 @@ package dev.yorkie.document.operation
 
 import dev.yorkie.document.crdt.CrdtArray
 import dev.yorkie.document.crdt.CrdtContainer
+import dev.yorkie.document.crdt.CrdtObject
 import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.VersionVector
@@ -11,7 +12,7 @@ import dev.yorkie.util.Logger.Companion.logError
  * [RemoveOperation] is an operation that removes an element from [CrdtContainer].
  */
 internal data class RemoveOperation(
-    val createdAt: TimeTicket,
+    var createdAt: TimeTicket,
     override val parentCreatedAt: TimeTicket,
     override var executedAt: TimeTicket,
 ) : Operation() {
@@ -25,18 +26,57 @@ internal data class RemoveOperation(
     /**
      * Executes this [RemoveOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
+    override fun execute(
+        root: CrdtRoot,
+        source: OpSource,
+        versionVector: VersionVector?,
+    ): ExecutionResult {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtContainer) {
+            // Capture BEFORE delete for reverse op
             val key = parentObject.subPathOf(createdAt)
+            val prevCreatedAtForArray = if (parentObject is CrdtArray) {
+                parentObject.getPrevCreatedAt(createdAt)
+            } else {
+                null
+            }
+
             val element = parentObject.delete(createdAt, executedAt)
             root.registerRemovedElement(element)
             val index = if (parentObject is CrdtArray) key?.toInt() else null
-            listOf(OperationInfo.RemoveOpInfo(key, index, root.createPath(parentCreatedAt)))
+
+            val reverseOp = when (parentObject) {
+                is CrdtArray -> {
+                    AddOperation(
+                        prevCreatedAt = prevCreatedAtForArray!!,
+                        value = element.deepCopy(),
+                        parentCreatedAt = parentCreatedAt,
+                        executedAt = executedAt,
+                    )
+                }
+
+                is CrdtObject -> {
+                    SetOperation(
+                        key = key ?: "",
+                        value = element.deepCopy(),
+                        parentCreatedAt = parentCreatedAt,
+                        executedAt = executedAt,
+                    )
+                }
+
+                else -> null
+            }
+
+            ExecutionResult(
+                opInfos = listOf(
+                    OperationInfo.RemoveOpInfo(key, index, root.createPath(parentCreatedAt)),
+                ),
+                reverseOp = reverseOp,
+            )
         } else {
             parentObject ?: logError(TAG, "fail to find $parentCreatedAt")
             logError(TAG, "only object and array can execute remove: $parentObject")
-            emptyList()
+            ExecutionResult(opInfos = emptyList())
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
@@ -27,18 +27,39 @@ internal data class SetOperation(
     /**
      * Executes this [SetOperation] on the given [root].
      */
-    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
+    override fun execute(
+        root: CrdtRoot,
+        source: OpSource,
+        versionVector: VersionVector?,
+    ): ExecutionResult {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtObject) {
+            val previousValue = if (parentObject.has(key)) {
+                parentObject[key].takeIf { !it.isRemoved }
+            } else {
+                null
+            }
             val copiedValue = value.deepCopy()
             val removed = parentObject.set(key, copiedValue, executedAt)
             root.registerElement(copiedValue, parentObject)
             removed?.let(root::registerRemovedElement)
-            listOf(OperationInfo.SetOpInfo(key, root.createPath(parentCreatedAt)))
+
+            val reverseOp = if (previousValue != null) {
+                SetOperation(key, previousValue.deepCopy(), parentCreatedAt, executedAt)
+            } else {
+                RemoveOperation(copiedValue.createdAt, parentCreatedAt, executedAt)
+            }
+
+            ExecutionResult(
+                opInfos = listOf(
+                    OperationInfo.SetOpInfo(key, root.createPath(parentCreatedAt)),
+                ),
+                reverseOp = reverseOp,
+            )
         } else {
             parentObject ?: logError(TAG, "fail to find $parentCreatedAt")
             logError(TAG, "fail to execute, only object can execute set")
-            emptyList()
+            ExecutionResult(opInfos = emptyList())
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt
@@ -19,7 +19,11 @@ internal data class StyleOperation(
     override val effectedCreatedAt: TimeTicket
         get() = parentCreatedAt
 
-    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
+    override fun execute(
+        root: CrdtRoot,
+        source: OpSource,
+        versionVector: VersionVector?,
+    ): ExecutionResult {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtText) {
             val result = parentObject.style(
@@ -33,18 +37,20 @@ internal data class StyleOperation(
             root.acc(result.dataSize)
 
             result.gcPairs.forEach(root::registerGCPair)
-            changes.map {
-                OperationInfo.StyleOpInfo(
-                    it.from,
-                    it.to,
-                    it.attributes.orEmpty(),
-                    root.createPath(parentCreatedAt),
-                )
-            }
+            ExecutionResult(
+                opInfos = changes.map {
+                    OperationInfo.StyleOpInfo(
+                        it.from,
+                        it.to,
+                        it.attributes.orEmpty(),
+                        root.createPath(parentCreatedAt),
+                    )
+                },
+            )
         } else {
             parentObject ?: logError(TAG, "fail to find $parentCreatedAt")
             logError(TAG, "fail to execute, only Text can execute style")
-            emptyList()
+            ExecutionResult(opInfos = emptyList())
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
@@ -22,19 +22,23 @@ internal data class TreeEditOperation(
 ) : Operation() {
     override val effectedCreatedAt = parentCreatedAt
 
-    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
+    override fun execute(
+        root: CrdtRoot,
+        source: OpSource,
+        versionVector: VersionVector?,
+    ): ExecutionResult {
         val tree = root.findByCreatedAt(parentCreatedAt)
         if (tree == null) {
             logError(TAG, "fail to find $parentCreatedAt")
-            return emptyList()
+            return ExecutionResult(opInfos = emptyList())
         }
         if (tree !is CrdtTree) {
             logError(TAG, "fail to execute, only Tree can execute edit")
-            return emptyList()
+            return ExecutionResult(opInfos = emptyList())
         }
         if (!tree.checkPosRangeValid(fromPos to toPos)) {
             logError(TAG, "has invalid pos range, skip executing the operation")
-            return emptyList()
+            return ExecutionResult(opInfos = emptyList())
         }
 
         val editedAt = executedAt
@@ -52,17 +56,19 @@ internal data class TreeEditOperation(
 
         gcPairs.forEach(root::registerGCPair)
 
-        return changes.map {
-            OperationInfo.TreeEditOpInfo(
-                it.from,
-                it.to,
-                it.fromPath,
-                it.toPath,
-                it.value?.map(TreeNode::toJsonTreeNode),
-                it.splitLevel,
-                root.createPath(parentCreatedAt),
-            )
-        }
+        return ExecutionResult(
+            opInfos = changes.map {
+                OperationInfo.TreeEditOpInfo(
+                    it.from,
+                    it.to,
+                    it.fromPath,
+                    it.toPath,
+                    it.value?.map(TreeNode::toJsonTreeNode),
+                    it.splitLevel,
+                    root.createPath(parentCreatedAt),
+                )
+            },
+        )
     }
 
     private fun issueTimeTicket(executedAt: TimeTicket): () -> TimeTicket {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeStyleOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeStyleOperation.kt
@@ -21,15 +21,19 @@ internal data class TreeStyleOperation(
 ) : Operation() {
     override val effectedCreatedAt = parentCreatedAt
 
-    override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> {
+    override fun execute(
+        root: CrdtRoot,
+        source: OpSource,
+        versionVector: VersionVector?,
+    ): ExecutionResult {
         val tree = root.findByCreatedAt(parentCreatedAt)
         if (tree == null) {
             logError(TAG, "fail to find $parentCreatedAt")
-            return emptyList()
+            return ExecutionResult(opInfos = emptyList())
         }
         if (tree !is CrdtTree) {
             logError(TAG, "fail to execute, only Tree can execute edit")
-            return emptyList()
+            return ExecutionResult(opInfos = emptyList())
         }
 
         return when {
@@ -44,16 +48,18 @@ internal data class TreeStyleOperation(
                 root.acc(diff)
 
                 gcPairs.forEach(root::registerGCPair)
-                changes.map {
-                    TreeStyleOpInfo(
-                        it.from,
-                        it.to,
-                        it.fromPath,
-                        it.toPath,
-                        it.attributes.orEmpty(),
-                        path = root.createPath(parentCreatedAt),
-                    )
-                }
+                ExecutionResult(
+                    opInfos = changes.map {
+                        TreeStyleOpInfo(
+                            it.from,
+                            it.to,
+                            it.fromPath,
+                            it.toPath,
+                            it.attributes.orEmpty(),
+                            path = root.createPath(parentCreatedAt),
+                        )
+                    },
+                )
             }
 
             attributesToRemove?.isNotEmpty() == true -> {
@@ -64,19 +70,21 @@ internal data class TreeStyleOperation(
                     versionVector,
                 )
                 gcPairs.forEach(root::registerGCPair)
-                changes.map {
-                    TreeStyleOpInfo(
-                        it.from,
-                        it.to,
-                        it.fromPath,
-                        it.toPath,
-                        attributesToRemove = it.attributesToRemove.orEmpty(),
-                        path = root.createPath(parentCreatedAt),
-                    )
-                }
+                ExecutionResult(
+                    opInfos = changes.map {
+                        TreeStyleOpInfo(
+                            it.from,
+                            it.to,
+                            it.fromPath,
+                            it.toPath,
+                            attributesToRemove = it.attributesToRemove.orEmpty(),
+                            path = root.createPath(parentCreatedAt),
+                        )
+                    },
+                )
             }
 
-            else -> emptyList()
+            else -> ExecutionResult(opInfos = emptyList())
         }
     }
 

--- a/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
@@ -30,10 +30,11 @@ import dev.yorkie.document.json.JsonTree
 import dev.yorkie.document.json.TreeBuilder.element
 import dev.yorkie.document.operation.AddOperation
 import dev.yorkie.document.operation.EditOperation
+import dev.yorkie.document.operation.ExecutionResult
 import dev.yorkie.document.operation.IncreaseOperation
 import dev.yorkie.document.operation.MoveOperation
+import dev.yorkie.document.operation.OpSource
 import dev.yorkie.document.operation.Operation
-import dev.yorkie.document.operation.OperationInfo
 import dev.yorkie.document.operation.RemoveOperation
 import dev.yorkie.document.operation.SetOperation
 import dev.yorkie.document.operation.StyleOperation
@@ -514,8 +515,11 @@ class ConverterTest {
         override var executedAt: TimeTicket,
         override val effectedCreatedAt: TimeTicket,
     ) : Operation() {
-        override fun execute(root: CrdtRoot, versionVector: VersionVector?): List<OperationInfo> =
-            emptyList()
+        override fun execute(
+            root: CrdtRoot,
+            source: OpSource,
+            versionVector: VersionVector?,
+        ): ExecutionResult = ExecutionResult(opInfos = emptyList())
     }
 
     private class TestCrdtElement(


### PR DESCRIPTION
> **RTCOLLABPLATFORM-631**: [[Android] Implement multi-user Undo/Redo (JS SDK v0.6.36 parity)](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-631)

## Summary
- PR 1 of 3 for undo/redo: pure refactor of operation execution layer
- Add `OpSource` enum and `ExecutionResult` data class
- Update `Operation.execute()` across all 11 subclasses to return reverse ops

## Changes
- **`OpSource.kt`** (new): `Local`, `Remote`, `UndoRedo` enum for operation source tracking
- **`Operation.kt`**: `ExecutionResult` data class with `opInfos` + `reverseOp`; updated abstract `execute()` signature
- **6 operations with reverse ops**: `SetOperation`, `RemoveOperation`, `AddOperation`, `ArraySetOperation`, `MoveOperation`, `IncreaseOperation`
- **4 operations without reverse ops**: `EditOperation`, `StyleOperation`, `TreeEditOperation`, `TreeStyleOperation` (v0.7.x scope)
- **`Change.kt`**: `execute()` returns `Triple` with collected `reverseOps`
- **`Document.kt`**: Updated all `change.execute()` callers for new return type
- **`ConverterTest.kt`**: Updated `TestOperation` for new signature

## Test plan
- [ ] All existing unit tests pass (no behavior change — pure refactor)
- [ ] All existing instrumented tests pass (no regression)

> Items run automatically by CI (lint, unit tests, coverage) are excluded.