### PR TITLE
Add workflow skills (fix-bug, new-feature, refactor) and refactor solve-jira as dispatcher

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,16 +1,41 @@
 ---
 name: create-pr
 description: |
-  Creates a PR for yorkie-android-sdk with English body and JIRA integration.
-  Triggered by "create PR", "make PR", "open PR", "pull request", "push and PR".
-argument-hint: "[--jira RTCOLLABPLATFORM-N] [--draft] [--base branch] [--skip-ai-review]"
+  Creates or updates a PR for yorkie-android-sdk with English body and JIRA integration.
+  Auto-detects base branch from current branch name. Supports updating existing PRs.
+  Triggered by "create PR", "make PR", "open PR", "pull request", "push and PR",
+  "update PR", "update PR title", "update PR body".
+argument-hint: "[--jira RTCOLLABPLATFORM-N] [--draft] [--base branch] [--skip-ai-review] [--update PR_NUMBER]"
+---
+
+## Mode Detection
+
+- If `--update` is specified → **Update mode** (skip to Step 6)
+- Otherwise → **Create mode** (Steps 1–5)
+
 ---
 
 ## Step 1: Analyze changes
 
-1. If `--base` is specified, verify: `git rev-parse --verify {base}`. Stop with error if not found.
-2. Collect: `git log {base}..HEAD --oneline` and `git diff {base}...HEAD` (default base: `develop`).
-3. If no commits since base but uncommitted changes exist, commit all changes:
+1. Determine the base branch (in priority order):
+   - `--base` argument if specified
+   - Auto-detect from current branch name:
+
+   | Branch pattern | Base | Reason |
+   |----------------|------|--------|
+   | `hotfix/*` | `main` | Hotfixes target main |
+   | `feat/RTCOLLABPLATFORM-{N}-*` where a remote branch with same name exists | Check if PR already exists targeting a feature base branch | Sub-PR for large feature |
+   | `fix/*` or `feat/*` | `develop` | Default workflow |
+   | anything else | `develop` | Fallback |
+
+   For sub-PRs: if the current branch was created from a feature base branch (e.g.,
+   `feat/RTCOLLABPLATFORM-{sub}` branched from `feat/RTCOLLABPLATFORM-{parent}`),
+   detect the parent feature branch as the base. Check by looking at the branch's
+   upstream or by matching the parent ticket number from the branch name.
+
+2. Verify base: `git rev-parse --verify {base}`. Stop with error if not found.
+3. Collect: `git log {base}..HEAD --oneline` and `git diff {base}...HEAD`.
+4. If no commits since base but uncommitted changes exist, commit all changes:
    - Check for sensitive files (`.env`, `*credentials*`, `*secret*`, `*token*`, `local.properties`) — warn and exclude
    - Run `./gradlew formatKotlin` before committing
    - Use the PR title format (from Step 3) as the commit message
@@ -58,8 +83,33 @@ Show title and body. Ask "Create PR" (proceed) or "Edit" (revise).
      --title "{title}" \
      --body "{body}" \
      --assignee @me \
