### PR TITLE
Add History class and Document.history undo/redo API

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -18,9 +18,14 @@ import dev.yorkie.document.change.CheckPoint
 import dev.yorkie.document.crdt.CrdtObject
 import dev.yorkie.document.crdt.CrdtRoot
 import dev.yorkie.document.crdt.ElementRht
+import dev.yorkie.document.history.History
+import dev.yorkie.document.history.HistoryOperation
 import dev.yorkie.document.json.JsonArray
 import dev.yorkie.document.json.JsonElement
 import dev.yorkie.document.json.JsonObject
+import dev.yorkie.document.operation.AddOperation
+import dev.yorkie.document.operation.ArraySetOperation
+import dev.yorkie.document.operation.OpSource
 import dev.yorkie.document.operation.OperationInfo
 import dev.yorkie.document.presence.DocPresence
 import dev.yorkie.document.presence.P
@@ -81,6 +86,10 @@ public class Document(
 
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
     private val localChanges = mutableListOf<Change>()
+    private val internalHistory = History()
+
+    @Volatile
+    private var isUpdating = false
 
     @Volatile
     private var maxSizeLimit = 0
@@ -140,6 +149,31 @@ public class Document(
         get() = allPresences.value[changeID.actor]
             .takeIf { status == ResourceStatus.Attached }
             .orEmpty()
+
+    /**
+     * Provides undo/redo operations for this document.
+     */
+    public val history = object {
+        /**
+         * Returns true if there are operations that can be undone.
+         */
+        fun canUndo(): Boolean = internalHistory.hasUndo() && !isUpdating
+
+        /**
+         * Returns true if there are operations that can be redone.
+         */
+        fun canRedo(): Boolean = internalHistory.hasRedo() && !isUpdating
+
+        /**
+         * Undoes the last local operation.
+         */
+        fun undoAsync(): Deferred<OperationResult> = executeUndoRedo(isUndo = true)
+
+        /**
+         * Redoes the last undone operation.
+         */
+        fun redoAsync(): Deferred<OperationResult> = executeUndoRedo(isUndo = false)
+    }
 
     /**
      * Executes the given [updater] to update this document.
@@ -213,10 +247,20 @@ public class Document(
                 return@async result
             }
             val change = context.toChange()
-            val (operationInfos, newPresences, _) = change.execute(root, _presences.value)
+            val (operationInfos, newPresences, reverseOps) =
+                change.execute(root, _presences.value)
 
             localChanges += change
             changeID = context.getNextId()
+
+            // Push reverse ops for undo
+            val reverseHistoryOps = reverseOps.map { HistoryOperation.Op(it) }
+            if (reverseHistoryOps.isNotEmpty()) {
+                internalHistory.pushUndo(reverseHistoryOps)
+            }
+            if (operationInfos.isNotEmpty()) {
+                internalHistory.clearRedo()
+            }
 
             if (change.hasOperations) {
                 eventStream.emit(Event.LocalChange(change.toChangeInfo(operationInfos)))
@@ -229,6 +273,89 @@ public class Document(
                 }
             }
             result
+        }
+    }
+
+    private fun executeUndoRedo(isUndo: Boolean): Deferred<OperationResult> {
+        return scope.async {
+            check(!isUpdating) {
+                "${if (isUndo) "Undo" else "Redo"} is not allowed during an update"
+            }
+
+            val ops = if (isUndo) {
+                internalHistory.popUndo()
+            } else {
+                internalHistory.popRedo()
+            } ?: error("There is no operation to be ${if (isUndo) "undone" else "redone"}")
+
+            val clone = ensureClone()
+            val context = ChangeContext(
+                prevId = changeID,
+                root = clone.root,
+            )
+
+            for (historyOp in ops) {
+                when (historyOp) {
+                    is HistoryOperation.Op -> {
+                        val op = historyOp.operation
+                        val ticket = context.issueTimeTicket()
+                        op.executedAt = ticket
+
+                        // Reconcile createdAt for ArraySet and Add operations
+                        if (op is ArraySetOperation) {
+                            val prev = op.createdAt
+                            op.value.createdAt = ticket
+                            internalHistory.reconcileCreatedAt(prev, ticket)
+                        } else if (op is AddOperation) {
+                            val prev = op.value.createdAt
+                            op.value.createdAt = ticket
+                            internalHistory.reconcileCreatedAt(prev, ticket)
+                        }
+
+                        context.push(op)
+                    }
+
+                    is HistoryOperation.Presence -> {
+                        // Presence undo — not implemented in v0.6.36 scope
+                    }
+                }
+            }
+
+            if (!context.hasChange) {
+                return@async Result.success(Unit)
+            }
+
+            val change = context.toChange()
+            // Execute on clone (validation)
+            change.execute(clone.root, clone.presences, OpSource.UndoRedo)
+            // Execute on root (real application)
+            val (opInfos, _, reverseOps) = change.execute(
+                root,
+                _presences.value,
+                OpSource.UndoRedo,
+            )
+
+            val reverseHistoryOps = reverseOps.map { HistoryOperation.Op(it) }
+            if (reverseHistoryOps.isNotEmpty()) {
+                if (isUndo) {
+                    internalHistory.pushRedo(reverseHistoryOps)
+                } else {
+                    internalHistory.pushUndo(reverseHistoryOps)
+                }
+            }
+
+            if (opInfos.isEmpty()) {
+                return@async Result.success(Unit)
+            }
+
+            localChanges += change
+            changeID = context.getNextId()
+
+            if (opInfos.isNotEmpty()) {
+                eventStream.emit(Event.LocalChange(change.toChangeInfo(opInfos)))
+            }
+
+            Result.success(Unit)
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtArray.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtArray.kt
@@ -7,7 +7,7 @@ import dev.yorkie.util.DataSize
  * [CrdtArray] represents an array data type containing [CrdtElement]s.
  */
 internal data class CrdtArray(
-    override val createdAt: TimeTicket,
+    override var createdAt: TimeTicket,
     override var movedAt: TimeTicket? = null,
     override var removedAt: TimeTicket? = null,
     val elements: RgaTreeList = RgaTreeList(),

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtCounter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtCounter.kt
@@ -14,7 +14,7 @@ internal typealias CounterValue = Number
 @Suppress("DataClassPrivateConstructor")
 internal data class CrdtCounter(
     var value: CounterValue,
-    override val createdAt: TimeTicket,
+    override var createdAt: TimeTicket,
     override var movedAt: TimeTicket? = null,
     override var removedAt: TimeTicket? = null,
 ) : CrdtElement() {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtElement.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtElement.kt
@@ -11,7 +11,7 @@ import dev.yorkie.util.DataSize
  */
 @Suppress("PropertyName")
 abstract class CrdtElement {
-    abstract val createdAt: TimeTicket
+    abstract var createdAt: TimeTicket
     abstract var movedAt: TimeTicket?
     abstract var removedAt: TimeTicket?
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtObject.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtObject.kt
@@ -8,7 +8,7 @@ import dev.yorkie.util.DataSize
  * [TimeTicket]s which are created by logical clock.
  */
 internal data class CrdtObject(
-    override val createdAt: TimeTicket,
+    override var createdAt: TimeTicket,
     override var movedAt: TimeTicket? = null,
     override var removedAt: TimeTicket? = null,
     val memberNodes: ElementRht<CrdtElement> = ElementRht(),

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtPrimitive.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtPrimitive.kt
@@ -16,7 +16,7 @@ import java.util.Date
 @Suppress("DataClassPrivateConstructor")
 internal data class CrdtPrimitive(
     private val _value: Any?,
-    override val createdAt: TimeTicket,
+    override var createdAt: TimeTicket,
     override var movedAt: TimeTicket? = null,
     override var removedAt: TimeTicket? = null,
 ) : CrdtElement() {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtText.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtText.kt
@@ -14,7 +14,7 @@ import java.util.TreeMap
  */
 internal data class CrdtText(
     val rgaTreeSplit: RgaTreeSplit<TextValue>,
-    override val createdAt: TimeTicket,
+    override var createdAt: TimeTicket,
     override var movedAt: TimeTicket? = null,
     override var removedAt: TimeTicket? = null,
 ) : CrdtElement(), GCCrdtElement {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -32,7 +32,7 @@ internal typealias TreeNodePair = Pair<CrdtTreeNode, CrdtTreeNode>
 @SuppressLint("VisibleForTests")
 internal data class CrdtTree(
     val root: CrdtTreeNode,
-    override val createdAt: TimeTicket,
+    override var createdAt: TimeTicket,
     override var movedAt: TimeTicket? = null,
     override var removedAt: TimeTicket? = null,
 ) : CrdtElement(), GCParent<CrdtTreeNode>, GCCrdtElement {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/history/History.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/history/History.kt
@@ -1,0 +1,111 @@
+package dev.yorkie.document.history
+
+import dev.yorkie.document.operation.AddOperation
+import dev.yorkie.document.operation.ArraySetOperation
+import dev.yorkie.document.operation.MoveOperation
+import dev.yorkie.document.operation.RemoveOperation
+import dev.yorkie.document.time.TimeTicket
+
+/**
+ * Maximum depth of undo/redo stack.
+ */
+@Suppress("ktlint:standard:property-naming")
+internal const val MaxUndoRedoStackDepth = 50
+
+/**
+ * Stores the undo/redo history of a [Document][dev.yorkie.document.Document].
+ */
+internal class History {
+    private val undoStack = ArrayDeque<List<HistoryOperation>>()
+    private val redoStack = ArrayDeque<List<HistoryOperation>>()
+
+    fun hasUndo(): Boolean = undoStack.isNotEmpty()
+
+    fun hasRedo(): Boolean = redoStack.isNotEmpty()
+
+    fun pushUndo(ops: List<HistoryOperation>) {
+        if (undoStack.size >= MaxUndoRedoStackDepth) {
+            undoStack.removeFirst()
+        }
+        undoStack.addLast(ops)
+    }
+
+    fun popUndo(): List<HistoryOperation>? {
+        return if (undoStack.isNotEmpty()) undoStack.removeLast() else null
+    }
+
+    fun pushRedo(ops: List<HistoryOperation>) {
+        if (redoStack.size >= MaxUndoRedoStackDepth) {
+            redoStack.removeFirst()
+        }
+        redoStack.addLast(ops)
+    }
+
+    fun popRedo(): List<HistoryOperation>? {
+        return if (redoStack.isNotEmpty()) redoStack.removeLast() else null
+    }
+
+    fun clearRedo() {
+        redoStack.clear()
+    }
+
+    /**
+     * Scans both stacks and replaces old createdAt/prevCreatedAt references
+     * when elements are replaced during undo. Ensures consistency when an
+     * element receives a new createdAt (executedAt) during undo/redo.
+     */
+    fun reconcileCreatedAt(prevCreatedAt: TimeTicket, currCreatedAt: TimeTicket) {
+        reconcileStack(undoStack, prevCreatedAt, currCreatedAt)
+        reconcileStack(redoStack, prevCreatedAt, currCreatedAt)
+    }
+
+    private fun reconcileStack(
+        stack: ArrayDeque<List<HistoryOperation>>,
+        prevCreatedAt: TimeTicket,
+        currCreatedAt: TimeTicket,
+    ) {
+        for (ops in stack) {
+            for (historyOp in ops) {
+                if (historyOp !is HistoryOperation.Op) continue
+                val op = historyOp.operation
+
+                // Update createdAt references
+                when (op) {
+                    is ArraySetOperation -> {
+                        if (op.createdAt === prevCreatedAt) {
+                            op.createdAt = currCreatedAt
+                        }
+                    }
+
+                    is RemoveOperation -> {
+                        if (op.createdAt === prevCreatedAt) {
+                            op.createdAt = currCreatedAt
+                        }
+                    }
+
+                    is MoveOperation -> {
+                        if (op.createdAt === prevCreatedAt) {
+                            op.createdAt = currCreatedAt
+                        }
+                        if (op.prevCreatedAt === prevCreatedAt) {
+                            op.prevCreatedAt = currCreatedAt
+                        }
+                    }
+
+                    is AddOperation -> {
+                        if (op.prevCreatedAt === prevCreatedAt) {
+                            op.prevCreatedAt = currCreatedAt
+                        }
+                    }
+
+                    else -> {
+                        // No reconciliation needed for other operation types
+                    }
+                }
+            }
+        }
+    }
+
+    internal fun getUndoStackForTest() = undoStack.toList()
+    internal fun getRedoStackForTest() = redoStack.toList()
+}

--- a/yorkie/src/main/kotlin/dev/yorkie/document/history/HistoryOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/history/HistoryOperation.kt
@@ -1,0 +1,11 @@
+package dev.yorkie.document.history
+
+import dev.yorkie.document.operation.Operation
+
+/**
+ * Represents an operation stored in the undo/redo history.
+ */
+internal sealed interface HistoryOperation {
+    data class Op(val operation: Operation) : HistoryOperation
+    data class Presence(val value: Map<String, String>) : HistoryOperation
+}

--- a/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
@@ -523,7 +523,7 @@ class ConverterTest {
     }
 
     private class TestCrdtElement(
-        override val createdAt: TimeTicket,
+        override var createdAt: TimeTicket,
         override var movedAt: TimeTicket? = null,
         override var removedAt: TimeTicket? = null,
     ) : CrdtElement() {


### PR DESCRIPTION
> **RTCOLLABPLATFORM-631**: [[Android] Implement multi-user Undo/Redo (JS SDK v0.6.36 parity)](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-631)

## Summary
- PR 2 of 3 for undo/redo: the feature itself
- Add `History` class with undo/redo stacks, `reconcileCreatedAt` for element replacement consistency
- Add `Document.history` API: `canUndo()`, `canRedo()`, `undoAsync()`, `redoAsync()`
- Make `CrdtElement.createdAt` mutable for undo/redo createdAt reassignment

## Changes
- **`History.kt`** (new): Undo/redo stacks (max 50), `reconcileCreatedAt` with actual mutations on ArraySet/Remove/Move/Add operations
- **`HistoryOperation.kt`** (new): Sealed interface for Op and Presence history entries
- **`Document.kt`**: Add `history` object with `undoAsync()`/`redoAsync()` returning `Deferred<OperationResult>` via `scope.async{}`; capture reverse ops in `updateAsync`; add `executeUndoRedo` private method
- **`CrdtElement.kt`**: Change `createdAt` from `abstract val` to `abstract var`
- **6 CRDT subclasses**: Update `override val createdAt` to `override var createdAt`

## Test plan
- [ ] All existing unit tests pass (no regression from createdAt mutability change)
- [ ] All existing instrumented tests pass
- [ ] PR 3 will add dedicated undo/redo tests

> Items run automatically by CI (lint, unit tests, coverage) are excluded.