### PR TITLE
Split SplayTreeSet.find into findForText and findForArray

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeList.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeList.kt
@@ -173,16 +173,7 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node> {
      */
     fun getByIndex(index: Int): Node? {
         if (length <= index) return null
-
-        val (value, offset) = nodeMapByIndex.find(index)
-        var rgaNode = nodeMapByCreatedAt[value?.value?.createdAt ?: ""]
-
-        if ((index == 0 && rgaNode == dummyHead) || offset > 0) {
-            do {
-                rgaNode = rgaNode?.next
-            } while (rgaNode?.isRemoved == true)
-        }
-        return rgaNode
+        return nodeMapByIndex.findForArray(index)
     }
 
     /**

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeSplit.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeSplit.kt
@@ -345,7 +345,7 @@ internal class RgaTreeSplit<T : RgaTreeSplitValue<T>> :
      * Finds [RgaTreeSplitPos] of the given [index].
      */
     fun indexToPos(index: Int): RgaTreeSplitPos {
-        val (node, offset) = treeByIndex.find(index)
+        val (node, offset) = treeByIndex.findForText(index)
         return node?.let {
             RgaTreeSplitPos(it.id, offset)
         } ?: throw NoSuchElementException("no node found with the given index: $index")

--- a/yorkie/src/main/kotlin/dev/yorkie/util/SplayTreeSet.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/SplayTreeSet.kt
@@ -39,10 +39,11 @@ internal class SplayTreeSet<V>(
     }
 
     /**
-     * Returns the value and offset of the given index.
+     * Returns the value and offset of the given cursor position.
+     * Used for Text where cursor lives between characters.
      */
     @Suppress("UNCHECKED_CAST")
-    fun find(pos: Int): ValueToOffset<V> {
+    fun findForText(pos: Int): ValueToOffset<V> {
         var target = pos
         val root = root
         if (root == null || target < 0) {
@@ -67,6 +68,35 @@ internal class SplayTreeSet<V>(
         }
         splayInternal(node)
         return ValueToOffset(node.value, target)
+    }
+
+    /**
+     * Returns the value at the given array index.
+     * Used for Array where index points to an element (removed nodes have length 0).
+     *
+     * @throws IndexOutOfBoundsException when [idx] is negative or past the tree length.
+     */
+    fun findForArray(idx: Int): V? {
+        val root = root ?: return null
+        if (idx < 0 || idx >= length) {
+            throw IndexOutOfBoundsException(
+                "out of index range: idx: $idx, length: $length",
+            )
+        }
+        var target = idx
+        var node: Node<V> = root
+        while (true) {
+            if (node.left != null && target < node.leftWeight) {
+                node = requireNotNull(node.left)
+            } else if (node.right != null && node.leftWeight + node.length <= target) {
+                target -= node.leftWeight + node.length
+                node = requireNotNull(node.right)
+            } else {
+                break
+            }
+        }
+        splayInternal(node)
+        return node.value
     }
 
     /**

--- a/yorkie/src/test/kotlin/dev/yorkie/util/SplayTreeSetTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/util/SplayTreeSetTest.kt
@@ -1,6 +1,8 @@
 package dev.yorkie.util
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
 
@@ -35,8 +37,48 @@ class SplayTreeSetTest {
         assertEquals(5, target.indexOf(Node("C234")))
         assertEquals(9, target.indexOf(Node("D2345")))
 
-        assertEquals(SplayTreeSet.ValueToOffset.Empty, target.find(-1))
+        assertEquals(SplayTreeSet.ValueToOffset.Empty, target.findForText(-1))
         assertEquals(14, target.length)
+    }
+
+    @Test
+    fun `findForArray returns element at index and throws when out of range`() {
+        // given: array-style SplayTreeSet where removed nodes contribute length 0
+        val arrayTarget = SplayTreeSet<Node> {
+            if (it.isRemoved) 0 else 1
+        }
+
+        // when: empty tree — findForArray returns null
+        assertNull(arrayTarget.findForArray(0))
+
+        // given: four inserted nodes
+        val a = Node("A").also(arrayTarget::insert)
+        val b = Node("B").also(arrayTarget::insert)
+        val c = Node("C").also(arrayTarget::insert)
+        val d = Node("D").also(arrayTarget::insert)
+        assertEquals(4, arrayTarget.length)
+
+        // then: each index maps to the correct element
+        assertEquals(a, arrayTarget.findForArray(0))
+        assertEquals(b, arrayTarget.findForArray(1))
+        assertEquals(c, arrayTarget.findForArray(2))
+        assertEquals(d, arrayTarget.findForArray(3))
+
+        // when: B is marked removed and splayed — length shrinks, findForArray skips it
+        b.isRemoved = true
+        arrayTarget.splay(b)
+        assertEquals(3, arrayTarget.length)
+        assertEquals(a, arrayTarget.findForArray(0))
+        assertEquals(c, arrayTarget.findForArray(1))
+        assertEquals(d, arrayTarget.findForArray(2))
+
+        // then: out-of-range throws
+        assertThrows(IndexOutOfBoundsException::class.java) {
+            arrayTarget.findForArray(3)
+        }
+        assertThrows(IndexOutOfBoundsException::class.java) {
+            arrayTarget.findForArray(-1)
+        }
     }
 
     @Test


### PR DESCRIPTION
> **RTCOLLABPLATFORM-645**: [[Android] [A9] Fix SplayTree.Find semantics for CRDT Array](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-645)
>
> Sync-up task **A9** in the [Yorkie Android ⇄ JS sync-up roadmap](https://wiki.navercorp.com/pages/viewpage.action?pageId=5131863864). Ports JS SDK PR [yorkie-team/yorkie-js-sdk#1150](https://github.com/yorkie-team/yorkie-js-sdk/pull/1150).

## Summary
- Text uses cursor positions that may land between characters; Array uses index positions that must resolve to a non-removed element.
- The single `find()` signature forced `RgaTreeList.getByIndex()` to walk past removed next-nodes after indexing — expensive after bulk deletion and can yield a removed node or `offset == 1` when max length is 1.

## Changes
- `yorkie/src/main/kotlin/dev/yorkie/util/SplayTreeSet.kt`
  - Rename `find` → `findForText` (cursor semantics, unchanged).
  - Add `findForArray(idx): V?` — skips removed nodes via `weight = 0` and throws `IndexOutOfBoundsException` on out-of-range.
- `yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeList.kt` — `getByIndex` delegates to `findForArray`; drop the next-hop loop.
- `yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeSplit.kt` — `indexToPos` calls `findForText`.
- `yorkie/src/test/kotlin/dev/yorkie/util/SplayTreeSetTest.kt` — rename existing assertion to `findForText(-1)`; add new test covering insert / splay-after-remove / out-of-range for `findForArray`.

## Test plan
- [x] New `findForArray` test passes; existing `SplayTreeSetTest` still green.
- [x] Full `./gradlew yorkie:testDebugUnitTest` green (no regressions across converters, RGA, CRDT).
- [x] `./gradlew lintKotlin` clean.
- [x] `./gradlew yorkie:connectedDebugAndroidTest` green (275 tests, 2 pre-existing skips) on Pixel_6_API_33 against local Yorkie Docker server.

> Items run automatically by CI (lint, unit tests, coverage) are excluded.