### PR TITLE
Add Undo/Redo to TodoMVC example app

### DIFF
--- a/examples/todomvc/src/main/java/dev/yorkie/example/todomvc/ui/todo/Todo.kt
+++ b/examples/todomvc/src/main/java/dev/yorkie/example/todomvc/ui/todo/Todo.kt
@@ -26,6 +26,8 @@ data class TodoState(
     val filter: TodoFilter = TodoFilter.ALL,
     val isLoading: Boolean = false,
     val error: String? = null,
+    val canUndo: Boolean = false,
+    val canRedo: Boolean = false,
 ) {
     val filteredTodos: List<Todo>
         get() = when (filter) {

--- a/examples/todomvc/src/main/java/dev/yorkie/example/todomvc/ui/todo/TodoAction.kt
+++ b/examples/todomvc/src/main/java/dev/yorkie/example/todomvc/ui/todo/TodoAction.kt
@@ -12,4 +12,6 @@ sealed class TodoAction {
     object ClearCompleted : TodoAction()
     object ToggleAll : TodoAction()
     data class SetFilter(val filter: TodoFilter) : TodoAction()
+    object Undo : TodoAction()
+    object Redo : TodoAction()
 }

--- a/examples/todomvc/src/main/java/dev/yorkie/example/todomvc/ui/todo/TodoScreen.kt
+++ b/examples/todomvc/src/main/java/dev/yorkie/example/todomvc/ui/todo/TodoScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Surface
@@ -29,6 +30,8 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.automirrored.filled.Redo
+import androidx.compose.material.icons.automirrored.filled.Undo
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Check
@@ -326,7 +329,47 @@ fun TodoScreen(
             }
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Undo/Redo buttons
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(
+                onClick = { onAction(TodoAction.Undo) },
+                enabled = state.canUndo,
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.Undo,
+                    contentDescription = stringResource(id = R.string.undo),
+                    tint = if (state.canUndo) {
+                        MaterialTheme.colors.primary
+                    } else {
+                        MaterialTheme.colors.onSurface.copy(alpha = 0.3f)
+                    },
+                )
+            }
+            IconButton(
+                onClick = { onAction(TodoAction.Redo) },
+                enabled = state.canRedo,
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.Redo,
+                    contentDescription = stringResource(id = R.string.redo),
+                    tint = if (state.canRedo) {
+                        MaterialTheme.colors.primary
+                    } else {
+                        MaterialTheme.colors.onSurface.copy(alpha = 0.3f)
+                    },
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
 
         if (state.isLoading) {
             Box(

--- a/examples/todomvc/src/main/java/dev/yorkie/example/todomvc/ui/todo/TodoViewModel.kt
+++ b/examples/todomvc/src/main/java/dev/yorkie/example/todomvc/ui/todo/TodoViewModel.kt
@@ -257,7 +257,7 @@ class TodoViewModel(
         _state.value = _state.value.copy(filter = filter)
     }
 
-    private fun refreshFromDocument() {
+    private suspend fun refreshFromDocument() {
         val todosArray = document.getRoot().getAsOrNull<JsonArray>(DOCUMENT_TODOS_KEY)
         if (todosArray != null) {
             updateTodosFromDocument(todosArray)

--- a/examples/todomvc/src/main/java/dev/yorkie/example/todomvc/ui/todo/TodoViewModel.kt
+++ b/examples/todomvc/src/main/java/dev/yorkie/example/todomvc/ui/todo/TodoViewModel.kt
@@ -49,14 +49,11 @@ class TodoViewModel(
             launch {
                 document.events.collect { event ->
                     when (event) {
-                        is Document.Event.SyncStatusChanged.Synced -> {
-                            document.getRoot().getAsOrNull<JsonArray>(DOCUMENT_TODOS_KEY)
-                                ?.let(::updateTodosFromDocument)
-                        }
+                        is Document.Event.SyncStatusChanged.Synced,
+                        is Document.Event.LocalChange,
+                        -> refreshFromDocument()
 
-                        else -> {
-                            Unit
-                        }
+                        else -> Unit
                     }
                 }
             }
@@ -148,6 +145,8 @@ class TodoViewModel(
             is TodoAction.ClearCompleted -> clearCompleted()
             is TodoAction.ToggleAll -> toggleAll()
             is TodoAction.SetFilter -> setFilter(action.filter)
+            is TodoAction.Undo -> undo()
+            is TodoAction.Redo -> redo()
         }
     }
 
@@ -162,8 +161,8 @@ class TodoViewModel(
                     set("text", text.trim())
                     set("completed", false)
                 }
-                updateTodosFromDocument(todos)
             }.await()
+            refreshFromDocument()
         }
     }
 
@@ -174,8 +173,8 @@ class TodoViewModel(
                 val todoToRemove = todos.filterIsInstance<JsonObject>()
                     .find { it.getAs<JsonPrimitive>("id").getValueAs<String>() == id }
                 todoToRemove?.let { todos.remove(it.id) }
-                updateTodosFromDocument(todos)
             }.await()
+            refreshFromDocument()
         }
     }
 
@@ -191,8 +190,8 @@ class TodoViewModel(
                 todos.filterIsInstance<JsonObject>()
                     .find { it.getAs<JsonPrimitive>("id").getValueAs<String>() == id }
                     ?.set("text", text.trim())
-                updateTodosFromDocument(todos)
             }.await()
+            refreshFromDocument()
         }
     }
 