-     --base develop \
-     [--draft] [--base {base}] [--label skip-ai-review]
+     --base {base} \
+     [--draft] [--label skip-ai-review]
    ```
 3. Auto-assign reviewers from repo contributors (exclude bots and self). Skip in draft mode.
 4. Return the PR URL.
+
+---
+
+## Step 6: Update existing PR
+
+Triggered by `--update PR_NUMBER` or when user says "update PR title/body".
+
+1. Fetch the existing PR:
+   ```bash
+   gh pr view {PR_NUMBER} --json title,body,number,url
+   ```
+   Stop if PR does not exist.
+
+2. Determine what to update:
+   - If user specifies what to change (e.g., "update title to X") → apply that change
+   - If no specific instruction → re-analyze changes (Step 1–3) and regenerate title and body
+
+3. Show the updated title and body to the user. Ask "Update PR" or "Edit".
+
+4. Apply the update:
+   ```bash
+   gh pr edit {PR_NUMBER} --title "{new_title}" --body "{new_body}"
+   ```
+
+5. Return the PR URL.

--- a/.claude/skills/fix-bug-flow/SKILL.md
+++ b/.claude/skills/fix-bug-flow/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: fix-bug-flow
+description: |
+  Bug-fix workflow from JIRA ticket to PR. Fetches the bug report, investigates root cause,
+  writes a failing test (when possible), fixes the bug, and creates a PR.
+  Use this whenever the user wants to fix a bug from a JIRA ticket, e.g. "fix bug 123",
+  "fix-bug-flow 123", "fix-bug-flow RTCOLLABPLATFORM-123",
+  "there's a bug in ticket 123 please fix it", "hotfix 123".
+argument-hint: "[issue-number] [--from baseBranch] [--hotfix]"
+---
+
+## Progress Checklist
+
+```
+- [ ] Phase 1: Issue confirmed, branch created
+- [ ] Phase 2: Investigation complete, root cause identified
+- [ ] Phase 3: Fix implemented and verified
+- [ ] Phase 4: PR created, JIRA updated
+```
+
+## Phase 1: Setup
+
+1. Fetch the JIRA issue:
+   ```bash
+   curl -s -H "Authorization: Bearer $JIRA_PERSONAL_TOKEN" \
+     "https://jira.navercorp.com/rest/api/2/issue/RTCOLLABPLATFORM-{N}" \
+     -o /tmp/jira-issue.json
+   ```
+   Extract: summary, description, status, assignee. Stop if issue does not exist.
+
+2. Verify assignee matches current user (`GET /rest/api/2/myself`). Stop if assigned to someone else.
+
+3. Transition to "In Progress" if status is "To Do" or "Open" (transition id: `21`).
+   If already "In Progress", skip. Any other status — ask user first.
+
+4. Determine the base branch and branch prefix:
+
+   | Scenario | Flag / Detection | Base | Branch prefix | PR target |
+   |----------|-----------------|------|---------------|-----------|
+   | Normal bug | default | `origin/develop` | `fix/` | `develop` |
+   | Release bug | `--from release/vX.X.X` | `origin/release/vX.X.X` | `fix/` | `release/vX.X.X` |
+   | Hotfix | `--hotfix` | `origin/main` | `hotfix/` | `main` |
+
+   If `--from` starts with `release/`, auto-detect as a release bug.
+   If `--hotfix` is passed, base from `main` and use `hotfix/` prefix.
+
+   Create the branch:
+   ```bash
+   git fetch origin {base}
+   git checkout -b {prefix}RTCOLLABPLATFORM-{N}-{short-desc} --no-track origin/{base}
+   git push -u origin HEAD
+   ```
+   Derive `{short-desc}` from the issue title: lowercase, hyphens, max 4 words.
+   Store the PR target branch for use in Phase 4.
+
+## Phase 2: Investigation
+
+The goal is to understand *why* the bug happens and *where* in the code. Write findings
+to a tracking plan so the work is documented.
+
+### Step 1: Understand the bug
+
+Read the JIRA description carefully. Identify:
+- What is the expected behavior?
+- What is the actual behavior?
+- Are there reproduction steps, stack traces, or screenshots?
+
+### Step 2: Locate the relevant code
+
+Use the bug description to find the affected area. Typical investigation tools:
+- Grep for error messages, class names, or method names mentioned in the ticket
+- Read the relevant source files, trace the logic flow
+- Check git blame / recent commits if the bug is a regression
+
+### Step 3: Reproduce (when possible)
+
+There are two paths depending on whether the bug can be reproduced with a unit test:
+
+**Path A — Unit-testable bug:**
+Write a failing test that demonstrates the bug. Run it to confirm it fails:
+```bash
+./gradlew yorkie:testDebugUnitTest --tests "dev.yorkie.{TestClass}"
+```
+This is the ideal path — a failing test proves the bug exists and later proves the fix works.
+
+**Path B — Requires manual verification:**
+If the bug involves UI, integration with a real server, multi-client sync, or device-specific
+behavior, it cannot be reproduced via unit test. In this case:
+- Document the reproduction steps in the plan
+- Explain the root cause from code analysis (trace through the code to show where it breaks)
+- The user will manually verify on a device after the fix is applied
+
+### Step 4: Write the tracking plan
+
+Save to `docs/superpowers/plans/RTCOLLABPLATFORM-{N}.md`:
+
+```markdown
+# Bug Fix: [JIRA title]
+
+> RTCOLLABPLATFORM-{N}: [title](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-{N})
+
+## Bug Summary
+- **Expected**: ...
+- **Actual**: ...
+
+## Root Cause
+[Explain what code path causes the bug and why]
+
+## Reproduction
+- [ ] Failing test: `{test class and method}` (or "Manual — see steps below")
+- Reproduction steps (if manual): ...
+
+## Fix Approach
+[What will be changed and why]
+
+## Files to Change
+- `path/to/file.kt` — description of change
+```
+
+Show the plan to the user and wait for confirmation before proceeding.
+
+## Phase 3: Fix and Verify
+
+### Step 1: Implement the fix
+
+Apply the fix as described in the plan. Follow CLAUDE.md rules — keep changes minimal
+and focused on the bug. Do not refactor surrounding code.
+
+### Step 2: Verify
+
+Run the full verification suite:
+```bash
+./gradlew formatKotlin
+./gradlew yorkie:testDebugUnitTest lintKotlin
+```
+
+If a failing test was written in Phase 2, confirm it now passes.
+
+If the bug is Path B (manual verification), tell the user:
+> "The fix is applied. Please verify manually on device: [reproduction steps]"
+
+Wait for the user to confirm before proceeding.
+
+### Step 3: Commit
+
+```bash
+git add {changed files}
+git commit -m "fix: {description of the fix}"
+```
+
+Debugging budget: max 2 fix attempts per test failure. After 2 failures, stop and
+ask the user: **Debug myself** / **Continue** / **Stop**.
+
+## Phase 4: Deliver
+
+1. Create the PR:
+   Invoke `create-pr --jira RTCOLLABPLATFORM-{N} --base {PR target branch}`.
+
+2. Transition JIRA to "In Review" (transition id: `31`).
+
+3. Add a JIRA comment summarizing:
+   - Root cause
+   - What was fixed
+   - PR URL
+
+4. Clean up the plan file:
+   ```bash
+   rm docs/superpowers/plans/RTCOLLABPLATFORM-{N}.md
+   ```

--- a/.claude/skills/fix-bug-flow/SKILL.md
+++ b/.claude/skills/fix-bug-flow/SKILL.md
@@ -128,10 +128,17 @@ and focused on the bug. Do not refactor surrounding code.
 
 ### Step 2: Verify
 
-Run the full verification suite:
+Run the fast verification suite:
 ```bash
 ./gradlew formatKotlin
 ./gradlew yorkie:testDebugUnitTest lintKotlin
