### PR TITLE
Document-key retrieval via intent extra in example apps

### DIFF
--- a/examples/scheduler/src/main/java/dev/yorkie/example/scheduler/MainActivity.kt
+++ b/examples/scheduler/src/main/java/dev/yorkie/example/scheduler/MainActivity.kt
@@ -18,6 +18,10 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        // Matches JS example behaviour (Yorkie JS PR #1108): if the launcher
+        // provides a "key" extra (e.g. `adb shell am start ... --es key my-room`),
+        // skip the Enter-Document-Key screen and open that document directly.
+        val initialDocumentKey = intent?.getStringExtra(EXTRA_DOCUMENT_KEY)
         setContent {
             SchedulerTheme {
                 Surface(
@@ -27,9 +31,16 @@ class MainActivity : ComponentActivity() {
                         .navigationBarsPadding(),
                     color = MaterialTheme.colors.background,
                 ) {
-                    SchedulerAppHost(navController = rememberNavController())
+                    SchedulerAppHost(
+                        navController = rememberNavController(),
+                        initialDocumentKey = initialDocumentKey,
+                    )
                 }
             }
         }
+    }
+
+    companion object {
+        private const val EXTRA_DOCUMENT_KEY = "key"
     }
 }

--- a/examples/scheduler/src/main/java/dev/yorkie/example/scheduler/ui/SchedulerAppHost.kt
+++ b/examples/scheduler/src/main/java/dev/yorkie/example/scheduler/ui/SchedulerAppHost.kt
@@ -5,14 +5,22 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import dev.yorkie.example.feature.enterdocumentkey.navigation.ENTER_DOCUMENT_KEY_ROUTE
 import dev.yorkie.example.feature.enterdocumentkey.navigation.enterDocumentKeyScreen
+import dev.yorkie.example.scheduler.ui.scheduler.navigation.SCHEDULER_BASE_ROUTE
 import dev.yorkie.example.scheduler.ui.scheduler.navigation.navigateToScheduler
 import dev.yorkie.example.scheduler.ui.scheduler.navigation.schedulerScreen
+import java.net.URLEncoder
+import kotlin.text.Charsets.UTF_8
 
 @Composable
-fun SchedulerAppHost(navController: NavHostController) {
+fun SchedulerAppHost(navController: NavHostController, initialDocumentKey: String? = null) {
+    val startDestination = if (initialDocumentKey != null) {
+        "$SCHEDULER_BASE_ROUTE?documentKey=${URLEncoder.encode(initialDocumentKey, UTF_8.name())}"
+    } else {
+        ENTER_DOCUMENT_KEY_ROUTE
+    }
     NavHost(
         navController = navController,
-        startDestination = ENTER_DOCUMENT_KEY_ROUTE,
+        startDestination = startDestination,
     ) {
         enterDocumentKeyScreen(
             onNextClick = {

--- a/examples/todomvc/src/main/java/dev/yorkie/example/todomvc/MainActivity.kt
+++ b/examples/todomvc/src/main/java/dev/yorkie/example/todomvc/MainActivity.kt
@@ -18,6 +18,10 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        // Matches JS example behaviour (Yorkie JS PR #1108): if the launcher
+        // provides a "key" extra (e.g. `adb shell am start ... --es key my-room`),
+        // skip the Enter-Document-Key screen and open that document directly.
+        val initialDocumentKey = intent?.getStringExtra(EXTRA_DOCUMENT_KEY)
         setContent {
             TodoMVCTheme {
                 Surface(
@@ -27,9 +31,16 @@ class MainActivity : ComponentActivity() {
                         .navigationBarsPadding(),
                     color = MaterialTheme.colors.background,
                 ) {
-                    TodoAppHost(navController = rememberNavController())
+                    TodoAppHost(
+                        navController = rememberNavController(),
+                        initialDocumentKey = initialDocumentKey,
+                    )
                 }
             }
         }
+    }
+
+    companion object {
+        private const val EXTRA_DOCUMENT_KEY = "key"
     }
 }

--- a/examples/todomvc/src/main/java/dev/yorkie/example/todomvc/ui/TodoAppHost.kt
+++ b/examples/todomvc/src/main/java/dev/yorkie/example/todomvc/ui/TodoAppHost.kt
@@ -5,14 +5,22 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import dev.yorkie.example.feature.enterdocumentkey.navigation.ENTER_DOCUMENT_KEY_ROUTE
 import dev.yorkie.example.feature.enterdocumentkey.navigation.enterDocumentKeyScreen
+import dev.yorkie.example.todomvc.ui.todo.navigation.TODO_BASE_ROUTE
 import dev.yorkie.example.todomvc.ui.todo.navigation.navigateToTodo
 import dev.yorkie.example.todomvc.ui.todo.navigation.todoScreen
+import java.net.URLEncoder
+import kotlin.text.Charsets.UTF_8
 
 @Composable
-fun TodoAppHost(navController: NavHostController) {
+fun TodoAppHost(navController: NavHostController, initialDocumentKey: String? = null) {
+    val startDestination = if (initialDocumentKey != null) {
+        "$TODO_BASE_ROUTE?documentKey=${URLEncoder.encode(initialDocumentKey, UTF_8.name())}"
+    } else {
+        ENTER_DOCUMENT_KEY_ROUTE
+    }
     NavHost(
         navController = navController,
-        startDestination = ENTER_DOCUMENT_KEY_ROUTE,
+        startDestination = startDestination,
     ) {
         enterDocumentKeyScreen(
             onNextClick = {


### PR DESCRIPTION
> **RTCOLLABPLATFORM-665**: [[Android] [D4] Document-key retrieval via query string](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-665)

Sync-up task D4 from the [Yorkie JS→Android roadmap](https://wiki.navercorp.com/pages/viewpage.action?pageId=5131863864). Ports the example-app change from Yorkie JS PR [#1108](https://github.com/yorkie-team/yorkie-js-sdk/pull/1108) "Add document key retrieval to use query string".

## Summary
- JS change was example-only: `react-todomvc` and `vanilla-quill` examples read `?key=<value>` from `window.location.search` so users can join a shared document by URL.
- Android equivalent: the `todomvc` and `scheduler` sample apps now read `intent.getStringExtra("key")` in the launcher `MainActivity`. When the extra is present, the `NavHost` starts directly on the todo/scheduler screen with that document key and skips the Enter-Document-Key screen. Without the extra, the default flow (Enter-Document-Key screen) is unchanged.
- URL query strings aren't idiomatic on Android, so the intent extra is the natural analog — launchers, tests, and `adb` can all supply it.

## Changes
- `examples/todomvc/.../MainActivity.kt`: read `"key"` intent extra and forward to `TodoAppHost`.
- `examples/todomvc/.../ui/TodoAppHost.kt`: accept optional `initialDocumentKey`; compute `startDestination` accordingly.
- `examples/scheduler/.../MainActivity.kt`: mirror the above for the scheduler example.
- `examples/scheduler/.../ui/SchedulerAppHost.kt`: mirror the above.

## Test plan
- [ ] Install todomvc, run `adb shell am start -n dev.yorkie.example.todomvc/.MainActivity --es key my-room` → app opens the todo screen directly.
- [ ] Install todomvc, run without `--es key` → app opens the Enter-Document-Key screen (default behaviour).
- [ ] Same two checks for `scheduler`.

> Items run automatically by CI (lint, unit tests, coverage) are excluded. Manually verified both flows on Pixel_6_API_33.