### PR TITLE
Retain peer presence across watch-stream reconnections

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/presence/DocPresenceTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/presence/DocPresenceTest.kt
@@ -880,6 +880,89 @@ class DocPresenceTest {
     }
 
     @Test
+    fun test_peer_presence_retained_across_watch_stream_reconnection() {
+        runBlocking {
+            val c1 = createClient()
+            val c2 = createClient()
+            val key = UUID.randomUUID().toString().toDocKey()
+            val d1 = Document(key)
+            val d2 = Document(key)
+
+            c1.activateAsync().await()
+            c2.activateAsync().await()
+
+            c1.attachDocument(d1, initialPresence = mapOf("name" to "a")).await()
+
+            val d1PresenceEvents = mutableListOf<Others>()
+            val d1ConnectionEvents = mutableListOf<StreamConnectionChanged>()
+            val jobs = listOf(
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    d1.events.filterIsInstance<Others>().collect(d1PresenceEvents::add)
+                },
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    d1.events.filterIsInstance<StreamConnectionChanged>()
+                        .collect(d1ConnectionEvents::add)
+                },
+            )
+
+            // given: c2 joins and c1 observes c2's Watched event
+            c2.attachDocument(d2, initialPresence = mapOf("name" to "b")).await()
+            withTimeout(GENERAL_TIMEOUT) {
+                while (d1PresenceEvents.none { it is Others.Watched }) {
+                    delay(50)
+                }
+            }
+            assertEquals(
+                Others.Watched(PresenceInfo(c2.requireClientId(), mapOf("name" to "b"))),
+                d1PresenceEvents.last { it is Others.Watched },
+            )
+
+            // when: c1 drops its watch stream
+            c1.changeSyncMode(d1, Manual)
+            withTimeout(GENERAL_TIMEOUT) {
+                while (d1ConnectionEvents.none { it is StreamConnectionChanged.Disconnected }) {
+                    delay(50)
+                }
+            }
+
+            // then: c2's presence is filtered out of d1.presences, but retained in allPresences
+            assertNull(d1.presences.value[c2.requireClientId()])
+            assertEquals(
+                mapOf("name" to "b"),
+                d1.allPresences.value[c2.requireClientId()],
+            )
+
+            // when: c1 reopens its watch stream
+            c1.changeSyncMode(d1, Realtime)
+            withTimeout(GENERAL_TIMEOUT) {
+                while (d1.presences.value[c2.requireClientId()] == null) {
+                    delay(50)
+                }
+            }
+
+            // then: c2's presence is visible again through the retained allPresences map
+            assertEquals(
+                mapOf("name" to "b"),
+                d1.presences.value[c2.requireClientId()],
+            )
+            assertEquals(
+                mapOf("name" to "b"),
+                d1.allPresences.value[c2.requireClientId()],
+            )
+
+            jobs.forEach(Job::cancel)
+            c1.detachDocument(d1).await()
+            c2.detachDocument(d2).await()
+            c1.deactivateAsync().await()
+            c2.deactivateAsync().await()
+            c1.close()
+            c2.close()
+            d1.close()
+            d2.close()
+        }
+    }
+
+    @Test
     fun test_whether_presence_event_queue_is_empty_after_consecutive_presence_changes() {
         withTwoClientsAndDocuments { c1, _, d1, d2, _ ->
             val d1PresenceEvents = mutableListOf<MyPresence.PresenceChanged>()


### PR DESCRIPTION
> **RTCOLLABPLATFORM-646**: [[Android] [A10] Retain peer presence across watch-stream reconnections](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-646)

Sync-up task A10 from the [Yorkie JS→Android roadmap](https://wiki.navercorp.com/pages/viewpage.action?pageId=5131863864). Ports the regression test from Yorkie JS PR [#1186](https://github.com/yorkie-team/yorkie-js-sdk/pull/1186) "Retain peer presence across watch stream reconnections".

## Summary
- JS bug root cause: `applyWatchInit` pruned `presences` for any client absent from the server's new watcher list. When that peer later sent `DOCUMENT_WATCHED`, `hasPresence()` returned false and the watched event was dropped, making the peer silently invisible.
- **The Android SDK does not reproduce this bug.** `Document.setOnlineClients` only mutates the `onlineClients` set; `_presences` is never pruned on watch init or disconnect. `Client.handleWatchDocumentResponse` also never touches presences when handling Initialization. The `DOCUMENT_WATCHED` handler at `Client.kt:553` looks up `document.allPresences.value[publisher]` (the raw map), so retained presences are found and `Others.Watched` fires correctly.
- This PR adds a regression test to guard that invariant.

## Changes
- New instrumented test `test_peer_presence_retained_across_watch_stream_reconnection` in `DocPresenceTest.kt`:
  - c1 and c2 attach with presence; c1 observes c2's `Watched` event.
  - c1 flips to Manual sync, closing its watch stream; waits for `Disconnected`.
  - Asserts c2's presence is filtered out of `d1.presences` but retained in `d1.allPresences`.
  - c1 flips back to Realtime sync, reopening its watch stream.
  - Asserts c2's presence is visible again in both `d1.presences` and `d1.allPresences`.

## Test plan
- [ ] Verify the new test is green locally (`yorkie:connectedDebugAndroidTest --tests dev.yorkie.document.presence.DocPresenceTest#test_peer_presence_retained_across_watch_stream_reconnection`).

> Items run automatically by CI (lint, unit tests, coverage) are excluded.