### PR TITLE
Return unwrapped primitive values from Array iterator

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonArray.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonArray.kt
@@ -320,6 +320,14 @@ public class JsonArray internal constructor(
         return JsonArrayIterator(context, target)
     }
 
+    /**
+     * Returns an iterator over wrapped [JsonElement] entries, exposing CRDT
+     * metadata via [JsonElement.id] and the typed subclass ([JsonPrimitive],
+     * [JsonObject], [JsonArray], [JsonText], [JsonCounter], [JsonTree]).
+     * Mirrors the JS SDK's `elements()` method added in PR #1178.
+     */
+    public fun elements(): Iterator<JsonElement> = iterator()
+
     private class JsonArrayIterator(
         private val context: ChangeContext,
         target: CrdtArray,

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonArrayTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonArrayTest.kt
@@ -185,6 +185,25 @@ class JsonArrayTest {
     }
 
     @Test
+    fun `elements returns wrapped JsonElement entries in array order`() {
+        // given: primitives and a nested object mixed in one array
+        target.apply {
+            put(1)
+            put("two")
+            putNewObject().set("k", "v")
+        }
+
+        // when
+        val elements = target.elements().asSequence().toList()
+
+        // then: each yielded entry is the typed wrapper, in insertion order
+        assertEquals(3, elements.size)
+        assertEquals(1, assertIs<JsonPrimitive>(elements[0]).value)
+        assertEquals("two", assertIs<JsonPrimitive>(elements[1]).value)
+        assertIs<JsonObject>(elements[2])
+    }
+
+    @Test
     fun `should return requested type with getAs`() {
         target.put(0)
         val get = assertIs<JsonPrimitive>(target[0])


### PR DESCRIPTION
> **RTCOLLABPLATFORM-664**: [[Android] [D3] Return unwrapped primitive values from Array iterator](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-664)

Sync-up task D3 from the [Yorkie JS→Android roadmap](https://wiki.navercorp.com/pages/viewpage.action?pageId=5131863864). Ports the API-parity portion of Yorkie JS PR [#1178](https://github.com/yorkie-team/yorkie-js-sdk/pull/1178) "Return unwrapped primitive values from Array iterator".

## Summary
- JS change: the default `for..of` iterator on `JSONArray` now yields raw primitive values (via `toJSONElement`) instead of `WrappedElement`; a new `elements()` method exposes the wrapped form (via `toWrappedElement`).
- Kotlin equivalent: `JsonArray` already implements `Collection<JsonElement>`, so the default iterator yields strongly-typed `JsonElement` wrappers (`JsonPrimitive`, `JsonObject`, etc.). Changing that semantic would drop `Collection<JsonElement>` — a breaking change that would break the example apps (e.g. `todos.filterIsInstance<JsonObject>()` in `TodoViewModel.kt`).
- This PR adds `JsonArray.elements()` as an explicit entry point that mirrors the JS API and returns `Iterator<JsonElement>`. No production behavior change, no contract break.

## Changes
- `yorkie/src/main/kotlin/dev/yorkie/document/json/JsonArray.kt`: add public `elements(): Iterator<JsonElement>`.
- `yorkie/src/test/kotlin/dev/yorkie/document/json/JsonArrayTest.kt`: add unit test covering mixed primitive + structural iteration order.

## Test plan
- [ ] Smoke-check that existing examples still compile and iterate (`todomvc`, `scheduler`).

> Items run automatically by CI (lint, unit tests, coverage) are excluded.