@@ -207,8 +206,8 @@ class TodoViewModel(
                             todo.getAs<JsonPrimitive>("completed").getValueAs<Boolean>()
                         todo["completed"] = !currentCompleted
                     }
-                updateTodosFromDocument(todos)
             }.await()
+            refreshFromDocument()
         }
     }
 
@@ -219,8 +218,8 @@ class TodoViewModel(
                 val completedTodos = todos.filterIsInstance<JsonObject>()
                     .filter { it.getAs<JsonPrimitive>("completed").getValueAs<Boolean>() }
                 completedTodos.forEach { todos.remove(it.id) }
-                updateTodosFromDocument(todos)
             }.await()
+            refreshFromDocument()
         }
     }
 
@@ -235,8 +234,22 @@ class TodoViewModel(
                 todoObjects.forEach { todo ->
                     todo["completed"] = !allCompleted
                 }
-                updateTodosFromDocument(todos)
             }.await()
+            refreshFromDocument()
+        }
+    }
+
+    private fun undo() {
+        viewModelScope.launch {
+            document.history.undoAsync().await()
+            refreshFromDocument()
+        }
+    }
+
+    private fun redo() {
+        viewModelScope.launch {
+            document.history.redoAsync().await()
+            refreshFromDocument()
         }
     }
 
@@ -244,28 +257,37 @@ class TodoViewModel(
         _state.value = _state.value.copy(filter = filter)
     }
 