+```
+
+Then run instrumented tests against a local Yorkie server (required before PR):
+```bash
+docker compose -f docker/docker-compose.yml up --build -d
+./scripts/config-yorkie-local-server.sh
+./gradlew yorkie:connectedDebugAndroidTest
 ```
 
 If a failing test was written in Phase 2, confirm it now passes.

--- a/.claude/skills/new-feature-flow/SKILL.md
+++ b/.claude/skills/new-feature-flow/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: new-feature-flow
+description: |
+  Feature development workflow from JIRA ticket to PR. Fetches the feature request,
+  writes implementation plan, implements with team-review, and creates PR(s).
+  For large features, creates subtask tickets and a base feature branch with sub-PRs.
+  Use this whenever the user wants to implement a new feature from a JIRA ticket, e.g.
+  "new-feature-flow 123", "implement feature 123", "add feature from ticket 123",
+  "work on feature RTCOLLABPLATFORM-123".
+argument-hint: "[issue-number] [--from baseBranch] [--exec-model opus|sonnet|haiku]"
+---
+
+## Execution Model
+
+`--exec-model` sets the model for Phase 4 (implementation). Default: `sonnet`.
+
+## Progress Checklist
+
+```
+- [ ] Phase 1: Issue confirmed, branch created
+- [ ] Phase 2: Research complete, implementation plan written
+- [ ] Phase 3: Plan reviewed and approved
+- [ ] Phase 4: Implementation complete
+- [ ] Phase 5: PR created, JIRA updated
+```
+
+## Phase 1: Setup
+
+1. Fetch the JIRA issue:
+   ```bash
+   curl -s -H "Authorization: Bearer $JIRA_PERSONAL_TOKEN" \
+     "https://jira.navercorp.com/rest/api/2/issue/RTCOLLABPLATFORM-{N}" \
+     -o /tmp/jira-issue.json
+   ```
+   Extract: summary, description, status, assignee. Stop if issue does not exist.
+
+2. Verify assignee matches current user (`GET /rest/api/2/myself`). Stop if assigned to someone else.
+
+3. Transition to "In Progress" if status is "To Do" or "Open" (transition id: `21`).
+   If already "In Progress", skip. Any other status — ask user first.
+
+4. Determine the base branch:
+
+   | Scenario | Flag | Base | Branch prefix | PR target |
+   |----------|------|------|---------------|-----------|
+   | Normal feature | default | `origin/develop` | `feat/` | `develop` |
+   | From release | `--from release/vX.X.X` | `origin/release/vX.X.X` | `feat/` | `release/vX.X.X` |
+
+   Create the branch:
+   ```bash
+   git fetch origin {base}
+   git checkout -b feat/RTCOLLABPLATFORM-{N}-{short-desc} --no-track origin/{base}
+   git push -u origin HEAD
+   ```
+   Derive `{short-desc}` from the issue title: lowercase, hyphens, max 4 words.
+   Store the PR target branch for use in Phase 5.
+
+## Phase 2: Research and Plan
+
+The goal is to understand what needs to be built and write a detailed implementation plan.
+Features are larger than bug fixes and benefit from upfront planning to avoid rework.
+
+### Step 1: Explore the codebase
+
+Investigate the Android SDK codebase to understand:
+- Which existing classes/files are relevant
+- What patterns are already used for similar features
+- What tests exist for related functionality
+- What the public API surface looks like
+
+### Step 2: Write the prompt
+
+Write a prompt describing what to implement, informed by the JIRA ticket and codebase
+exploration. Show to user and wait for approval.
+
+### Step 3: Write the implementation plan
+
+Write a detailed plan including:
+- Absolute file paths with specific locations (class/function/line)
+- Exact code snippets for each change
+- New files to create
+- Test cases (unit and instrumented where applicable)
+- Change order (which files to modify first)
+
+Save to: `docs/superpowers/plans/RTCOLLABPLATFORM-{N}.md`
+
+### Step 4: Assess scope and split if needed
+
+After the plan is written, assess whether the feature should be delivered as a single PR
+or split into multiple PRs. A single PR is appropriate when changes are small and cohesive.
+Split when:
+- The plan touches many files across different concerns (e.g., CRDT layer + API layer + tests)
+- The total change is large enough that reviewing a single PR would be difficult
+- Parts of the feature can be merged and tested independently
+
+**If splitting into multiple PRs:**
+
+1. Document the PR split in the plan with clear boundaries for each PR.
+
+2. Create subtask JIRA tickets for each PR using `create-jira`:
+   ```
+   /create-jira --type subtask --parent {N} --title "{PR description}"
+   ```
+
+3. The branch created in Phase 1 becomes the **base feature branch**. Each subtask
+   gets its own branch off this base and PRs back to it:
+   ```
+   Base branch: feat/RTCOLLABPLATFORM-{N}-{short-desc}     (PR target: develop)
+     ├─ Sub-branch 1: feat/RTCOLLABPLATFORM-{sub1}-{desc}  (PR target: base branch)
+     ├─ Sub-branch 2: feat/RTCOLLABPLATFORM-{sub2}-{desc}  (PR target: base branch)
+     └─ Sub-branch 3: feat/RTCOLLABPLATFORM-{sub3}-{desc}  (PR target: base branch)
+   ```
+
+4. After all sub-PRs are merged into the base branch, create a final PR from the base
+   branch to the PR target (develop or release).
+
+## Phase 3: Plan Review
+
+Ask the user: **Review** (run `team-review --target plan --method subagent`) or **Skip**.
+
+If reviewing:
+1. Run team-review
+2. Update plan with feedback
+3. Confirm with user before proceeding
+
+## Phase 4: Implementation
+
+### Single PR flow
+
+1. Implement the changes as described in the plan
+2. Verify:
+   ```bash
+   ./gradlew formatKotlin
+   ./gradlew yorkie:testDebugUnitTest lintKotlin
+   ```
+3. Commit and push
+
+Delegate to implementation subagent if the feature is large:
+- `model`: `--exec-model` value or `sonnet`
+- `run_in_background: true`
+
+Prompt must include:
+- Full plan content
+- "Follow CLAUDE.md rules."
+- Commit message format: `feat: {description}`
+- Run `./gradlew formatKotlin` before committing
+- Run `./gradlew yorkie:testDebugUnitTest lintKotlin` to verify
+
+### Multi-PR flow
+
+For each subtask PR:
+
+1. Create the sub-branch from the base feature branch:
+   ```bash
+   git checkout feat/RTCOLLABPLATFORM-{N}-{short-desc}
+   git pull origin feat/RTCOLLABPLATFORM-{N}-{short-desc}
+   git checkout -b feat/RTCOLLABPLATFORM-{subN}-{desc} --no-track origin/feat/RTCOLLABPLATFORM-{N}-{short-desc}
+   ```
+
+2. Implement the subtask changes
+
+3. Verify:
+   ```bash
+   ./gradlew formatKotlin
+   ./gradlew yorkie:testDebugUnitTest lintKotlin
+   ```
+
+4. Commit, push, and create PR targeting the **base feature branch**:
+   ```
+   /create-pr --jira RTCOLLABPLATFORM-{subN} --base feat/RTCOLLABPLATFORM-{N}-{short-desc}
+   ```
+
+5. Wait for user to merge the sub-PR
+
+6. Switch back to base branch, pull latest, and continue to next subtask
+
+Debugging budget: max 2 fix attempts per failure. After 2 failures, stop and
+ask the user: **Debug myself** / **Continue subagent** / **Stop**.
+
+## Phase 5: Deliver
+
+### Single PR
+
+1. Create the PR:
+   Invoke `create-pr --jira RTCOLLABPLATFORM-{N} --base {PR target branch}`.
+
+### Multi-PR (after all sub-PRs merged)
+
+1. Create the final PR from the base feature branch to the PR target:
+   Invoke `create-pr --jira RTCOLLABPLATFORM-{N} --base {PR target branch}`.
+
+### Common steps
+
+2. Transition JIRA to "In Review" (transition id: `31`).
+
+3. Add a JIRA comment summarizing:
+   - What was implemented
+   - Key design decisions
+   - PR URL(s) — include all sub-PRs if multi-PR
+
+4. Clean up the plan file:
+   ```bash
+   rm docs/superpowers/plans/RTCOLLABPLATFORM-{N}.md
+   ```

--- a/.claude/skills/new-feature-flow/SKILL.md
+++ b/.claude/skills/new-feature-flow/SKILL.md
@@ -128,12 +128,18 @@ If reviewing:
 ### Single PR flow
 
 1. Implement the changes as described in the plan
-2. Verify:
+2. Verify (fast loop):
    ```bash
    ./gradlew formatKotlin
    ./gradlew yorkie:testDebugUnitTest lintKotlin
    ```
-3. Commit and push
+3. Run instrumented tests before PR:
+   ```bash
+   docker compose -f docker/docker-compose.yml up --build -d
+   ./scripts/config-yorkie-local-server.sh
+   ./gradlew yorkie:connectedDebugAndroidTest
+   ```
+4. Commit and push
 
 Delegate to implementation subagent if the feature is large:
 - `model`: `--exec-model` value or `sonnet`
@@ -145,6 +151,7 @@ Prompt must include:
 - Commit message format: `feat: {description}`
 - Run `./gradlew formatKotlin` before committing
 - Run `./gradlew yorkie:testDebugUnitTest lintKotlin` to verify
+- Run instrumented tests before handing off: `docker compose -f docker/docker-compose.yml up --build -d && ./scripts/config-yorkie-local-server.sh && ./gradlew yorkie:connectedDebugAndroidTest`
 
 ### Multi-PR flow
 
@@ -159,13 +166,20 @@ For each subtask PR:
 
 2. Implement the subtask changes
 
-3. Verify:
+3. Verify (fast loop):
    ```bash
    ./gradlew formatKotlin
    ./gradlew yorkie:testDebugUnitTest lintKotlin
    ```
 
-4. Commit, push, and create PR targeting the **base feature branch**:
+4. Run instrumented tests before PR:
+   ```bash
+   docker compose -f docker/docker-compose.yml up --build -d
+   ./scripts/config-yorkie-local-server.sh
+   ./gradlew yorkie:connectedDebugAndroidTest
+   ```
+
+5. Commit, push, and create PR targeting the **base feature branch**:
    ```
    /create-pr --jira RTCOLLABPLATFORM-{subN} --base feat/RTCOLLABPLATFORM-{N}-{short-desc}
    ```

--- a/.claude/skills/refactor-flow/SKILL.md
+++ b/.claude/skills/refactor-flow/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: refactor-flow
+description: |
+  Refactoring workflow from JIRA ticket to PR. Fetches the refactoring task, analyzes current
+  code, ensures tests pass before changes, refactors with zero behavior change, and creates PR.
+  Use this whenever the user wants to refactor code from a JIRA ticket, e.g.
+  "refactor-flow 123", "refactor ticket 123", "clean up code for ticket 123",
+  "restructure the code in RTCOLLABPLATFORM-123".
+argument-hint: "[issue-number] [--from baseBranch] [--exec-model opus|sonnet|haiku]"
+---
+
+## Execution Model
+
+`--exec-model` sets the model for Phase 4 (implementation). Default: `sonnet`.
+
+## Progress Checklist
+
+```
+- [ ] Phase 1: Issue confirmed, branch created
+- [ ] Phase 2: Analysis complete, refactoring plan written
+- [ ] Phase 3: Plan reviewed and approved
+- [ ] Phase 4: Refactoring complete, all tests still pass
+- [ ] Phase 5: PR created, JIRA updated
+```
+
+## Phase 1: Setup
+
+1. Fetch the JIRA issue:
+   ```bash
+   curl -s -H "Authorization: Bearer $JIRA_PERSONAL_TOKEN" \
+     "https://jira.navercorp.com/rest/api/2/issue/RTCOLLABPLATFORM-{N}" \
+     -o /tmp/jira-issue.json
+   ```
+   Extract: summary, description, status, assignee. Stop if issue does not exist.
+
+2. Verify assignee matches current user (`GET /rest/api/2/myself`). Stop if assigned to someone else.
+
+3. Transition to "In Progress" if status is "To Do" or "Open" (transition id: `21`).
+   If already "In Progress", skip. Any other status — ask user first.
+
+4. Determine the base branch:
+
+   | Scenario | Flag | Base | Branch prefix | PR target |
+   |----------|------|------|---------------|-----------|
+   | Normal refactor | default | `origin/develop` | `refactor/` | `develop` |
+   | From release | `--from release/vX.X.X` | `origin/release/vX.X.X` | `refactor/` | `release/vX.X.X` |
+
+   Create the branch:
+   ```bash
+   git fetch origin {base}
+   git checkout -b refactor/RTCOLLABPLATFORM-{N}-{short-desc} --no-track origin/{base}
+   git push -u origin HEAD
+   ```
+   Derive `{short-desc}` from the issue title: lowercase, hyphens, max 4 words.
+
+## Phase 2: Analysis and Plan
+
+Refactoring means changing code structure without changing behavior. The plan needs to
+capture what the code looks like now, what it should look like after, and why the change
+improves things — while proving nothing breaks.
+
+### Step 1: Baseline test run
+
+Run the test suite before making any changes. This establishes the green baseline that
+the refactoring must preserve:
+```bash
+./gradlew yorkie:testDebugUnitTest lintKotlin
+```
+Record the result. If tests already fail, stop and tell the user — refactoring on a
+broken baseline is risky.
+
+### Step 2: Understand the current code
+
+Read the JIRA description to understand what needs refactoring and why. Then explore
+the relevant code:
+- Read the files mentioned in the ticket
+- Understand the current structure, dependencies, and public API surface
+- Identify what tests cover the code being refactored
+
+### Step 3: Write the refactoring plan
+
+Save to `docs/superpowers/plans/RTCOLLABPLATFORM-{N}.md`:
+
+```markdown
+# Refactor: [JIRA title]
+
+> RTCOLLABPLATFORM-{N}: [title](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-{N})
+
+## Current State
+[Describe the current code structure and why it needs refactoring]
+
+## Goal
+[What the code should look like after refactoring]
+
+## Approach
+[Step-by-step description of changes]
+
+## Behavior Guarantee
+- Baseline tests: all passing (N tests)
+- Public API changes: none / list any intentional changes
+- No new functionality added
+
+## Files to Change
+- `path/to/file.kt` — description of change
+
+## Test Coverage
+- Existing tests covering this code: [list test classes]
+- Additional tests needed: [if any structural changes require new tests]
+```
+
+Show the plan to the user and wait for confirmation.
+
+## Phase 3: Plan Review
+
+Ask the user: **Review** (run `team-review --target plan --method subagent`) or **Skip**.
+
+If reviewing:
+1. Run team-review
+2. Update plan with feedback
+3. Confirm with user before proceeding
+
+## Phase 4: Implementation
+
+### Step 1: Refactor
+
+Apply the changes described in the plan. Key principles:
+- Make small, incremental commits — each commit should leave tests passing
+- Do not add new features or fix bugs as part of the refactoring
+- If you discover a bug while refactoring, note it but don't fix it — that's a separate ticket
+
+Delegate to implementation subagent if the refactoring is large:
+- `model`: `--exec-model` value or `sonnet`
+- `run_in_background: true`
+
+Prompt must include:
+- Full plan content
+- "Follow CLAUDE.md rules."
+- "This is a refactor — zero behavior change. All existing tests must still pass."
+- Commit message format: `refactor: {description}`
+- Run `./gradlew formatKotlin` before committing
+- Run `./gradlew yorkie:testDebugUnitTest lintKotlin` to verify after each commit
+
+### Step 2: Final verification
+
+Run the full test suite one more time to confirm nothing is broken:
+```bash
+./gradlew formatKotlin
+./gradlew yorkie:testDebugUnitTest lintKotlin
+```
+
+Compare with the baseline from Phase 2 Step 1 — the same number of tests should pass.
+If any test that previously passed now fails, the refactoring introduced a regression.
+Fix it before proceeding.
+
+### Step 3: Commit and push
+
+```bash
+git add {changed files}
+git commit -m "refactor: {description}"
+git push
+```
+
+Debugging budget: max 2 fix attempts per test failure. After 2 failures, stop and
+ask the user: **Debug myself** / **Continue subagent** / **Stop**.
+
+## Phase 5: Deliver
+
+1. Create the PR:
+   Invoke `create-pr --jira RTCOLLABPLATFORM-{N} --base {PR target branch}`.
+
+2. Transition JIRA to "In Review" (transition id: `31`).
+
+3. Add a JIRA comment summarizing:
+   - What was refactored and why
+   - Confirmation that all tests pass (before and after)
+   - PR URL
+
+4. Clean up the plan file:
+   ```bash
+   rm docs/superpowers/plans/RTCOLLABPLATFORM-{N}.md
+   ```

--- a/.claude/skills/refactor-flow/SKILL.md
+++ b/.claude/skills/refactor-flow/SKILL.md
@@ -66,7 +66,16 @@ the refactoring must preserve:
 ```bash
 ./gradlew yorkie:testDebugUnitTest lintKotlin
 ```
-Record the result. If tests already fail, stop and tell the user — refactoring on a
+
+Also capture an instrumented-test baseline (critical for refactors that touch sync,
+presence, or CRDT paths):
+```bash
+docker compose -f docker/docker-compose.yml up --build -d
+./scripts/config-yorkie-local-server.sh
+./gradlew yorkie:connectedDebugAndroidTest
+```
+
+Record both results. If tests already fail, stop and tell the user — refactoring on a
 broken baseline is risky.
 
 ### Step 2: Understand the current code
@@ -139,18 +148,26 @@ Prompt must include:
 - Commit message format: `refactor: {description}`
 - Run `./gradlew formatKotlin` before committing
 - Run `./gradlew yorkie:testDebugUnitTest lintKotlin` to verify after each commit
+- Run instrumented tests before handing off: `docker compose -f docker/docker-compose.yml up --build -d && ./scripts/config-yorkie-local-server.sh && ./gradlew yorkie:connectedDebugAndroidTest`
 
 ### Step 2: Final verification
 
-Run the full test suite one more time to confirm nothing is broken:
+Run the fast suite:
 ```bash
 ./gradlew formatKotlin
 ./gradlew yorkie:testDebugUnitTest lintKotlin
 ```
 
-Compare with the baseline from Phase 2 Step 1 — the same number of tests should pass.
-If any test that previously passed now fails, the refactoring introduced a regression.
-Fix it before proceeding.
+Then run the instrumented suite against a local Yorkie server:
+```bash
+docker compose -f docker/docker-compose.yml up --build -d
+./scripts/config-yorkie-local-server.sh
+./gradlew yorkie:connectedDebugAndroidTest
+```
+
+Compare with the baseline from Phase 2 Step 1 — the same number of tests should pass
+in both suites. If any test that previously passed now fails, the refactoring introduced
+a regression. Fix it before proceeding.
 
 ### Step 3: Commit and push
 

--- a/.claude/skills/solve-jira/SKILL.md
+++ b/.claude/skills/solve-jira/SKILL.md
@@ -1,114 +1,58 @@
 ---
 name: solve-jira
 description: |
-  Full end-to-end JIRA issue workflow: fetch issue, create branch, write plan, review plan,
-  implement, code review, create PR. Triggered when an issue number is mentioned or when
-  the current branch matches feat/RTCOLLABPLATFORM-* or fix/RTCOLLABPLATFORM-*.
-  Natural language triggers: "solve 42", "work on ticket 42", "RTCOLLABPLATFORM-42".
-argument-hint: "[issue-number] [--from baseBranch] [--exec-model opus|sonnet|haiku (default: sonnet)]"
+  JIRA ticket dispatcher. Fetches the issue, detects the type (bug, feature, refactor, etc.),
+  and routes to the appropriate workflow skill. Use this when the user mentions a JIRA ticket
+  number without specifying a workflow, e.g. "solve 42", "work on ticket 42",
+  "RTCOLLABPLATFORM-42", "what should I do with ticket 123".
+argument-hint: "[issue-number] [--from baseBranch] [--hotfix] [--exec-model opus|sonnet|haiku]"
 ---
 
-## Execution Model
+## Step 1: Fetch and classify the issue
 
-`--exec-model` sets the model for Phase 5 (implementation). Default: `sonnet`.
-
-## Progress Checklist
-
-```
-- [ ] Phase 1: Issue confirmed, branch created
-- [ ] Phase 2: Prompt written and approved
-- [ ] Phase 3: Plan written
-- [ ] Phase 4: Plan reviewed
-- [ ] Phase 5: Implementation complete
-- [ ] Phase 6: PR created, JIRA commented, plan cleaned up
+```bash
+curl -s -H "Authorization: Bearer $JIRA_PERSONAL_TOKEN" \
+  "https://jira.navercorp.com/rest/api/2/issue/RTCOLLABPLATFORM-{N}" \
+  -o /tmp/jira-issue.json
 ```
 
