### PR TITLE
Fix tree style divergence on concurrent split via End-token guard

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -101,6 +101,13 @@ internal data class CrdtTree(
             val clientLamportAtChange = getClientInfoForChange(actorID, versionVector)
 
             if (node.canStyle(executedAt, clientLamportAtChange) && attributes != null) {
+                if (tokenType == TokenType.End &&
+                    versionVector != null &&
+                    hasUnknownSplitSibling(node, versionVector)
+                ) {
+                    return@traverseInPosRange
+                }
+
                 val parentOfNode = requireNotNull(node.parent)
                 val previousNode = node.prevSibling ?: parentOfNode
 
@@ -484,7 +491,7 @@ internal data class CrdtTree(
 
         val changes = mutableListOf<TreeChange>()
         val gcPairs = mutableListOf<GCPair<RhtNode>>()
-        traverseInPosRange(fromParent, fromLeft, toParent, toLeft) { (node, _), _ ->
+        traverseInPosRange(fromParent, fromLeft, toParent, toLeft) { (node, tokenType), _ ->
             val actorID = node.createdAt.actorID
             val clientLamportAtChange = getClientInfoForChange(actorID, versionVector)
 
@@ -493,6 +500,13 @@ internal data class CrdtTree(
                     clientLamportAtChange,
                 ) && attributeToRemove.isNotEmpty()
             ) {
+                if (tokenType == TokenType.End &&
+                    versionVector != null &&
+                    hasUnknownSplitSibling(node, versionVector)
+                ) {
+                    return@traverseInPosRange
+                }
+
                 attributeToRemove.forEach { key ->
                     node.removeAttribute(key, executedAt)
                         .map { rhtNode -> GCPair(node, rhtNode) }
@@ -592,6 +606,27 @@ internal data class CrdtTree(
     fun findFloorNode(id: CrdtTreeNodeID): CrdtTreeNode? {
         val (key, value) = nodeMapByID.floorEntry(id) ?: return null
         return value.takeIf { key.createdAt == id.createdAt }
+    }
+
+    /**
+     * Checks whether [node] has a split sibling (via [CrdtTreeNode.insNextID])
+     * whose creation the editor did not know about. Prevents styling via End
+     * tokens when a concurrent split extended the range into the split sibling.
+     *
+     * Unlike a traversal-advance helper, intentionally omits the parent-equality
+     * check: in multi-level splits the sibling may have been moved to a
+     * different parent by the recursive ancestor split. The End-token guard
+     * must still fire because the node WAS split — [CrdtTreeNode.insNextID]
+     * is only set by SplitElement.
+     */
+    private fun hasUnknownSplitSibling(node: CrdtTreeNode, versionVector: VersionVector): Boolean {
+        val insNextID = node.insNextID ?: return false
+        val next = findFloorNode(insNextID) ?: return false
+        if (next.isText) return false
+
+        val actorID = next.id.createdAt.actorID
+        val knownLamport = versionVector.get(actorID)
+        return knownLamport == null || knownLamport < next.id.createdAt.lamport
     }
 
     fun checkPosRangeValid(posRange: TreePosRange): Boolean {


### PR DESCRIPTION
> **RTCOLLABPLATFORM-643**: [[Android] [A7] Fix tree style divergence on concurrent split via End-token guard](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-643)

## Summary
- Sync-up task **A7** from the Yorkie JS→Android [roadmap](https://wiki.navercorp.com/pages/viewpage.action?pageId=5131863864).
- Ports JS [#1211](https://github.com/yorkie-team/yorkie-js-sdk/pull/1211) (mirrors Go Fix 11, [yorkie-team/yorkie#1731](https://github.com/yorkie-team/yorkie/pull/1731)).
- Prevents tree-style divergence when one replica styles a range whose `End` token lies on an element that another replica concurrently split.

## Changes
- `CrdtTree.hasUnknownSplitSibling(node, versionVector)` — returns `true` when `node.insNextID` resolves to an element whose creation lamport is unknown in the caller's version vector.
- `CrdtTree.style()` and `CrdtTree.removeStyle()` now early-return inside the `canStyle(...)` block when the current token is an `End` token, a version vector is supplied, and the node has an unknown split sibling.
- `removeStyle()` captures `tokenType` from the traversal (previously discarded) to apply the guard.
- Intentionally omits the parent-equality check used by JS's `advancePastUnknownSplitSiblings`: multi-level splits relocate the sibling, but `insNextID` is only set by `SplitElement`, so the guard must still fire.
- Fix-only port — JS PR #1211 added no tests; convergence is covered by the server-side integration suite. Full `JsonTreeConcurrencyTest`, `JsonTreeTest`, and `JsonTreeSplitMergeTest` still pass.

## Test plan
- [ ] Instrumented: `./gradlew yorkie:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.yorkie.document.json.JsonTreeConcurrencyTest` passes on Pixel_6_API_33 (5 passed; 2 pre-existing skips for split-split/split-edit unrelated to this change).
- [ ] `JsonTreeTest` + `JsonTreeSplitMergeTest` full suite (74/74) passes.

> Items run automatically by CI (lint, unit tests, coverage) are excluded.