### PR TITLE
Add undo/redo tests and fix DocumentHistory interface

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/UndoRedoTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/UndoRedoTest.kt
@@ -1,0 +1,206 @@
+package dev.yorkie.document
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.yorkie.core.Client.SyncMode.Manual
+import dev.yorkie.core.withTwoClientsAndDocuments
+import dev.yorkie.document.json.JsonCounter
+import dev.yorkie.document.json.JsonPrimitive
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class UndoRedoTest {
+
+    @Test
+    fun test_undo_reverts_object_set() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root["k1"] = "v1"
+            }.await()
+            assertEquals("v1", d1.getRoot().getAs<JsonPrimitive>("k1").value)
+
+            d1.updateAsync { root, _ ->
+                root["k1"] = "v2"
+            }.await()
+            assertEquals("v2", d1.getRoot().getAs<JsonPrimitive>("k1").value)
+
+            assertTrue(d1.history.canUndo())
+            d1.history.undoAsync().await()
+            assertEquals("v1", d1.getRoot().getAs<JsonPrimitive>("k1").value)
+        }
+    }
+
+    @Test
+    fun test_undo_restores_removed_object_key() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root["k1"] = "v1"
+            }.await()
+
+            d1.updateAsync { root, _ ->
+                root.remove("k1")
+            }.await()
+
+            d1.history.undoAsync().await()
+            assertEquals("v1", d1.getRoot().getAs<JsonPrimitive>("k1").value)
+        }
+    }
+
+    @Test
+    fun test_redo_restores_undone_operation() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root["k1"] = "v1"
+            }.await()
+
+            d1.updateAsync { root, _ ->
+                root["k1"] = "v2"
+            }.await()
+
+            d1.history.undoAsync().await()
+            assertEquals("v1", d1.getRoot().getAs<JsonPrimitive>("k1").value)
+
+            assertTrue(d1.history.canRedo())
+            d1.history.redoAsync().await()
+            assertEquals("v2", d1.getRoot().getAs<JsonPrimitive>("k1").value)
+        }
+    }
+
+    @Test
+    fun test_undo_reverts_counter_increase() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewCounter("counter", 10)
+            }.await()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonCounter>("counter").increase(5)
+            }.await()
+            assertEquals(15, d1.getRoot().getAs<JsonCounter>("counter").value)
+
+            d1.history.undoAsync().await()
+            assertEquals(10, d1.getRoot().getAs<JsonCounter>("counter").value)
+        }
+    }
+
+    @Test
+    fun test_redo_cleared_on_new_local_edit() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root["k1"] = "v1"
+            }.await()
+
+            d1.updateAsync { root, _ ->
+                root["k1"] = "v2"
+            }.await()
+
+            d1.history.undoAsync().await()
+            assertTrue(d1.history.canRedo())
+
+            // New edit should clear redo
+            d1.updateAsync { root, _ ->
+                root["k1"] = "v3"
+            }.await()
+            assertFalse(d1.history.canRedo())
+        }
+    }
+
+    @Test
+    fun test_undo_empty_stack_throws() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            assertFalse(d1.history.canUndo())
+            val result = d1.history.undoAsync().await()
+            assertTrue(result.isFailure)
+        }
+    }
+
+    @Test
+    fun test_multiple_sequential_undos_restore_initial_state() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root["k1"] = "A"
+            }.await()
+
+            d1.updateAsync { root, _ ->
+                root["k1"] = "B"
+            }.await()
+
+            d1.updateAsync { root, _ ->
+                root["k1"] = "C"
+            }.await()
+            assertEquals("C", d1.getRoot().getAs<JsonPrimitive>("k1").value)
+
+            // Undo C → B
+            d1.history.undoAsync().await()
+            assertEquals("B", d1.getRoot().getAs<JsonPrimitive>("k1").value)
+
+            // Undo B → A
+            d1.history.undoAsync().await()
+            assertEquals("A", d1.getRoot().getAs<JsonPrimitive>("k1").value)
+        }
+    }
+
+    @Test
+    fun test_multi_user_undo_reverts_only_own_changes() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            // c1 sets k1
+            d1.updateAsync { root, _ ->
+                root["k1"] = "c1-value"
+            }.await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+
+            // c2 sets k2
+            d2.updateAsync { root, _ ->
+                root["k2"] = "c2-value"
+            }.await()
+            c2.syncAsync().await()
+            c1.syncAsync().await()
+
+            // Both documents have both keys
+            assertEquals("c1-value", d1.getRoot().getAs<JsonPrimitive>("k1").value)
+            assertEquals("c2-value", d1.getRoot().getAs<JsonPrimitive>("k2").value)
+
+            // c1 undoes — only c1's change should be reverted
+            d1.history.undoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+
+            // c2's value should still be there on both
+            assertEquals("c2-value", d2.getRoot().getAs<JsonPrimitive>("k2").value)
+        }
+    }
+
+    @Test
+    fun test_undo_after_remote_sync() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            // c1 sets a key
+            d1.updateAsync { root, _ ->
+                root["k1"] = "original"
+            }.await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+
+            // c1 updates the key
+            d1.updateAsync { root, _ ->
+                root["k1"] = "updated"
+            }.await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+
+            assertEquals("updated", d2.getRoot().getAs<JsonPrimitive>("k1").value)
+
+            // c1 undoes
+            d1.history.undoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+
+            // Both should see the original value
+            assertEquals("original", d1.getRoot().getAs<JsonPrimitive>("k1").value)
+            assertEquals("original", d2.getRoot().getAs<JsonPrimitive>("k1").value)
+        }
+    }
+}

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -153,26 +153,39 @@ public class Document(
     /**
      * Provides undo/redo operations for this document.
      */
-    public val history = object {
+    public val history: DocumentHistory = object : DocumentHistory {
+        override fun canUndo(): Boolean = internalHistory.hasUndo() && !isUpdating
+
+        override fun canRedo(): Boolean = internalHistory.hasRedo() && !isUpdating
+
+        override fun undoAsync(): Deferred<OperationResult> = executeUndoRedo(isUndo = true)
+
+        override fun redoAsync(): Deferred<OperationResult> = executeUndoRedo(isUndo = false)
+    }
+
+    /**
+     * Interface for undo/redo operations on a document.
+     */
+    public interface DocumentHistory {
         /**
          * Returns true if there are operations that can be undone.
          */
-        fun canUndo(): Boolean = internalHistory.hasUndo() && !isUpdating
+        fun canUndo(): Boolean
 
         /**
          * Returns true if there are operations that can be redone.
          */
-        fun canRedo(): Boolean = internalHistory.hasRedo() && !isUpdating
+        fun canRedo(): Boolean
 
         /**
          * Undoes the last local operation.
          */
-        fun undoAsync(): Deferred<OperationResult> = executeUndoRedo(isUndo = true)
+        fun undoAsync(): Deferred<OperationResult>
 
         /**
          * Redoes the last undone operation.
          */
-        fun redoAsync(): Deferred<OperationResult> = executeUndoRedo(isUndo = false)
+        fun redoAsync(): Deferred<OperationResult>
     }
 
     /**
@@ -278,15 +291,26 @@ public class Document(
 
     private fun executeUndoRedo(isUndo: Boolean): Deferred<OperationResult> {
         return scope.async {
-            check(!isUpdating) {
-                "${if (isUndo) "Undo" else "Redo"} is not allowed during an update"
+            if (isUpdating) {
+                return@async Result.failure(
+                    IllegalStateException(
+                        "${if (isUndo) "Undo" else "Redo"} is not allowed during an update",
+                    ),
+                )
             }
 
             val ops = if (isUndo) {
                 internalHistory.popUndo()
             } else {
                 internalHistory.popRedo()
-            } ?: error("There is no operation to be ${if (isUndo) "undone" else "redone"}")
+            }
+            if (ops == null) {
+                return@async Result.failure(
+                    IllegalStateException(
+                        "There is no operation to be ${if (isUndo) "undone" else "redone"}",
+                    ),
+                )
+            }
 
             val clone = ensureClone()
             val context = ChangeContext(

--- a/yorkie/src/test/kotlin/dev/yorkie/document/history/HistoryTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/history/HistoryTest.kt
@@ -1,0 +1,134 @@
+package dev.yorkie.document.history
+
+import dev.yorkie.document.crdt.CrdtPrimitive
+import dev.yorkie.document.operation.IncreaseOperation
+import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class HistoryTest {
+
+    private fun createDummyOp(): HistoryOperation.Op {
+        val ticket = InitialTimeTicket
+        val primitive = CrdtPrimitive(1, ticket)
+        return HistoryOperation.Op(
+            IncreaseOperation(primitive, ticket, ticket),
+        )
+    }
+
+    @Test
+    fun `undo stack push and pop`() {
+        val history = History()
+        assertFalse(history.hasUndo())
+
+        val ops = listOf(createDummyOp())
+        history.pushUndo(ops)
+        assertTrue(history.hasUndo())
+
+        val popped = history.popUndo()
+        assertNotNull(popped)
+        assertEquals(1, popped.size)
+        assertFalse(history.hasUndo())
+    }
+
+    @Test
+    fun `redo stack push and pop`() {
+        val history = History()
+        assertFalse(history.hasRedo())
+
+        val ops = listOf(createDummyOp())
+        history.pushRedo(ops)
+        assertTrue(history.hasRedo())
+
+        val popped = history.popRedo()
+        assertNotNull(popped)
+        assertFalse(history.hasRedo())
+    }
+
+    @Test
+    fun `clearRedo empties redo stack`() {
+        val history = History()
+        history.pushRedo(listOf(createDummyOp()))
+        assertTrue(history.hasRedo())
+
+        history.clearRedo()
+        assertFalse(history.hasRedo())
+    }
+
+    @Test
+    fun `clearRedo on empty stack is a no-op`() {
+        val history = History()
+        assertFalse(history.hasRedo())
+        history.clearRedo()
+        assertFalse(history.hasRedo())
+    }
+
+    @Test
+    fun `undo stack at exactly 50 retains all`() {
+        val history = History()
+        repeat(MaxUndoRedoStackDepth) {
+            history.pushUndo(listOf(createDummyOp()))
+        }
+        assertEquals(MaxUndoRedoStackDepth, history.getUndoStackForTest().size)
+    }
+
+    @Test
+    fun `undo stack at 51 evicts oldest`() {
+        val history = History()
+        repeat(MaxUndoRedoStackDepth + 1) {
+            history.pushUndo(listOf(createDummyOp()))
+        }
+        assertEquals(MaxUndoRedoStackDepth, history.getUndoStackForTest().size)
+    }
+
+    @Test
+    fun `redo stack depth limit`() {
+        val history = History()
+        repeat(60) {
+            history.pushRedo(listOf(createDummyOp()))
+        }
+        assertEquals(MaxUndoRedoStackDepth, history.getRedoStackForTest().size)
+    }
+
+    @Test
+    fun `popUndo returns null when empty`() {
+        val history = History()
+        assertNull(history.popUndo())
+    }
+
+    @Test
+    fun `popRedo returns null when empty`() {
+        val history = History()
+        assertNull(history.popRedo())
+    }
+
+    @Test
+    fun `push after pop preserves ordering`() {
+        val history = History()
+        val op1 = listOf(createDummyOp())
+        val op2 = listOf(createDummyOp())
+        val op3 = listOf(createDummyOp())
+
+        history.pushUndo(op1)
+        history.pushUndo(op2)
+        history.pushUndo(op3)
+
+        // Pop last
+        val popped = history.popUndo()
+        assertEquals(op3, popped)
+
+        // Push new
+        val op4 = listOf(createDummyOp())
+        history.pushUndo(op4)
+
+        // Pop should return op4, then op2, then op1
+        assertEquals(op4, history.popUndo())
+        assertEquals(op2, history.popUndo())
+        assertEquals(op1, history.popUndo())
+        assertNull(history.popUndo())
+    }
+}


### PR DESCRIPTION
> **RTCOLLABPLATFORM-631**: [[Android] Implement multi-user Undo/Redo (JS SDK v0.6.36 parity)](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-631)

## Summary
- PR 3 of 3 for undo/redo: tests + API fixes found during testing
- 10 unit tests for History class
- 9 instrumented tests for undo/redo end-to-end
- Fix `Document.history` to use `DocumentHistory` interface (anonymous objects don't expose members externally)
- Fix `executeUndoRedo` to return `Result.failure` instead of throwing

## Changes
- **`HistoryTest.kt`** (new): 10 unit tests covering push/pop, depth limit boundary (50/51), ordering, clearRedo
- **`UndoRedoTest.kt`** (new): 9 instrumented tests — undo set/remove, redo, counter increase, sequential undos, multi-user undo, undo after remote sync, redo cleared on edit, empty stack
- **`Document.kt`**: Extract `DocumentHistory` interface for public API; return `Result.failure` instead of throwing in `executeUndoRedo`

## Test plan
- [ ] 10 History unit tests pass
- [ ] 9 UndoRedoTest instrumented tests pass
- [ ] All existing unit tests pass (no regression)
- [ ] All existing instrumented tests pass (no regression)

> Items run automatically by CI (lint, unit tests, coverage) are excluded.