-## Phase 1: Confirm issue and create branch
+Stop if issue does not exist.
 
-1. Fetch issue:
-   ```bash
-   curl -s -H "Authorization: Bearer $JIRA_PERSONAL_TOKEN" \
-     "https://jira.navercorp.com/rest/api/2/issue/RTCOLLABPLATFORM-{N}" \
-     -o /tmp/jira-issue.json
-   ```
-   Stop if issue does not exist.
+Extract: `summary`, `issuetype.name`, `status.name`, `assignee.name`.
 
-2. Check assignee (`GET /rest/api/2/myself`). Stop if assigned to someone else.
+## Step 2: Detect the workflow type
 
-3. **JS sync check** — if the issue title contains a reference to `yorkie-js-sdk#` (e.g. `(yorkie-js-sdk#1099)`):
-   - Fetch the PR's changed files:
-     ```bash
-     curl -s "https://api.github.com/repos/yorkie-team/yorkie-js-sdk/pulls/{PR_N}/files" \
-       | python3 -c "import sys,json; [print(f['filename']) for f in json.load(sys.stdin)]"
-     ```
-   - If **all** changed files are outside `packages/sdk/src/` (e.g. only `packages/react/`, `examples/`, docs):
-     - Inform the user: "This issue only touches the JS UI/integration layer — no Android SDK changes needed."
-     - Transition issue to **Closed** (id: `61`) with resolution **Won't Fix** (id: `10500`):
-       ```bash
-       curl -s -X POST -H "Authorization: Bearer $JIRA_PERSONAL_TOKEN" \
-         -H "Content-Type: application/json" \
-         -d '{"transition":{"id":"61"},"fields":{"resolution":{"id":"10500"}}}' \
-         "https://jira.navercorp.com/rest/api/2/issue/RTCOLLABPLATFORM-{N}/transitions"
-       ```
-     - **Stop here.** Do not create a branch or proceed further.
-   - If any changed files are under `packages/sdk/src/` → continue normally.
+Determine the workflow from the JIRA issue type and title keywords:
 
