### PR TITLE
Cancel-watch-stream regression test

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -280,6 +280,88 @@ class ClientTest {
     }
 
     @Test
+    fun test_should_cancel_watch_stream_when_changing_to_manual_sync_mode() {
+        // Port of Yorkie JS PR #1105. Verifies that changing a client from
+        // Realtime to Manual sync mode closes the watch stream: peers observe
+        // Others.Unwatched, remote updates are no longer auto-delivered, and
+        // a manual sync is still able to fetch them.
+        runBlocking {
+            val c1 = createClient()
+            val c2 = createClient()
+            val key = UUID.randomUUID().toString().toDocKey()
+            val d1 = Document(key)
+            val d2 = Document(key)
+
+            c1.activateAsync().await()
+            c2.activateAsync().await()
+
+            c1.attachDocument(d1).await()
+            c2.attachDocument(d2).await()
+
+            val d1RemoteChanges = mutableListOf<RemoteChange>()
+            val d2PresenceEvents = mutableListOf<Document.Event.PresenceChanged.Others>()
+            val jobs = listOf(
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    d1.events.filterIsInstance<RemoteChange>().collect(d1RemoteChanges::add)
+                },
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    d2.events
+                        .filterIsInstance<Document.Event.PresenceChanged.Others>()
+                        .collect(d2PresenceEvents::add)
+                },
+            )
+
+            // given: initial sync works — d1 receives a RemoteChange from d2
+            d2.updateAsync { root, _ ->
+                root["version"] = "v1"
+            }.await()
+            withTimeout(GENERAL_TIMEOUT) {
+                while (d1RemoteChanges.isEmpty()) {
+                    delay(50)
+                }
+            }
+            assertJsonContentEquals("""{"version":"v1"}""", d1.toJson())
+
+            // when: c1 switches to Manual — watch stream should cancel and
+            //       c2 should see an Unwatched event for c1
+            c1.changeSyncMode(d1, Manual)
+            withTimeout(GENERAL_TIMEOUT) {
+                while (
+                    d2PresenceEvents.none {
+                        it is Document.Event.PresenceChanged.Others.Unwatched &&
+                            it.changed.actorID == c1.requireClientId()
+                    }
+                ) {
+                    delay(50)
+                }
+            }
+
+            // then: c2's further update does not auto-deliver to c1
+            d1RemoteChanges.clear()
+            d2.updateAsync { root, _ ->
+                root["version"] = "v2"
+            }.await()
+            delay(1_000)
+            assertTrue(d1RemoteChanges.isEmpty())
+            assertJsonContentEquals("""{"version":"v1"}""", d1.toJson())
+
+            // then: manual sync still works
+            c1.syncAsync().await()
+            assertJsonContentEquals("""{"version":"v2"}""", d1.toJson())
+
+            jobs.forEach(Job::cancel)
+            c1.detachDocument(d1).await()
+            c2.detachDocument(d2).await()
+            c1.deactivateAsync().await()
+            c2.deactivateAsync().await()
+            d1.close()
+            d2.close()
+            c1.close()
+            c2.close()
+        }
+    }
+
+    @Test
     fun test_applying_previous_changes_after_switching_to_realtime() = runBlocking {
         val client1 = createClient()
         val client2 = createClient()


### PR DESCRIPTION
> **RTCOLLABPLATFORM-666**: [[Android] [D5] Cancel-watch-stream test + LLRB Floor nil-deref mirror](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-666)

Sync-up task D5 from the [Yorkie JS→Android roadmap](https://wiki.navercorp.com/pages/viewpage.action?pageId=5131863864). Ports the test addition from Yorkie JS PR [#1105](https://github.com/yorkie-team/yorkie-js-sdk/pull/1105) "Add cancel watch stream test". The companion PR [#1107](https://github.com/yorkie-team/yorkie-js-sdk/pull/1107) (LLRB Floor nil-deref fix) does **not** apply to Android — see below.

## Summary
- JS PR #1105 added an integration test asserting that flipping an attached client from Realtime → Manual sync (a) cancels the watch stream, (b) makes peers emit `Unwatched`, and (c) leaves manual `sync()` still functional.
- JS PR #1107 fixes a nil-pointer dereference in the SDK's custom LLRB tree's `floorEntry` when the requested key is smaller than all keys. Android doesn't have this code path: floor lookups use `java.util.TreeMap.floorEntry` (CrdtTree.kt:593, RgaTreeSplit.kt:137), which is safe for all inputs. No Android change is needed.

## Changes
- `yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt`: add `test_should_cancel_watch_stream_when_changing_to_manual_sync_mode` mirroring the JS scenario — two clients attach in realtime, c1 receives a remote change, c1 switches to Manual, verifies c2 observes `Others.Unwatched(c1)`, verifies subsequent c2 updates are no longer auto-delivered to c1, and verifies `c1.syncAsync()` still fetches them.

## Test plan
- [ ] `./gradlew yorkie:connectedDebugAndroidTest --tests "dev.yorkie.core.ClientTest.test_should_cancel_watch_stream_when_changing_to_manual_sync_mode"` passes on a running server.

> Items run automatically by CI (lint, unit tests, coverage) are excluded.