### PR TITLE
Fix ElementRht.set producing duplicate keys on timestamp reversal

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/ElementRht.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/ElementRht.kt
@@ -31,6 +31,10 @@ internal class ElementRht<T : CrdtElement> : Iterable<ElementRht.Node<T>> {
         if (node == null || node.value.getPositionedAt() < executedAt) {
             nodeMapByKey[key] = newNode
             value.movedAt = executedAt
+        } else if (!node.isRemoved) {
+            // The new node loses the LWW conflict; tombstone it so it does not
+            // surface as a duplicate key during iteration.
+            value.remove(node.value.getPositionedAt())
         }
         return removed
     }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/ElementRhtTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/ElementRhtTest.kt
@@ -239,6 +239,70 @@ class ElementRhtTest {
     }
 
     @Test
+    fun `Verify CrdtObject keys has no duplicates when late-arriving set loses LWW conflict`() {
+        // given: client A sets "color" at lamport=2 (winner)
+        val elementRht = ElementRht<CrdtPrimitive>()
+        val winnerTicket = generateTimeTicket(2, 2, "actorA")
+        elementRht.set(
+            key = "color",
+            value = CrdtPrimitive("red", winnerTicket),
+            executedAt = winnerTicket,
+        )
+
+        // when: client B's set for the same key arrives with earlier lamport=1 (loser)
+        val loserTicket = generateTimeTicket(1, 1, "actorB")
+        elementRht.set(
+            key = "color",
+            value = CrdtPrimitive("blue", loserTicket),
+            executedAt = loserTicket,
+        )
+
+        // then: CrdtObject keys must not contain duplicates
+        val obj =
+            CrdtObject(
+                TimeTicket.InitialTimeTicket,
+                memberNodes = elementRht as ElementRht<CrdtElement>,
+            )
+        assertEquals(listOf("color"), obj.keys)
+        assertEquals("red", (obj["color"] as CrdtPrimitive).value)
+    }
+
+    @Test
+    fun `Verify CrdtObject keys stays unique across multiple late-arriving concurrent sets`() {
+        // given: initial value at lamport=3
+        val elementRht = ElementRht<CrdtPrimitive>()
+        val firstTicket = generateTimeTicket(3, 3, "actor1")
+        elementRht.set(
+            key = "key",
+            value = CrdtPrimitive("first", firstTicket),
+            executedAt = firstTicket,
+        )
+
+        // when: two late-arriving sets with earlier lamports
+        val secondTicket = generateTimeTicket(1, 1, "actor2")
+        elementRht.set(
+            key = "key",
+            value = CrdtPrimitive("second", secondTicket),
+            executedAt = secondTicket,
+        )
+        val thirdTicket = generateTimeTicket(2, 2, "actor3")
+        elementRht.set(
+            key = "key",
+            value = CrdtPrimitive("third", thirdTicket),
+            executedAt = thirdTicket,
+        )
+
+        // then: exactly one live key, winner is the first (latest positionedAt)
+        val obj =
+            CrdtObject(
+                TimeTicket.InitialTimeTicket,
+                memberNodes = elementRht as ElementRht<CrdtElement>,
+            )
+        assertEquals(listOf("key"), obj.keys)
+        assertEquals("first", (obj["key"] as CrdtPrimitive).value)
+    }
+
+    @Test
     fun `Verity the getKeyOfQueue() using sequence`() {
         val elementRht = ElementRht<CrdtPrimitive>()
         val list = mutableListOf<String>()


### PR DESCRIPTION
> **RTCOLLABPLATFORM-644**: [[Android] [A8] Fix ElementRHT.set() producing duplicate ownKeys on timestamp reversal](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-644)
>
> Sync-up task **A8** in the [Yorkie Android ⇄ JS sync-up roadmap](https://wiki.navercorp.com/pages/viewpage.action?pageId=5131863864). Ports JS SDK PR [yorkie-team/yorkie-js-sdk#1188](https://github.com/yorkie-team/yorkie-js-sdk/pull/1188).

## Summary
- When a late-arriving concurrent `ElementRht.set()` loses the LWW conflict (`executedAt` earlier than the existing node's `positionedAt`), the new node was added to `nodeMapByCreatedAt` without being tombstoned.
- This left two non-removed nodes with the same `strKey`, so `CrdtObject.iterator()` (filter on `!isRemoved`) yielded duplicate entries and `CrdtObject.keys` returned the same key twice.
- Fix mirrors JS PR #1188: mark the losing new node as removed using the winner's `positionedAt` so it is filtered out during iteration.

## Changes
- `yorkie/src/main/kotlin/dev/yorkie/document/crdt/ElementRht.kt` — add `else if (!node.isRemoved) { value.remove(node.value.getPositionedAt()) }` branch in `set()`.
- `yorkie/src/test/kotlin/dev/yorkie/document/crdt/ElementRhtTest.kt` — two new unit tests covering single and multi late-arriving concurrent sets on the same key.

## Test plan
- [x] New unit tests reproduce the bug pre-fix (assertion failure) and pass post-fix.
- [x] Full `./gradlew yorkie:testDebugUnitTest` green (no regressions).
- [x] `./gradlew lintKotlin` clean.
- [x] `./gradlew yorkie:connectedDebugAndroidTest` green (275 tests, 2 pre-existing skips) against local Yorkie Docker server on Pixel_6_API_33.

> Items run automatically by CI (lint, unit tests, coverage) are excluded.