-4. Check current status from issue `fields.status.name`:
-   - `"In Progress"` → skip, no transition needed
-   - `"To Do"` or `"Open"` → transition to "In Progress" (id: `21`):
-     ```bash
-     curl -s -X POST -H "Authorization: Bearer $JIRA_PERSONAL_TOKEN" \
-       -H "Content-Type: application/json" \
-       -d '{"transition": {"id": "21"}}' \
-       "https://jira.navercorp.com/rest/api/2/issue/RTCOLLABPLATFORM-{N}/transitions"
-     ```
-   - Any other status → ask user before transitioning.
+| Issue type | Title keywords | Workflow skill | Args to forward |
+|------------|---------------|----------------|-----------------|
+| Bug | — | `fix-bug-flow` | `{N} [--from] [--hotfix]` |
+| Sub-task (parent is Bug) | "Fix" | `fix-bug-flow` | `{N} [--from] [--hotfix]` |
+| Task / Story / Sub-task | "Add", "Implement", "Support", "Sync" | `new-feature-flow` | `{N} [--from] [--exec-model]` |
+| Task / Story | "Refactor", "Clean", "Restructure" | `refactor-flow` | `{N} [--from] [--exec-model]` |
+| Task / Story | "Migrate", "Remove", "Update", "Bump", "Config", "CI" | `new-feature-flow` | `{N} [--from] [--exec-model]` |
 