-    private fun updateTodosFromDocument(todosArray: JsonArray) {
-        viewModelScope.launch {
-            val todos = todosArray.filterIsInstance<JsonObject>()
-                .mapNotNull { todoObj ->
-                    val id = todoObj.getAsOrNull<JsonPrimitive>("id")
-                    if (id != null) {
-                        Todo(
-                            id = todoObj.getAs<JsonPrimitive>("id").getValueAs(),
-                            text = todoObj.getAs<JsonPrimitive>("text").getValueAs(),
-                            completed = todoObj.getAs<JsonPrimitive>("completed").getValueAs(),
-                        )
-                    } else {
-                        null
-                    }
-                }
-
-            _state.value = _state.value.copy(
-                todos = todos,
-                isLoading = false,
-                error = null,
-            )
+    private fun refreshFromDocument() {
+        val todosArray = document.getRoot().getAsOrNull<JsonArray>(DOCUMENT_TODOS_KEY)
+        if (todosArray != null) {
+            updateTodosFromDocument(todosArray)
         }
+        _state.value = _state.value.copy(
+            canUndo = document.history.canUndo(),
+            canRedo = document.history.canRedo(),
+        )
+    }
+
+    private fun updateTodosFromDocument(todosArray: JsonArray) {
+        val todos = todosArray.filterIsInstance<JsonObject>()
+            .mapNotNull { todoObj ->
+                val id = todoObj.getAsOrNull<JsonPrimitive>("id")
+                if (id != null) {
+                    Todo(
+                        id = todoObj.getAs<JsonPrimitive>("id").getValueAs(),
+                        text = todoObj.getAs<JsonPrimitive>("text").getValueAs(),
+                        completed = todoObj.getAs<JsonPrimitive>("completed").getValueAs(),
+                    )
+                } else {
+                    null
+                }
+            }
+
+        _state.value = _state.value.copy(
+            todos = todos,
+            isLoading = false,
+            error = null,
+        )
     }
 
     override fun onCleared() {

--- a/examples/todomvc/src/main/res/values/strings.xml
+++ b/examples/todomvc/src/main/res/values/strings.xml
@@ -10,4 +10,6 @@
     <string name="item_left">%d item left</string>
     <string name="no_items_left">No items left</string>
     <string name="mark_all_complete">Mark all as complete</string>
+    <string name="undo">Undo</string>
+    <string name="redo">Redo</string>
 </resources>

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -36,6 +36,7 @@ import dev.yorkie.document.presence.Presences.Companion.UninitializedPresences
 import dev.yorkie.document.presence.Presences.Companion.asPresences
 import dev.yorkie.document.schema.Rule
 import dev.yorkie.document.schema.validateYorkieRuleset
+import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
 import dev.yorkie.document.time.VersionVector
 import dev.yorkie.util.DocSize
@@ -318,7 +319,7 @@ public class Document(
                 root = clone.root,
             )
 
-            for (historyOp in ops) {
+            for ((index, historyOp) in ops.withIndex()) {
                 when (historyOp) {
                     is HistoryOperation.Op -> {
                         val op = historyOp.operation
@@ -330,10 +331,12 @@ public class Document(
                             val prev = op.createdAt
                             op.value.createdAt = ticket
                             internalHistory.reconcileCreatedAt(prev, ticket)
+                            reconcileOpsCreatedAt(ops, index + 1, prev, ticket)
                         } else if (op is AddOperation) {
                             val prev = op.value.createdAt
                             op.value.createdAt = ticket
                             internalHistory.reconcileCreatedAt(prev, ticket)
+                            reconcileOpsCreatedAt(ops, index + 1, prev, ticket)
                         }
 
                         context.push(op)
@@ -380,6 +383,28 @@ public class Document(
             }
 
             Result.success(Unit)
+        }
+    }
+
+    /**
+     * Reconciles parentCreatedAt references in the remaining ops of the current batch.
+     * When an AddOperation or ArraySetOperation assigns a new createdAt to its value,
+     * subsequent ops in the same batch that reference the old createdAt as their
+     * parentCreatedAt must be updated to point to the new one.
+     */
+    private fun reconcileOpsCreatedAt(
+        ops: List<HistoryOperation>,
+        fromIndex: Int,
+        prevCreatedAt: TimeTicket,
+        currCreatedAt: TimeTicket,
+    ) {
+        for (i in fromIndex until ops.size) {
+            val historyOp = ops[i]
+            if (historyOp !is HistoryOperation.Op) continue
+            val op = historyOp.operation
+            if (op.parentCreatedAt === prevCreatedAt) {
+                op.parentCreatedAt = currCreatedAt
+            }
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/Change.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/Change.kt
@@ -47,7 +47,9 @@ public data class Change internal constructor(
         for (op in operations) {
             val result = op.execute(root, source, id.versionVector)
             allOpInfos.addAll(result.opInfos)
-            result.reverseOp?.let { reverseOps.add(0, it) }
+            for (reverseOp in result.reverseOps) {
+                reverseOps.add(0, reverseOp)
+            }
         }
 
         return Triple(allOpInfos, newPresences, reverseOps)

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/Change.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/Change.kt
@@ -47,9 +47,9 @@ public data class Change internal constructor(
         for (op in operations) {
             val result = op.execute(root, source, id.versionVector)
             allOpInfos.addAll(result.opInfos)
-            for (reverseOp in result.reverseOps) {
-                reverseOps.add(0, reverseOp)
-            }
+            // addAll(0, ...) preserves internal order of multi-op reverses
+            // while reversing the outer operation order (first op's reverse runs last)
+            reverseOps.addAll(0, result.reverseOps)
         }
 
         return Triple(allOpInfos, newPresences, reverseOps)

--- a/yorkie/src/main/kotlin/dev/yorkie/document/history/History.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/history/History.kt
@@ -69,7 +69,12 @@ internal class History {
                 if (historyOp !is HistoryOperation.Op) continue
                 val op = historyOp.operation
 
-                // Update createdAt references
+                // Update parentCreatedAt for all operation types
+                if (op.parentCreatedAt === prevCreatedAt) {
+                    op.parentCreatedAt = currCreatedAt
+                }
+
+                // Update type-specific createdAt references
                 when (op) {
                     is ArraySetOperation -> {
                         if (op.createdAt === prevCreatedAt) {
@@ -99,7 +104,7 @@ internal class History {
                     }
 
                     else -> {
-                        // No reconciliation needed for other operation types
+                        // No additional reconciliation needed
                     }
                 }
             }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
@@ -13,7 +13,7 @@ import dev.yorkie.util.Logger.Companion.logError
 internal data class AddOperation(
     var prevCreatedAt: TimeTicket,
     val value: CrdtElement,
-    override val parentCreatedAt: TimeTicket,
+    override var parentCreatedAt: TimeTicket,
     override var executedAt: TimeTicket,
 ) : Operation() {
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
@@ -34,6 +34,7 @@ internal data class AddOperation(
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtArray) {
             val copiedValue = value.deepCopy()
+            copiedValue.removedAt = null
             parentObject.insertAfter(prevCreatedAt, copiedValue)
             root.registerElement(copiedValue, parentObject)
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
@@ -51,7 +51,7 @@ internal data class AddOperation(
                         root.createPath(parentCreatedAt),
                     ),
                 ),
-                reverseOp = reverseOp,
+                reverseOps = listOf(reverseOp),
             )
         } else {
             parentObject ?: logError(TAG, "fail to find $parentCreatedAt")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/ArraySetOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/ArraySetOperation.kt
@@ -13,7 +13,7 @@ import dev.yorkie.util.YorkieException
 internal data class ArraySetOperation(
     var createdAt: TimeTicket,
     val value: CrdtElement,
-    override val parentCreatedAt: TimeTicket,
+    override var parentCreatedAt: TimeTicket,
     override var executedAt: TimeTicket,
 ) : Operation() {
     override val effectedCreatedAt: TimeTicket

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/ArraySetOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/ArraySetOperation.kt
@@ -60,7 +60,7 @@ internal data class ArraySetOperation(
                     path = root.createPath(parentCreatedAt),
                 ),
             ),
-            reverseOp = reverseOp,
+            reverseOps = listOfNotNull(reverseOp),
         )
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/ArraySetOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/ArraySetOperation.kt
@@ -39,6 +39,7 @@ internal data class ArraySetOperation(
 
         val previousValue = parentObject[createdAt]
         val value = value.deepCopy()
+        value.removedAt = null
         parentObject.insertAfter(createdAt, value, executedAt)
         parentObject.delete(createdAt, executedAt)
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/EditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/EditOperation.kt
@@ -16,7 +16,7 @@ internal data class EditOperation(
     val fromPos: RgaTreeSplitPos,
     val toPos: RgaTreeSplitPos,
     val content: String,
-    override val parentCreatedAt: TimeTicket,
+    override var parentCreatedAt: TimeTicket,
     override var executedAt: TimeTicket,
     val attributes: Map<String, String>,
 ) : Operation() {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/IncreaseOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/IncreaseOperation.kt
@@ -61,7 +61,7 @@ internal data class IncreaseOperation(
                         root.createPath(parentCreatedAt),
                     ),
                 ),
-                reverseOp = reverseOp,
+                reverseOps = listOf(reverseOp),
             )
         } else {
             parentObject ?: logError(TAG, "fail to find $parentCreatedAt")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/IncreaseOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/IncreaseOperation.kt
@@ -15,7 +15,7 @@ import dev.yorkie.util.Logger.Companion.logError
  */
 internal data class IncreaseOperation(
     val value: CrdtElement,
-    override val parentCreatedAt: TimeTicket,
+    override var parentCreatedAt: TimeTicket,
     override var executedAt: TimeTicket,
 ) : Operation() {
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
@@ -12,7 +12,7 @@ import dev.yorkie.util.Logger.Companion.logError
 internal data class MoveOperation(
     var prevCreatedAt: TimeTicket,
     var createdAt: TimeTicket,
-    override val parentCreatedAt: TimeTicket,
+    override var parentCreatedAt: TimeTicket,
     override var executedAt: TimeTicket,
 ) : Operation() {
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
@@ -52,7 +52,7 @@ internal data class MoveOperation(
                         path = root.createPath(parentCreatedAt),
                     ),
                 ),
-                reverseOp = reverseOp,
+                reverseOps = listOf(reverseOp),
             )
         } else {
             parentObject ?: logError(TAG, "fail to find $parentCreatedAt")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/Operation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/Operation.kt
@@ -18,7 +18,7 @@ internal data class ExecutionResult(
  * [executedAt] is the execution time of this operation.
  */
 internal abstract class Operation {
-    abstract val parentCreatedAt: TimeTicket
+    abstract var parentCreatedAt: TimeTicket
 
     abstract var executedAt: TimeTicket
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/Operation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/Operation.kt
@@ -9,7 +9,7 @@ import dev.yorkie.document.time.VersionVector
  */
 internal data class ExecutionResult(
     val opInfos: List<OperationInfo>,
-    val reverseOp: Operation? = null,
+    val reverseOps: List<Operation> = emptyList(),
 )
 
 /**

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/RemoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/RemoveOperation.kt
@@ -2,8 +2,10 @@ package dev.yorkie.document.operation
 
 import dev.yorkie.document.crdt.CrdtArray
 import dev.yorkie.document.crdt.CrdtContainer
+import dev.yorkie.document.crdt.CrdtElement
 import dev.yorkie.document.crdt.CrdtObject
 import dev.yorkie.document.crdt.CrdtRoot
+import dev.yorkie.document.crdt.ElementRht
 import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.VersionVector
 import dev.yorkie.util.Logger.Companion.logError
@@ -45,33 +47,37 @@ internal data class RemoveOperation(
             root.registerRemovedElement(element)
             val index = if (parentObject is CrdtArray) key?.toInt() else null
 
-            val reverseOp = when (parentObject) {
+            val reverseOps = when (parentObject) {
                 is CrdtArray -> {
-                    AddOperation(
+                    val elementCopy = element.deepCopy()
+                    val addOp = AddOperation(
                         prevCreatedAt = prevCreatedAtForArray!!,
-                        value = element.deepCopy(),
+                        value = stripChildren(elementCopy),
                         parentCreatedAt = parentCreatedAt,
                         executedAt = executedAt,
                     )
+                    listOf(addOp) + childSetOps(element, element.createdAt, executedAt)
                 }
 
                 is CrdtObject -> {
-                    SetOperation(
-                        key = key ?: "",
-                        value = element.deepCopy(),
-                        parentCreatedAt = parentCreatedAt,
-                        executedAt = executedAt,
+                    listOf(
+                        SetOperation(
+                            key = key ?: "",
+                            value = element.deepCopy(),
+                            parentCreatedAt = parentCreatedAt,
+                            executedAt = executedAt,
+                        ),
                     )
                 }
 
-                else -> null
+                else -> emptyList()
             }
 
             ExecutionResult(
                 opInfos = listOf(
                     OperationInfo.RemoveOpInfo(key, index, root.createPath(parentCreatedAt)),
                 ),
-                reverseOp = reverseOp,
+                reverseOps = reverseOps,
             )
         } else {
             parentObject ?: logError(TAG, "fail to find $parentCreatedAt")
@@ -82,5 +88,41 @@ internal data class RemoveOperation(
 
     companion object {
         private const val TAG = "RemoveOperation"
+
+        /**
+         * Returns a deep copy of the element with children removed.
+         * For CrdtObject, clears memberNodes. For other types, returns deepCopy as-is.
+         */
+        private fun stripChildren(element: CrdtElement): CrdtElement {
+            return when (element) {
+                is CrdtObject -> element.copy(memberNodes = dev.yorkie.document.crdt.ElementRht())
+                else -> element
+            }
+        }
+
+        /**
+         * Generates SetOperations for each child of a CrdtObject so they are
+         * individually serialized for remote sync during undo/redo.
+         */
+        private fun childSetOps(
+            element: CrdtElement,
+            parentCreatedAt: TimeTicket,
+            executedAt: TimeTicket,
+        ): List<Operation> {
+            if (element !is CrdtObject) return emptyList()
+            val ops = mutableListOf<Operation>()
+            for ((childKey, child) in element) {
+                if (child.isRemoved) continue
+                ops.add(
+                    SetOperation(
+                        key = childKey,
+                        value = child.deepCopy(),
+                        parentCreatedAt = parentCreatedAt,
+                        executedAt = executedAt,
+                    ),
+                )
+            }
+            return ops
+        }
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/RemoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/RemoveOperation.kt
@@ -13,7 +13,7 @@ import dev.yorkie.util.Logger.Companion.logError
  */
 internal data class RemoveOperation(
     var createdAt: TimeTicket,
-    override val parentCreatedAt: TimeTicket,
+    override var parentCreatedAt: TimeTicket,
     override var executedAt: TimeTicket,
 ) : Operation() {
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
@@ -55,7 +55,7 @@ internal data class SetOperation(
                 opInfos = listOf(
                     OperationInfo.SetOpInfo(key, root.createPath(parentCreatedAt)),
                 ),
-                reverseOp = reverseOp,
+                reverseOps = listOf(reverseOp),
             )
         } else {
             parentObject ?: logError(TAG, "fail to find $parentCreatedAt")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
@@ -40,6 +40,7 @@ internal data class SetOperation(
                 null
             }
             val copiedValue = value.deepCopy()
+            copiedValue.removedAt = null
             val removed = parentObject.set(key, copiedValue, executedAt)
             root.registerElement(copiedValue, parentObject)
             removed?.let(root::registerRemovedElement)

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
@@ -14,7 +14,7 @@ import dev.yorkie.util.Logger.Companion.logError
 internal data class SetOperation(
     val key: String,
     val value: CrdtElement,
-    override val parentCreatedAt: TimeTicket,
+    override var parentCreatedAt: TimeTicket,
     override var executedAt: TimeTicket,
 ) : Operation() {
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt
@@ -12,7 +12,7 @@ internal data class StyleOperation(
     val fromPos: RgaTreeSplitPos,
     val toPos: RgaTreeSplitPos,
     val attributes: Map<String, String>,
-    override val parentCreatedAt: TimeTicket,
+    override var parentCreatedAt: TimeTicket,
     override var executedAt: TimeTicket,
 ) : Operation() {
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
@@ -13,7 +13,7 @@ import dev.yorkie.util.Logger.Companion.logError
  * [TreeEditOperation] is an operation representing Tree editing.
  */
 internal data class TreeEditOperation(
-    override val parentCreatedAt: TimeTicket,
+    override var parentCreatedAt: TimeTicket,
     val fromPos: CrdtTreePos,
     val toPos: CrdtTreePos,
     val contents: List<CrdtTreeNode>?,

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeStyleOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeStyleOperation.kt
@@ -12,7 +12,7 @@ import dev.yorkie.util.Logger.Companion.logError
  * [TreeStyleOperation] represents an operation that modifies the style of the node in the Tree.
  */
 internal data class TreeStyleOperation(
-    override val parentCreatedAt: TimeTicket,
+    override var parentCreatedAt: TimeTicket,
     val fromPos: CrdtTreePos,
     val toPos: CrdtTreePos,
     override var executedAt: TimeTicket,

--- a/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
@@ -511,7 +511,7 @@ class ConverterTest {
     }
 
     private class TestOperation(
-        override val parentCreatedAt: TimeTicket,
+        override var parentCreatedAt: TimeTicket,
         override var executedAt: TimeTicket,
         override val effectedCreatedAt: TimeTicket,
     ) : Operation() {


### PR DESCRIPTION
> **RTCOLLABPLATFORM-632**: [Add Undo/Redo to TodoMVC example app](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-632)

## Summary
- Wire `Document.history` API into the TodoMVC example app with undo/redo icon buttons
- Add `canUndo`/`canRedo` state tracking to enable/disable buttons
- Refresh undo/redo state after every mutation, sync, and local change event

## Changes
- **Todo.kt**: Add `canUndo`/`canRedo` fields to `TodoState`
- **TodoAction.kt**: Add `Undo`/`Redo` action objects
- **TodoViewModel.kt**: Add `undo()`/`redo()` methods, `refreshFromDocument()` helper, listen for `LocalChange` events
- **TodoScreen.kt**: Add undo/redo `IconButton` row with auto-mirrored icons
- **strings.xml**: Add "Undo"/"Redo" string resources

## Test plan
- [ ] Add a todo, tap undo — todo disappears
- [ ] Tap redo — todo reappears
- [ ] Edit a todo text, undo — text reverts
- [ ] Toggle complete, undo — completion reverts
- [ ] Buttons are disabled when stack is empty
- [ ] Undo/redo state refreshes after remote sync

> Items run automatically by CI (lint, unit tests, coverage) are excluded.