-5. Branch naming: Bug → `fix/RTCOLLABPLATFORM-{N}`, all others → `feat/RTCOLLABPLATFORM-{N}`
+If the type is ambiguous, show the user the ticket summary and ask which workflow to use:
+> "Ticket RTCOLLABPLATFORM-{N}: {summary}. Which workflow?"
+> - **Bug fix** (`/fix-bug-flow {N}`)
+> - **New feature** (`/new-feature-flow {N}`)
+> - **Refactor** (`/refactor-flow {N}`)
 
-6. Create branch from `--from` base (default: `origin/develop`):
-   ```bash
-   git fetch origin develop
-   git checkout -b {branch} --no-track origin/develop
-   git push -u origin HEAD
-   ```
+## Step 3: Forward all arguments
 
-## Phase 2–3: Prompt and Plan (Planning Subagent)
+Pass through any arguments the user provided (`--from`, `--hotfix`, `--exec-model`) to the
+selected workflow skill. Invoke via the Skill tool:
 
-Both phases run in a single planning subagent (`run_in_background: true`, `mode: "plan"`).
+```
+/fix-bug-flow {N} [--from {base}] [--hotfix]
+```
+or
+```
+/new-feature-flow {N} [--from {base}] [--exec-model {model}]
+```
+or
+```
+/refactor-flow {N} [--from {base}] [--exec-model {model}]
+```
 
-**Phase 2a — JS SDK research (if applicable):** If the issue references a JS SDK PR (`yorkie-js-sdk#N`), or the feature exists in the JS SDK, spawn `yorkie-js-researcher` to research the JS implementation before planning. Include in the prompt:
-- The JS PR number or feature name
-- "Show the relevant JS implementation, key files, algorithm, and API surface"
-
-Attach the researcher's output to the planning subagent's context.
-
-**Phase 2b:** Subagent explores codebase and writes a prompt describing what to implement. Show to user, wait for approval.
-
-**Phase 3:** Resume subagent with approved prompt to write detailed plan. Plan must include: absolute file paths, specific locations (class/function/line), exact code snippets, new files, test cases, change order. If JS research was done, reference the JS implementation and note any intentional deviations.
-
-Save plan to: `docs/superpowers/plans/RTCOLLABPLATFORM-{N}.md`
-
-## Phase 4: Review plan
-
-Ask user: **Review** (run `team-review --target plan --method subagent`) or **Skip**.
-Update plan with feedback. Append post-implementation steps section. Confirm before proceeding.
-
-## Phase 5: Implementation
-
-Delegate to implementation subagent:
-- `model`: `--exec-model` value or `sonnet`
-- `run_in_background: true`
-
-Prompt must include: full plan content, "Follow CLAUDE.md rules.", commit message format `[RTCOLLABPLATFORM-{N}] {issue title}`, run `./gradlew formatKotlin` before committing, run `./gradlew yorkie:testDebugUnitTest lintKotlin` to verify, return team-review output + Fix/Skip classification.
-
-Debugging budget: max 2 fix attempts per failure. After 2 failures, stop and report.
-
-If budget exhausted: ask user — **Debug myself** / **Continue subagent** / **Stop**.
-
-## Phase 6: Post-implementation
-
-1. Report team-review output and Fix/Skip summary.
-2. Invoke `create-pr --jira RTCOLLABPLATFORM-{N} --draft`.
-3. Add JIRA comment with approach summary, key fixes, and PR URL.
-4. Delete plan file: `rm docs/superpowers/plans/RTCOLLABPLATFORM-{N}.md`
+The dispatched skill handles everything from branch creation to PR delivery.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 # Instrumented tests (requires running Yorkie server via Docker)
 docker compose -f docker/docker-compose.yml up --build -d
+./scripts/config-yorkie-local-server.sh   # must be run before instrumented tests — writes YORKIE_SERVER_URL to local.properties
 ./gradlew yorkie:connectedDebugAndroidTest
 
 # Lint


### PR DESCRIPTION
## Summary
- Add `fix-bug-flow`, `new-feature-flow`, `refactor-flow` as separate workflow skills
- Refactor `solve-jira` into a lightweight dispatcher that routes to the appropriate workflow
- Enhance `create-pr` with auto-detect base branch, sub-PR support, and PR update capability

## Changes
- **fix-bug-flow**: Bug-fix workflow with Path A (unit-testable) / Path B (manual verification), hotfix support
- **new-feature-flow**: Feature workflow with multi-PR delivery via subtask tickets and base feature branch
- **refactor-flow**: Refactoring workflow with baseline test guarantee (tests must pass before AND after)
- **solve-jira**: Now a dispatcher — fetches ticket type and routes to fix-bug-flow / new-feature-flow / refactor-flow
- **create-pr**: Auto-detects base from branch name (hotfix→main, sub-PR→feature branch), adds `--update` for editing existing PRs

## Test plan
- [ ] Verify `/solve-jira` correctly dispatches bug tickets to fix-bug-flow
- [ ] Verify `/solve-jira` correctly dispatches feature tickets to new-feature-flow
- [ ] Verify `/solve-jira` correctly dispatches refactor tickets to refactor-flow
- [ ] Verify `/create-pr` auto-detects base branch from hotfix/ prefix
- [ ] Verify `/create-pr --update` can edit existing PR title/body