### PR TITLE
chore: adopt harness engineering scaffolding (specs, round reports, arch-lint, verify lanes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,10 @@ captures/
 *.ipr
 .claude/settings.local.json
 docs/superpowers/
+
+# Harness engineering
+.worktrees/
+docs/round-reports/
+# Track .work/state.json (default idle state) but ignore anything else placed there
+.work/*
+!.work/state.json

--- a/.work/state.json
+++ b/.work/state.json
@@ -1,0 +1,10 @@
+{
+  "phase": "idle",
+  "active_ticket": null,
+  "session_count": 0,
+  "current_round": 0,
+  "last_round_outcome": null,
+  "completed_features": [],
+  "last_session": null,
+  "stop_requested": false
+}

--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -1,0 +1,133 @@
+# CLAUDE.local.md — Harness Engineering
+
+This file supplements the team's `CLAUDE.md`. It is the agent's entry point for harness-driven work (specs → exec-plans → rounds → evaluator). Do NOT copy its rules into `CLAUDE.md`.
+
+## Stack Summary
+
+- Language: Kotlin 1.9.24 (JDK 17)
+- Build: Gradle (Kotlin DSL) + `gradle/libs.versions.toml` + `build-logic/convention/`
+- Android Gradle Plugin: 8.9.1
+- Lint/Format: kotlinter (ktlint wrapper) + Android Lint
+- Test: JUnit 4 + MockK + kotlinx-coroutines-test (unit); AndroidX Test + Espresso (instrumented)
+- Coverage: JaCoCo
+- RPC/Proto: Connect-Kotlin (gRPC) + buf plugin (protobuf-javalite)
+
+## Key Commands
+
+```bash
+./gradlew yorkie:testDebugUnitTest            # Unit tests (JVM)
+./gradlew yorkie:connectedDebugAndroidTest    # Instrumented tests (needs Yorkie server)
+./gradlew lintKotlin                          # Kotlin lint (ktlint)
+./gradlew formatKotlin                        # Format
+./gradlew lint                                # Android lint
+./gradlew yorkie:jacocoDebugTestReport        # Coverage
+./gradlew build                               # Full build
+bash scripts/verify.sh fast                   # lintKotlin + architecture lint
+bash scripts/verify.sh full                   # fast + Android lint + unit tests + coverage
+bash scripts/verify.sh session                # full + harness_check
+bash scripts/init_check.sh                    # Smoke test: env, gradle, docker
+docker compose -f docker/docker-compose.yml up --build -d  # Yorkie server for integration tests
+./scripts/config-yorkie-local-server.sh       # Write YORKIE_SERVER_URL to local.properties
+```
+
+## Architecture (enforced)
+
+Two-layer API inside `yorkie/src/main/kotlin/dev/yorkie/`:
+
+```
+yorkie/src/main/kotlin/dev/yorkie/
+├── api/           # Protobuf converters (ChangeConverter, OperationConverter, ElementConverter, ...)
+├── core/          # Client, sync loop, watch stream
+├── document/
+│   ├── crdt/      # INTERNAL CRDT implementations — never exposed
+│   ├── json/      # PUBLIC JSON API wrappers (JsonObject, JsonArray, JsonText, JsonTree)
+│   ├── operation/ # Operations (add, move, remove, edit, style, ...)
+│   ├── change/    # Change, ChangeID, ChangePack
+│   ├── time/      # TimeTicket, VersionVector
+│   └── presence/  # Presence system
+└── util/          # IndexTree, SplayTree, logging, ...
+```
+
+**Dependency rules (enforced by `scripts/lint_architecture.sh`):**
+- `document/crdt/**` MUST NOT import `document/json/**` (CRDT is internal; JSON is public)
+- `yorkie/` MUST NOT import `examples/**` or `microbenchmark/**`
+- No `println`, `System.out`, `System.err` in `yorkie/src/main/**` (use Timber if logging is needed)
+- Max 300 lines per Kotlin source file in `yorkie/src/main/kotlin/**` (excluding generated)
+
+When adding a data operation: CRDT in `document/crdt/` → public wrapper in `document/json/` → `Operation` in `document/operation/` → proto converters in `api/OperationConverter.kt` + `api/ElementConverter.kt`.
+
+## Documentation Map
+
+| Document | Description |
+|----------|-------------|
+| `CLAUDE.md` | Team-owned project overview (do not edit here) |
+| `CLAUDE.local.md` | Harness-specific agent instructions (this file) |
+| `docs/ARCHITECTURE.md` | Layer rules, dependency direction, module boundaries |
+| `docs/GOLDEN_PRINCIPLES.md` | Enforced code-hygiene rules for agents |
+| `docs/specs/` | Feature specs (spec-driven development) |
+| `docs/specs/backlog/` | Specs not yet promoted to active |
+| `docs/exec-plans/active/` | In-progress exec-plans |
+| `docs/exec-plans/completed/` | Archived exec-plans |
+| `docs/round-reports/` | Build/QA/fix/improvements per round |
+| `docs/progress.md` | Session-to-session handoff |
+| `docs/lessons.md` | Patterns, anti-patterns, decisions |
+| `.work/state.json` | Work state — owned by `/harness work` |
+
+## Coding Conventions
+
+1. Public API is only `dev.yorkie.core.Client`, `dev.yorkie.document.Document`, and the `dev.yorkie.document.json.*` types. Internal CRDT types MUST NOT appear in a public signature.
+2. Use structured logging via `dev.yorkie.util.YorkieLogger` (or Timber in examples). No `println`, `System.out`, `System.err` in production code.
+3. All external/network data validated at the `api/*Converter.kt` boundary — never trust proto fields downstream.
+4. File size limit: 300 lines per Kotlin source file. Split when exceeded.
+5. Concurrency: every `Client`/`Document` pair uses a dedicated single-threaded coroutine dispatcher — do not share dispatchers across pairs, do not block on them.
+6. Test conventions: MockK for mocking, `CoroutineRule` for coroutine tests, JUnit 4, English backtick method names, Given-When-Then bodies.
+
+## Session Start Ritual
+
+1. Read `docs/progress.md` (what was done last session, what's next)
+2. Read `docs/lessons.md` (patterns / anti-patterns / decisions)
+3. Check `docs/exec-plans/active/` — resume active work if any
+4. Run `bash scripts/init_check.sh` to verify env (JDK 17, gradlew, docker, local.properties)
+
+## Session End Ritual
+
+1. Run `bash scripts/verify.sh full` — must be clean
+2. Update checkpoint in the active exec-plan
+3. Update `docs/progress.md`
+4. Capture new patterns/anti-patterns in `docs/lessons.md`
+5. Run `bash scripts/harness_check.sh`
+6. Commit all changes (see `.claude/rules/git-workflow.md` for branch/commit format)
+
+## Pre-Implementation Gate (HARD RULE)
+
+Before writing ANY code, verify:
+1. `docs/exec-plans/active/` has tickets for the current work
+2. `.work/state.json` shows `phase: "executing"` with an `active_ticket`
+3. A spec exists in `docs/specs/` for the feature being built
+
+If any condition is missing — STOP and create it first. If it gets a git commit, it gets a ticket.
+
+## Work Lifecycle
+
+```
+Spec → Exec-Plan → Tickets → [Pick → Implement → Test → Verify DoD] → Complete
+  ↑                                                                       │
+  └── Discovery? Update spec first ←──────────────────────────────────────┘
+```
+
+- Spec states: `backlog/` → `docs/specs/` (active) → deprecated
+- Ticket states: `todo` → `in_progress` → `done` | `blocked`
+- 3 failures on the same ticket → mark blocked, escalate to user
+
+## Definition of Done (every ticket)
+
+- [ ] `./gradlew yorkie:testDebugUnitTest` passes
+- [ ] `./gradlew lintKotlin` clean (and `./gradlew lint` for Android lint)
+- [ ] `bash scripts/lint_architecture.sh` clean
+- [ ] Implementation matches spec in `docs/specs/`
+- [ ] For sync/watch/CRDT changes: corresponding instrumented test added or updated in `yorkie/src/androidTest/`
+- [ ] Evidence captured in the exec-plan ticket
+
+## Harness Directive
+
+Use `/harness` for all feature work — specs, planning, implementation, evaluation. Do not write code outside the harness work cycle unless the change is a trivial chore explicitly opted out of tracking.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,109 @@
+# Architecture — yorkie-android-sdk
+
+Android Kotlin SDK for Yorkie, a collaborative document store backed by CRDTs.
+
+## Modules
+
+| Path | Purpose | Publishable |
+|------|---------|-------------|
+| `yorkie/` | Main SDK library | **yes** (Maven artifact `dev.yorkie:yorkie`) |
+| `examples/todomvc` | TodoMVC sample app | no |
+| `examples/scheduler` | Scheduler sample app | no |
+| `examples/rich-text-editor` | Rich text editor sample | no |
+| `examples/simultaneous-cursors` | Cursor sharing sample | no |
+| `examples/core/common` | Shared sample code | no |
+| `examples/feature/enter-document-key` | Document-key entry screen | no |
+| `microbenchmark/` | JMH-style benchmarks | no |
+| `build-logic/convention/` | Shared Gradle convention plugins | no |
+
+Only `yorkie/` is published. Nothing in `yorkie/` may depend on `examples/**` or `microbenchmark/**`.
+
+## Layers Inside `yorkie/src/main/kotlin/dev/yorkie/`
+
+```
+api/              Protobuf ↔ domain converters (ChangeConverter, OperationConverter,
+                  ElementConverter, PresenceConverter, TimeConverter, ...)
+
+core/             Client (gRPC/Connect-RPC over OkHttp), sync loop, watch stream, auth
+
+document/
+├── Document.kt   Public document handle; updateAsync; change queue
+├── crdt/         INTERNAL CRDT data structures:
+│                   CrdtObject, CrdtArray, CrdtText, CrdtTree, ElementRht,
+│                   RgaTreeList, RgaTreeSplit, SplayTree, ...
+├── json/         PUBLIC user-facing wrappers:
+│                   JsonObject, JsonArray, JsonText, JsonTree, JsonCounter, ...
+├── operation/    Operations (Add, Move, Remove, Edit, Style, TreeEdit, ...)
+├── change/       Change, ChangeID, ChangePack, ChangeContext
+├── time/         TimeTicket (Lamport clock), VersionVector, ActorID
+├── history/      Undo/Redo history manager
+├── presence/     Presence (cursors, selections, custom metadata)
+└── schema/       JSON schema validation
+
+util/             IndexTree, SplayTree, SplayTreeSet, logging, ...
+```
+
+## Dependency Direction (enforced)
+
+**Rule 1 — Two-layer separation.** `document/crdt/**` MUST NOT import `document/json/**`. The JSON layer wraps the CRDT layer, never the other way around.
+
+```
+user code
+   │
+   ▼
+document/json/   ──────────────► document/crdt/   (json wraps crdt)
+        │                              ▲
+        └──► document/operation/ ──────┘
+                     │
+                     ▼
+               document/change/  ──► document/time/
+```
+
+**Rule 2 — No upward imports from utilities.** `util/**` must not import from `document/**`, `core/**`, or `api/**`.
+
+**Rule 3 — Protobuf is an I/O boundary.** Proto messages (generated under `yorkie/build/generated/`) are allowed in `api/*Converter.kt` and in `core/` (where the Connect-RPC Client is the other half of the I/O boundary). Pure domain code (`document/**`, `util/**`) MUST NOT reference proto types directly.
+
+**Rule 4 — Public API surface.** The only types intended for SDK consumers are:
+- `dev.yorkie.core.Client` and its public events
+- `dev.yorkie.document.Document` and its public events
+- `dev.yorkie.document.json.*` (JsonObject, JsonArray, JsonText, JsonTree, JsonCounter, JsonPrimitive)
+- `dev.yorkie.document.presence.*` (Presence, PresenceInfo)
+
+Anything in `document/crdt/`, `api/`, and most of `util/` is internal. A public signature must never return, accept, or expose a CRDT type.
+
+## Client–Document–Server Flow
+
+1. `Client.attachAsync(document)` — opens gRPC attachment, pulls initial snapshot.
+2. Local mutation: `Document.updateAsync { root -> ... }` — appends a `Change` to the local queue.
+3. `Client.runSyncLoop()` — push local `ChangePack` → pull remote `ChangePack` → apply to the CRDT root.
+4. `Client.watchStream` — streams remote changes and presence updates.
+5. Each `Client`/`Document` pair runs on a dedicated single-threaded coroutine dispatcher; all CRDT mutations happen on that dispatcher to avoid races.
+
+## Change Identity
+
+- `ChangeID` = (Lamport clock + `ActorID` + `ClientSeq` + `VersionVector`)
+- `TimeTicket` = the logical timestamp used to order CRDT operations
+- `VersionVector` encodes causal ordering across replicas
+
+## Test Surfaces
+
+- **Unit** (`yorkie/src/test/`) — JVM-only. CRDT logic, converters, utilities. MockK for `YorkieService`.
+- **Instrumented** (`yorkie/src/androidTest/`) — real Yorkie server over gRPC via Docker Compose. Authoritative for sync, presence, and schema validation.
+- **Benchmarks** (`microbenchmark/`) — hot-path performance.
+
+## External Dependencies
+
+- Connect-Kotlin (gRPC) + OkHttp for transport
+- protobuf-javalite (runtime) + buf plugin (codegen)
+- kotlinx-coroutines, kotlinx-collections-immutable, apache-commons-collections
+- Guava (shared with Connect-Kotlin)
+
+## Enforcement
+
+| Rule | Enforcement |
+|------|-------------|
+| Two-layer, module boundaries, forbidden patterns, file size | `scripts/lint_architecture.sh` |
+| Kotlin style | `./gradlew lintKotlin` (ktlint) |
+| Android lint | `./gradlew lint` |
+| Unit tests | `./gradlew yorkie:testDebugUnitTest` |
+| Integration | `./gradlew yorkie:connectedDebugAndroidTest` (needs docker-compose Yorkie server) |

--- a/docs/GOLDEN_PRINCIPLES.md
+++ b/docs/GOLDEN_PRINCIPLES.md
@@ -1,0 +1,77 @@
+# GOLDEN_PRINCIPLES.md — yorkie-android-sdk
+
+Rules for agents working in this codebase. All rules are enforced — not advisory.
+
+> **Note for evaluators (Stage 4):** When proposing harness improvements, append new rules under the `## Project Rules` or `## Evaluator-Discovered Rules` section. Do not modify the `## Core Rules` section.
+
+---
+
+## Core Rules (apply to every project)
+
+### File Size
+- **Max 300 lines per file.** If a file exceeds this, split it.
+  - Enforcement: `scripts/lint_architecture.sh` file size check
+  - Reason: Large files cause context overload and make the agent lose track of structure
+
+### Logging
+- **No `println`, `System.out`, or `System.err` in production code.** Use `dev.yorkie.util.YorkieLogger` (or Timber in examples).
+  - Enforcement: architecture linter forbidden-pattern check
+  - Reason: Unstructured output is invisible to observability tools
+
+### Validation
+- **All external data validated at entry points.** Proto messages are validated in `api/*Converter.kt`; never trust proto fields downstream.
+  - Enforcement: evaluator checks — converters validate before handing domain code
+  - Reason: Validation inside domain code = validation skipped when called internally
+
+### Error Handling
+- **No silent failures.** Every error is either thrown, returned via `Result`, or logged with context.
+  - Enforcement: evaluator adversarial tests (what happens when X fails?)
+  - Reason: Silent failures cause Stage 2 adversarial failures
+
+### Testing
+- **Tests written in the same round as the code.** No "I'll add tests later."
+  - Enforcement: evaluator auto-fails on Testing = 0
+  - Reason: Tests written after the fact optimize for the code that exists, not the spec
+
+### Spec Compliance
+- **Code matches the spec.** If implementation diverges, update the spec first.
+  - Enforcement: evaluator Stage 3 spec fidelity check
+  - Reason: Undocumented behavior is invisible to the next agent
+
+---
+
+## Project Rules
+
+### Architecture
+- **Two-layer rule.** `document/crdt/**` MUST NOT import `document/json/**`. CRDT is internal, JSON is public.
+- **No upward imports from `util/**`.** Utilities stay pure; they don't know about `document`, `core`, or `api`.
+- **Protobuf is an I/O boundary.** Proto types are allowed in `api/*Converter.kt` and in `core/**` (the Connect-RPC Client). Pure domain code (`document/**`, `util/**`) MUST NOT import generated proto classes.
+- **`yorkie/` never depends on `examples/**` or `microbenchmark/**`.**
+- Enforcement: `scripts/lint_architecture.sh`
+
+### Naming
+- Kotlin files: PascalCase matching the primary class (e.g., `CrdtObject.kt`, `JsonArray.kt`).
+- Unit test methods: English, backtick-quoted, Given-When-Then (e.g., `` `should push local change before pulling remote`()``).
+- Packages: lowercase, no underscores — `dev.yorkie.document.crdt`, `dev.yorkie.document.json`.
+
+### Stack-Specific
+- **Public API surface is fixed.** Only `Client`, `Document`, `JsonObject`, `JsonArray`, `JsonText`, `JsonTree`, `JsonCounter`, `JsonPrimitive`, and the `presence.*` types are intended for SDK consumers. A public signature must never return, accept, or expose a CRDT type.
+- **Concurrency discipline.** Each `Client`/`Document` pair has a single-threaded coroutine dispatcher; do not share dispatchers across pairs, do not block on them, do not touch CRDT state from another dispatcher.
+- **MockK for mocks, CoroutineRule for coroutines.** Do not introduce a second mocking or coroutine-test framework.
+- **CRDT invariants.** Changes to CRDT data structures require proof — instrumented tests for concurrent editing scenarios must accompany any fix in `document/crdt/**` (see `critic-reviewer` and `api-compat-checker` agents in `.claude/agents/`).
+- **Proto changes trigger converter updates.** Any modification under `yorkie/proto/yorkie/v1/` must be mirrored in `api/*Converter.kt` — enforced by the `protobuf-converter-checker` agent during review.
+
+---
+
+## Evaluator-Discovered Rules
+
+> Rules added here by Stage 4 harness improvement proposals.
+> Each rule includes: the bug it prevents, the round it was discovered, and the POC evidence.
+
+<!-- Stage 4 appends here. Format:
+### {rule name} (added round-{N}, {date})
+- **Rule:** {specific rule}
+- **Prevents:** {what bug or pattern this prevents}
+- **Evidence:** {what happened in round N that triggered this}
+- Enforcement: {how to verify — evaluator check, linter rule, etc.}
+-->

--- a/docs/exec-plans/_template.md
+++ b/docs/exec-plans/_template.md
@@ -1,0 +1,30 @@
+---
+id: NNN
+title: "{title}"
+status: todo
+priority: P1
+domain: "{domain}"
+layer: "{layer}"
+depends_on: []
+created: YYYY-MM-DD
+---
+
+# {title}
+
+## Description
+What this ticket accomplishes and why.
+
+## Scope
+- Domain: `yorkie/src/main/kotlin/dev/yorkie/{domain}/`
+- Layer: `{layer}`  (api | core | document/crdt | document/json | document/operation | document/change | document/time | document/presence | util)
+- Estimated effort: <2 hours
+
+## Success Metrics (DoD)
+- [ ] Unit tests pass
+- [ ] Instrumented tests pass if applicable
+- [ ] `./gradlew lintKotlin` clean
+- [ ] `bash scripts/lint_architecture.sh` clean
+- [ ] Implementation matches spec
+
+## Evidence
+(Filled after implementation)

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1,0 +1,16 @@
+# Lessons
+
+Patterns, anti-patterns, and decisions accumulated across sessions.
+Categorized for actionability: patterns (follow), anti-patterns (avoid), decisions (respect).
+
+The evaluator checks anti-patterns are not repeated in new code.
+
+---
+
+## 2026-04-21 — harness adopt
+
+- **Decision**: Architecture enforcement done in bash + ripgrep, not as a Gradle task — we don't want the linter to depend on a Gradle configuration phase, and the rules are simple enough for grep.
+- **Decision**: CRDT ↔ JSON separation is expressed as "R1" in `scripts/lint_architecture.sh`: `document/crdt/**` must not import `document/json/**`. Reversing this direction is never correct — the JSON layer wraps CRDT, not the other way round.
+- **Decision**: Generated proto types (`dev.yorkie.api.v1.*`) are only allowed in `api/*Converter.kt`. Leaking proto into `document/**`, `core/**`, or `util/**` breaks the "proto is an I/O boundary" contract and makes future proto refactors much more expensive.
+- **Pattern**: MockK + `CoroutineRule` + JUnit 4 + English backtick test names — existing `yorkie/src/test/` tests follow this; keep it consistent.
+- **Pattern**: Each `Client`/`Document` pair owns a single-threaded coroutine dispatcher. Never share dispatchers across pairs. Never block.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,0 +1,33 @@
+# Progress
+
+Session-to-session state handoff.
+
+## Last Session
+
+**Date**: 2026-04-21
+**Session**: harness adopt — generated CLAUDE.local.md, architecture lint, verify lanes, harness.config.json, work state, and docs scaffolding
+
+### Completed
+- `CLAUDE.local.md` — harness supplement to team `CLAUDE.md`
+- `docs/ARCHITECTURE.md` — explicit two-layer rule, module boundaries
+- `docs/GOLDEN_PRINCIPLES.md` — core + project-specific enforced rules
+- `docs/specs/_template.md`, `docs/exec-plans/_template.md`
+- `harness.config.json` — verify lanes, evaluator components (unit + instrumented)
+- `scripts/lint_architecture.sh` — R1..R6 checks (CRDT/JSON split, proto boundary, file size, etc.)
+- `scripts/verify.sh` — fast / full / entropy / session lanes
+- `scripts/init_check.sh` — env smoke test
+- `scripts/harness_check.sh`, `scripts/maintenance.sh`
+- `.work/state.json` — initialised at `phase: idle`
+
+### Next
+- Run `bash scripts/verify.sh fast` to confirm the architecture linter is clean against current code.
+- Write the first feature spec in `docs/specs/backlog/` (e.g., carry the peer-presence reconnect work from the current branch into an explicit spec).
+- Kick off `/harness work` on that spec.
+
+### Decisions Made
+- Architecture linter implemented as bash + ripgrep/grep (not a Kotlin/KSP AST tool) for zero build impact.
+- Unit and instrumented tests modelled as **two** evaluator components; instrumented requires `docker compose` + emulator.
+- `.claude/settings.local.json` was NOT modified — it already contains team permissions and a secret (`JIRA_PERSONAL_TOKEN`). No auto-format PostToolUse hook was added; `./gradlew formatKotlin` is expected before commits (per `.claude/rules/git-workflow.md`).
+
+### Blockers
+- None.

--- a/docs/specs-backlog.md
+++ b/docs/specs-backlog.md
@@ -1,0 +1,58 @@
+# Specs Backlog
+
+Non-blocker findings carried forward from prior sessions or from harness setup. `/harness plan` reads this file at its Step 0.5 before brainstorming.
+
+## Format
+
+```
+### {YYYY-MM-DD} — phase/source — {short title}
+
+**Source:** {where this came from, e.g. harness-adopt, round-2-qa.md §2b}
+**File:line:** {path:line if known}
+**Severity:** LOW | MEDIUM
+**Why deferred:** {time-box | scope | needs design | pre-existing}
+**Proposed action:** {fix | roll into next spec | watch}
+```
+
+---
+
+### 2026-04-21 — harness-adopt — CRDT layer imports JSON layer (R1)
+
+**Source:** `scripts/lint_architecture.sh` first run
+**File:line:**
+- `yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtElement.kt:3` — `JsonStringifier.toJsonString`
+- `yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt:8` — `TreePosStructRange`
+- `yorkie/src/main/kotlin/dev/yorkie/document/crdt/TextInfo.kt:3` — `escapeString`
+- `yorkie/src/main/kotlin/dev/yorkie/document/crdt/Rht.kt:3` — `escapeString`
+- `yorkie/src/main/kotlin/dev/yorkie/document/crdt/TreeInfo.kt:3` — `JsonTree`
+
+**Severity:** MEDIUM
+**Why deferred:** pre-existing; refactor crosses both layers and is worth its own spec
+**Proposed action:** write a spec to move `JsonStringifier.toJsonString`, `escapeString`, and `TreePosStructRange` into a lower layer (`util/` or `document/crdt/` itself) so CRDT no longer depends on JSON. `TreeInfo.kt` → rethink the `JsonTree` reference.
+
+### 2026-04-21 — harness-adopt — util imports document/time (R2)
+
+**Source:** `scripts/lint_architecture.sh` first run
+**File:line:** `yorkie/src/main/kotlin/dev/yorkie/util/IndexTree.kt:3` — `dev.yorkie.document.time.TimeTicket`
+
+**Severity:** LOW
+**Why deferred:** pre-existing; IndexTree is positional and arguably part of `document/` anyway
+**Proposed action:** either move `IndexTree` out of `util/` into `document/` or pull `TimeTicket` into a shared base package.
+
+### 2026-04-21 — harness-adopt — oversize files (R6)
+
+**Source:** `scripts/lint_architecture.sh` first run
+**File:line:**
+- `yorkie/src/main/kotlin/dev/yorkie/core/Client.kt` — 1498 lines
+- `yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt` — 1133 lines
+- `yorkie/src/main/kotlin/dev/yorkie/document/Document.kt` — 973 lines
+- `yorkie/src/main/kotlin/dev/yorkie/util/IndexTree.kt` — 823 lines
+- `yorkie/src/main/kotlin/dev/yorkie/document/json/JsonTree.kt` — 652 lines
+- `yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeSplit.kt` — 659 lines
+- `yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt` — 608 lines
+- `yorkie/src/main/kotlin/dev/yorkie/util/SplayTreeSet.kt` — 407 lines
+- `yorkie/src/main/kotlin/dev/yorkie/document/json/JsonArray.kt` — 345 lines
+
+**Severity:** LOW
+**Why deferred:** pre-existing; splitting is mechanical but requires per-file judgement to keep public APIs stable
+**Proposed action:** spec-per-file refactor to split by responsibility (e.g., Client.kt → ClientConnection + ClientSyncLoop + ClientWatchStream + ClientPresence). Keep public surface unchanged. Alternative: raise `YORKIE_MAX_FILE_LINES` per directory and enforce a stricter ceiling only on new files — decide in a dedicated spec.

--- a/docs/specs/001_RTCOLLABPLATFORM-643-tree-end-token-guard.md
+++ b/docs/specs/001_RTCOLLABPLATFORM-643-tree-end-token-guard.md
@@ -1,0 +1,103 @@
+---
+status: active
+chain: false
+created: 2026-04-21
+updated: 2026-04-21
+jira: RTCOLLABPLATFORM-643
+js_reference: https://github.com/yorkie-team/yorkie-js-sdk/pull/1211
+epic: RTCOLLABPLATFORM-633
+---
+
+# Feature: Fix tree style divergence on concurrent split via End-token guard (port JS #1211)
+
+## Problem
+
+When two clients concurrently (a) apply a `style` / `removeStyle` to a tree element range and (b) split the element via `SplitElement`, the style operation can land spuriously on one of the split siblings and cause CRDT-tree divergence between replicas.
+
+The root cause is that a `style` traversal visits *tokens*. An element emits a Start token and an End token. When a concurrent `SplitElement` has run, the original element's `insNextID` points at a newly-created split sibling. The End token of the original node now sits on the boundary between the two siblings. A styling client whose `VersionVector` does not yet know about the split will still replay its style over the post-split tree, hit the End token of the original, and apply attributes the originating client never intended — because from the originating client's perspective the split didn't exist yet.
+
+JS has already fixed this in `yorkie-js-sdk#1211` (merged 2026-04-10, itself a port of Go `yorkie#1731`). Android has the same defect.
+
+## Scope
+
+**In scope**
+- Port the End-token guard from `packages/sdk/src/document/crdt/tree.ts` to `yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt`:
+  - Add `private fun hasUnknownSplitSibling(node: CrdtTreeNode, versionVector: VersionVector): Boolean`.
+  - In `CrdtTree.style(...)`: after the existing guard, skip the attribute-set loop when `tokenType == TokenType.End` AND `hasUnknownSplitSibling(node, versionVector)`.
+  - In `CrdtTree.removeStyle(...)`: capture `tokenType` from the `traverseInPosRange` callback (currently destructured as `(node, _)`), then apply the same guard before the attribute-remove loop.
+- Add a CRDT unit test in `yorkie/src/test/kotlin/dev/yorkie/document/crdt/` that reproduces the concurrent style + split scenario and asserts convergence between two replicas after cross-apply.
+
+**Out of scope**
+- Any refactoring of `CrdtTree` beyond the two call sites.
+- Splitting `CrdtTree.kt` (1133 lines — tracked separately in `docs/specs-backlog.md`).
+- Changes to `IndexTree.kt`, `RgaTreeSplit.kt`, or any other file — the JS PR touched exactly one file (tree.ts); the Android port should mirror that.
+- Instrumented (androidTest) coverage — the JS reference did not add one; the Go PR this came from (yorkie#1731) covers the scenario in server-side tests; a unit test at the CRDT layer is sufficient.
+
+## Background (key snippets from JS #1211)
+
+From `packages/sdk/src/document/crdt/tree.ts`:
+
+```ts
+// helper — lines 1004-1035
+private hasUnknownSplitSibling(
+    node: CRDTTreeNode,
+    versionVector: VersionVector,
+): boolean {
+    if (node.insNextID === undefined) return false;
+    const sibling = this.nodeMapByID.get(node.insNextID);
+    if (sibling === undefined || sibling.isText) return false;
+    const knownLamport = versionVector.get(sibling.id.createdAt.actorID);
+    return knownLamport === undefined
+        || knownLamport < sibling.id.createdAt.lamport;
+}
+```
+
+```ts
+// guard — used at the top of the attribute-apply block inside style() and removeStyle()
+if (tokenType === TokenType.End
+    && versionVector !== undefined
+    && this.hasUnknownSplitSibling(node, versionVector)) {
+    return;
+}
+```
+
+Note: `hasUnknownSplitSibling` deliberately omits the parent-equality check that `advancePastUnknownSplitSiblings` uses — in multi-level splits the sibling may have been reparented, yet `insNextID` remains the authoritative split witness.
+
+## Scenarios
+
+1. **Happy path (no concurrency):** a single client applies a style over a range — behavior unchanged, the guard never fires because `insNextID` is null or the sibling is already in the version vector.
+2. **Concurrent split before style (the bug):**
+   - A: `<p>hello world</p>`, styles the whole paragraph `bold=true`.
+   - B: concurrently splits at the space → `<p>hello</p><p>world</p>`.
+   - After cross-apply, both replicas must agree on the final tree shape and attribute set. Pre-fix, A's style lands spuriously on an End token; post-fix, the End token with an unknown split sibling is skipped.
+3. **Concurrent split before `removeStyle`:** same shape as (2) but starting with `bold=true` and applying `removeStyle("bold")`. Today's code discards `tokenType` entirely in `removeStyle` — the guard can't even be written without first preserving `tokenType` from the callback.
+4. **Edge — text sibling:** if `insNextID` points at a text node (e.g., a text split), `hasUnknownSplitSibling` returns false immediately. Important: the JS version checks `sibling.isText` explicitly; the Android port must match.
+5. **Edge — `versionVector` is null** (older protocol paths): the guard does not fire (matches JS behavior). No crash, no divergence.
+
+## Implementation Plan (what the generator should produce)
+
+1. **`hasUnknownSplitSibling`** — add as a private method on `CrdtTree`, above `style`. Parameters: `node: CrdtTreeNode`, `versionVector: VersionVector`. Uses `nodeMapByID` (already exists) to resolve `node.insNextID`. Returns false for null sibling, text sibling, or known lamport.
+2. **`style(...)` guard** — locate the `traverseInPosRange { (node, tokenType) -> ... }` lambda. After the existing preconditions (including the `canStyle` checks on the node) but before mutating the attribute map, insert:
+    ```kotlin
+    if (tokenType == TokenType.End &&
+        versionVector != null &&
+        hasUnknownSplitSibling(node, versionVector)) {
+        return@traverseInPosRange
+    }
+    ```
+3. **`removeStyle(...)` guard** — change the lambda from `{ (node, _) -> ... }` to `{ (node, tokenType) -> ... }` and insert the same guard before the attribute-remove loop.
+4. **Test** — `CrdtTreeStyleDivergenceTest` (file name tentative — follow existing tree-test conventions). Given two `CrdtTree` replicas with the same initial tree, apply a style on replica A and a split on replica B concurrently; sync both; assert `toXml()` / structural equality is identical between A and B, and that the split sibling does not acquire an unintended attribute.
+
+## Definition of Done
+
+- [ ] `./gradlew yorkie:testDebugUnitTest` passes (all existing tests + the new divergence test)
+- [ ] `./gradlew lintKotlin` clean
+- [ ] `bash scripts/lint_architecture.sh` shows no NEW R1..R6 violations vs `origin/develop` baseline (existing pre-existing findings from `docs/specs-backlog.md` are not this PR's responsibility)
+- [ ] Implementation matches the JS reference: exactly one Kotlin file touched (`CrdtTree.kt`), one test file added
+- [ ] Port preserves JS behavior on the 5 scenarios above (unit tests cover scenarios 1, 2, 3; edges 4/5 covered as branch-coverage assertions in the same test class)
+- [ ] Evidence captured: the new test's output line from `./gradlew yorkie:testDebugUnitTest --tests "...CrdtTreeStyleDivergenceTest"` pasted into the round report
+- [ ] Commit message includes `RTCOLLABPLATFORM-643` and references JS `#1211`
+
+## Harness Config Delta
+
+none

--- a/docs/specs/_template.md
+++ b/docs/specs/_template.md
@@ -1,0 +1,27 @@
+---
+status: backlog
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# Feature: {name}
+
+## Problem
+What problem does this solve?
+
+## Scope
+- In scope: ...
+- Out of scope: ...
+
+## Scenarios
+1. Happy path: ...
+2. Edge case: ...
+3. Error case: ...
+
+## Definition of Done
+- [ ] Unit tests pass (`./gradlew yorkie:testDebugUnitTest`)
+- [ ] Instrumented tests pass if sync/watch/CRDT behavior changed (`./gradlew yorkie:connectedDebugAndroidTest`)
+- [ ] `./gradlew lintKotlin` clean
+- [ ] `bash scripts/lint_architecture.sh` clean
+- [ ] Documentation updated
+- [ ] Evidence captured

--- a/harness.config.json
+++ b/harness.config.json
@@ -1,0 +1,95 @@
+{
+  "project": "yorkie-android-sdk",
+  "version": "0.1.0",
+
+  "policies": {
+    "max_file_lines": 300,
+    "min_test_coverage": 70,
+    "max_ticket_failures": 3,
+    "stale_doc_threshold_days": 30
+  },
+
+  "retry": {
+    "max_retries_per_ticket": 3,
+    "action_on_max_failures": "block_and_report"
+  },
+
+  "verify_lanes": {
+    "fast": ["lint", "architecture_check"],
+    "full": ["lint", "architecture_check", "android_lint", "unit_tests", "coverage"],
+    "entropy": ["unused_code", "stale_deps", "untested_modules"],
+    "session": ["full", "harness_check"]
+  },
+
+  "spec_states": {
+    "backlog": "docs/specs/backlog/",
+    "active": "docs/specs/"
+  },
+
+  "exec_plans": {
+    "active": "docs/exec-plans/active/",
+    "completed": "docs/exec-plans/completed/"
+  },
+
+  "work_state": ".work/state.json",
+
+  "evaluator": {
+    "components": {
+      "yorkie_sdk_unit": {
+        "type": "cli",
+        "test_entry": "yorkie/src/test",
+        "test_tools": ["gradle", "bash"],
+        "_comment": "JVM-only unit tests. Does not require a running Yorkie server."
+      },
+      "yorkie_sdk_instrumented": {
+        "type": "cli",
+        "deployment": "docker",
+        "docker_config": {
+          "compose_file": "docker/docker-compose.yml",
+          "service_name": "yorkie",
+          "image": "yorkieteam/yorkie:0.6.36"
+        },
+        "test_entry": "yorkie/src/androidTest",
+        "test_tools": ["gradle", "bash", "docker"],
+        "_comment": "Instrumented tests against a real Yorkie server. Requires an Android emulator/device AND docker-compose."
+      }
+    },
+    "start_commands": {
+      "yorkie_server": "docker compose -f docker/docker-compose.yml up --build -d",
+      "config_server_url": "./scripts/config-yorkie-local-server.sh"
+    },
+    "health_check": "docker ps --filter name=yorkie --filter status=running --format '{{.Names}}' | grep -q '^yorkie$'",
+    "test_env": {
+      "YORKIE_SERVER_HOST": "localhost",
+      "YORKIE_SERVER_PORT": "8080"
+    },
+    "test_env_notes": "YORKIE_SERVER_URL is written to local.properties by scripts/config-yorkie-local-server.sh and picked up by the yorkie module's testInstrumentationRunnerArguments. For unit tests these values are unused.",
+    "lint_commands": {
+      "kotlin": "./gradlew lintKotlin",
+      "android": "./gradlew lint",
+      "architecture": "bash scripts/lint_architecture.sh"
+    },
+    "stop_commands": "docker compose -f docker/docker-compose.yml down"
+  },
+
+  "safety": {
+    "blocked_ticket_action": "stop_and_report",
+    "require_evidence_before_complete": true
+  },
+
+  "session": {
+    "start_ritual": [
+      "run init_check",
+      "check exec-plans/active/",
+      "read progress.md",
+      "read lessons.md"
+    ],
+    "end_ritual": [
+      "verify.sh full",
+      "update checkpoint",
+      "update progress.md",
+      "capture lessons",
+      "harness_check"
+    ]
+  }
+}

--- a/scripts/harness_check.sh
+++ b/scripts/harness_check.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Harness self-check — end-of-session verification (EL-11).
+#
+# Checks:
+#   1. No uncommitted working-tree changes (informational)
+#   2. .work/state.json is valid JSON and has required keys
+#   3. docs/progress.md was updated today (warn if not)
+#   4. docs/lessons.md was updated in the last 7 days (warn if not)
+#   5. Active exec-plans mentioned (informational)
+#   6. Commits since last session have exec-plan or round-report evidence
+#   7. `./gradlew yorkie:testDebugUnitTest` passes (optional: set YORKIE_SKIP_TESTS=1)
+
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+WARN=0
+FAIL=0
+say()  { echo "[harness-check] $*"; }
+fail() { say "FAIL: $*"; FAIL=$((FAIL + 1)); }
+warn() { say "warn: $*"; WARN=$((WARN + 1)); }
+ok()   { say "ok:   $*"; }
+
+today=$(date +%F)
+
+# 1. Working tree state (informational)
+if git rev-parse --git-dir >/dev/null 2>&1; then
+    dirty=$(git status --porcelain | wc -l | tr -d ' ')
+    if [[ "$dirty" != "0" ]]; then
+        say "info: $dirty uncommitted change(s) in working tree"
+    else
+        ok "working tree clean"
+    fi
+fi
+
+# 2. state.json
+STATE=".work/state.json"
+if [[ -f $STATE ]]; then
+    if command -v jq >/dev/null 2>&1; then
+        if jq -e '.phase and (has("active_ticket")) and (has("session_count"))' "$STATE" >/dev/null 2>&1; then
+            ok "$STATE valid"
+        else
+            fail "$STATE missing required keys (phase, active_ticket, session_count)"
+        fi
+        phase=$(jq -r '.phase // "?"' "$STATE")
+        active=$(jq -r '.active_ticket // "null"' "$STATE")
+        say "info: state.phase=$phase  active_ticket=$active"
+    else
+        ok "$STATE exists (jq not installed — skipping shape check)"
+    fi
+else
+    fail "$STATE missing"
+fi
+
+# 3. progress.md freshness
+if [[ -f docs/progress.md ]]; then
+    mtime=$(date -r docs/progress.md +%F 2>/dev/null || echo "?")
+    if [[ "$mtime" == "$today" ]]; then
+        ok "docs/progress.md updated today"
+    else
+        warn "docs/progress.md last updated $mtime (today=$today)"
+    fi
+else
+    fail "docs/progress.md missing"
+fi
+
+# 4. lessons.md recency (7 days)
+if [[ -f docs/lessons.md ]]; then
+    age_days=$(( ( $(date +%s) - $(stat -f %m docs/lessons.md 2>/dev/null || stat -c %Y docs/lessons.md) ) / 86400 ))
+    if (( age_days <= 7 )); then
+        ok "docs/lessons.md updated within 7 days (age=${age_days}d)"
+    else
+        warn "docs/lessons.md stale (age=${age_days}d) — capture a lesson if this session surfaced one"
+    fi
+else
+    fail "docs/lessons.md missing"
+fi
+
+# 5. active exec-plans
+active_count=0
+if [[ -d docs/exec-plans/active ]]; then
+    active_count=$(find docs/exec-plans/active -type f -name '*.md' | wc -l | tr -d ' ')
+fi
+say "info: $active_count active exec-plan(s)"
+
+# 6. Tracking enforcement
+if git rev-parse --git-dir >/dev/null 2>&1; then
+    since_ref="HEAD@{1.day.ago}"
+    commits_today=$(git log --oneline --since=yesterday 2>/dev/null | wc -l | tr -d ' ')
+    completed_count=0
+    rounds_count=0
+    [[ -d docs/exec-plans/completed ]] && completed_count=$(find docs/exec-plans/completed -type f -name '*.md' | wc -l | tr -d ' ')
+    [[ -d docs/round-reports ]] && rounds_count=$(find docs/round-reports -type f -name '*.md' | wc -l | tr -d ' ')
+
+    if (( commits_today > 0 )) && (( completed_count == 0 )) && (( rounds_count == 0 )) && (( active_count == 0 )); then
+        warn "$commits_today commit(s) since yesterday but no exec-plans or round reports — create tickets for traceability"
+    else
+        ok "tracking: $commits_today commit(s), $completed_count completed, $rounds_count round-reports, $active_count active"
+    fi
+fi
+
+# 7. Unit tests (optional)
+if [[ "${YORKIE_SKIP_TESTS:-0}" == "1" ]]; then
+    say "info: YORKIE_SKIP_TESTS=1 — skipping unit tests"
+else
+    echo
+    say "running: ./gradlew yorkie:testDebugUnitTest --no-daemon --console=plain"
+    if ./gradlew yorkie:testDebugUnitTest --no-daemon --console=plain >/tmp/yorkie-harness-check.log 2>&1; then
+        ok "unit tests passed"
+    else
+        fail "unit tests failed — see /tmp/yorkie-harness-check.log"
+    fi
+fi
+
+echo
+if (( FAIL > 0 )); then
+    say "FAILED — $FAIL fail, $WARN warn"
+    exit 1
+fi
+say "PASSED — $WARN warning(s)"
+exit 0

--- a/scripts/init_check.sh
+++ b/scripts/init_check.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# init_check — fast smoke test for the yorkie-android-sdk dev environment.
+#
+# Confirms:
+#   - gradlew is executable
+#   - JDK 17 available
+#   - Docker available (for integration tests)
+#   - local.properties has YORKIE_SERVER_URL (warn only)
+#   - expected harness dirs exist
+
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+FAIL=0
+WARN=0
+say() { echo "[init-check] $*"; }
+fail() { say "FAIL: $*"; FAIL=$((FAIL + 1)); }
+warn() { say "warn: $*"; WARN=$((WARN + 1)); }
+ok()   { say "ok:   $*"; }
+
+# --- gradlew ---
+if [[ -x ./gradlew ]]; then
+    ok "./gradlew is executable"
+else
+    fail "./gradlew missing or not executable"
+fi
+
+# --- JDK ---
+if command -v java >/dev/null 2>&1; then
+    jv=$(java -version 2>&1 | head -n 1)
+    ok "java: $jv"
+    # require JDK >= 17
+    major=$(java -version 2>&1 | sed -n 's/.*version "\([0-9][0-9]*\).*/\1/p' | head -n1)
+    if [[ -n "$major" && "$major" -lt 17 ]]; then
+        fail "JDK 17+ required (found $major)"
+    fi
+else
+    fail "java not on PATH — install JDK 17+"
+fi
+
+# --- Docker ---
+if command -v docker >/dev/null 2>&1; then
+    ok "docker on PATH"
+    if docker info >/dev/null 2>&1; then
+        ok "docker daemon reachable"
+    else
+        warn "docker daemon not reachable — integration tests will fail until started"
+    fi
+else
+    warn "docker not on PATH — integration tests will fail"
+fi
+
+# --- local.properties ---
+if [[ -f local.properties ]]; then
+    if grep -q '^YORKIE_SERVER_URL=' local.properties; then
+        ok "local.properties has YORKIE_SERVER_URL"
+    else
+        warn "local.properties is missing YORKIE_SERVER_URL — run scripts/config-yorkie-local-server.sh before instrumented tests"
+    fi
+else
+    warn "local.properties not found — create one (see CLAUDE.md for notes)"
+fi
+
+# --- harness layout ---
+for d in docs docs/specs docs/exec-plans/active docs/exec-plans/completed docs/round-reports .work; do
+    if [[ -d "$d" ]]; then
+        ok "dir: $d"
+    else
+        fail "missing dir: $d"
+    fi
+done
+
+for f in harness.config.json CLAUDE.local.md docs/GOLDEN_PRINCIPLES.md docs/ARCHITECTURE.md; do
+    if [[ -f "$f" ]]; then
+        ok "file: $f"
+    else
+        fail "missing file: $f"
+    fi
+done
+
+# --- .work/state.json shape ---
+if [[ -f .work/state.json ]]; then
+    if command -v jq >/dev/null 2>&1; then
+        if jq -e 'has("phase")' .work/state.json >/dev/null 2>&1; then
+            ok ".work/state.json has 'phase'"
+        else
+            fail ".work/state.json missing 'phase' key"
+        fi
+    else
+        ok ".work/state.json exists (jq not installed — skipping shape check)"
+    fi
+else
+    fail ".work/state.json missing"
+fi
+
+echo
+if (( FAIL > 0 )); then
+    say "FAILED — $FAIL fail, $WARN warn"
+    exit 1
+fi
+say "PASSED — $WARN warning(s)"
+exit 0

--- a/scripts/lint_architecture.sh
+++ b/scripts/lint_architecture.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Architecture linter — yorkie-android-sdk
+#
+# Enforces:
+#   R1. document/crdt/** must not import document/json/**
+#   R2. util/** must not import from document/**, core/**, api/**
+#   R3. Generated proto types may only be referenced from api/*Converter.kt (and api/* generally).
+#       Domain code (document/**, core/**, util/**) must not import dev.yorkie.api.v1.*.
+#   R4. yorkie/src/main/** must not import dev.yorkie.examples.** or examples.** or microbenchmark.**
+#   R5. No println / System.out / System.err in yorkie/src/main/**
+#   R6. Max 300 lines per .kt file in yorkie/src/main/kotlin/** (excluding generated/)
+#
+# Exit 0 on clean, 1 on any violation.
+
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MAIN="$ROOT/yorkie/src/main/kotlin"
+MAX_LINES="${YORKIE_MAX_FILE_LINES:-300}"
+
+VIOLATIONS=0
+report() {
+    echo "[arch-lint] $1"
+    VIOLATIONS=$((VIOLATIONS + 1))
+}
+
+ok() { echo "[arch-lint] ok: $1"; }
+
+# --- Preconditions ---
+if [[ ! -d "$MAIN" ]]; then
+    echo "[arch-lint] ERROR: $MAIN not found. Run from repo root or a worktree."
+    exit 1
+fi
+
+have_rg=0
+command -v rg >/dev/null 2>&1 && have_rg=1
+
+scan() {
+    # scan <path_glob> <pattern>  — prints matching "file:line:line-content"
+    local path="$1" pattern="$2"
+    if [[ $have_rg -eq 1 ]]; then
+        rg -n --no-heading --type kotlin "$pattern" "$path" 2>/dev/null || true
+    else
+        grep -rn --include='*.kt' -E "$pattern" "$path" 2>/dev/null || true
+    fi
+}
+
+# --- R1: crdt must not import json ---
+R1_HITS=$(scan "$MAIN/dev/yorkie/document/crdt" '^import dev\.yorkie\.document\.json\.')
+if [[ -n "$R1_HITS" ]]; then
+    report "R1 violation — document/crdt/** imports document/json/**:"
+    echo "$R1_HITS" | sed 's/^/  /'
+else
+    ok "R1 document/crdt/** does not import document/json/**"
+fi
+
+# --- R2: util must not import document/core/api ---
+R2_HITS=$(scan "$MAIN/dev/yorkie/util" '^import dev\.yorkie\.(document|core|api)\.')
+if [[ -n "$R2_HITS" ]]; then
+    report "R2 violation — util/** imports higher layer (document/core/api):"
+    echo "$R2_HITS" | sed 's/^/  /'
+else
+    ok "R2 util/** does not import document/core/api"
+fi
+
+# --- R3: pure-domain code must not import generated proto (dev.yorkie.api.v1.*) ---
+# core/ is the RPC I/O boundary (Connect-RPC client) and IS allowed to hold proto
+# types. document/** and util/** must not — proto stays behind converters.
+R3_HITS=$(
+    { scan "$MAIN/dev/yorkie/document" '^import dev\.yorkie\.api\.v1\.'
+      scan "$MAIN/dev/yorkie/util" '^import dev\.yorkie\.api\.v1\.'
+    } | sort -u
+)
+if [[ -n "$R3_HITS" ]]; then
+    report "R3 violation — document/util imports generated proto (dev.yorkie.api.v1.*):"
+    echo "$R3_HITS" | sed 's/^/  /'
+else
+    ok "R3 document/util do not import dev.yorkie.api.v1.*"
+fi
+
+# --- R4: yorkie/src/main/** must not import examples/microbenchmark ---
+R4_HITS=$(scan "$MAIN" '^import (dev\.yorkie\.examples|examples|microbenchmark|dev\.yorkie\.microbenchmark)\.')
+if [[ -n "$R4_HITS" ]]; then
+    report "R4 violation — yorkie/src/main/** imports examples or microbenchmark:"
+    echo "$R4_HITS" | sed 's/^/  /'
+else
+    ok "R4 yorkie/src/main/** has no imports from examples or microbenchmark"
+fi
+
+# --- R5: no println / System.out / System.err in production code ---
+# Exclude generated/ explicitly.
+R5_HITS=""
+if [[ $have_rg -eq 1 ]]; then
+    R5_HITS=$(rg -n --no-heading --type kotlin \
+        -g '!**/generated/**' \
+        '(\bprintln\s*\(|System\.out\.|System\.err\.)' \
+        "$MAIN" 2>/dev/null || true)
+else
+    R5_HITS=$(grep -rn --include='*.kt' --exclude-dir='generated' \
+        -E '(\bprintln[[:space:]]*\(|System\.out\.|System\.err\.)' \
+        "$MAIN" 2>/dev/null || true)
+fi
+if [[ -n "$R5_HITS" ]]; then
+    report "R5 violation — forbidden console output in production code:"
+    echo "$R5_HITS" | sed 's/^/  /'
+else
+    ok "R5 no println / System.out / System.err in yorkie/src/main/**"
+fi
+
+# --- R6: file size ---
+R6_VIOLATIONS=""
+while IFS= read -r -d '' f; do
+    case "$f" in *"/generated/"*) continue ;; esac
+    n=$(wc -l < "$f" | tr -d ' ')
+    if (( n > MAX_LINES )); then
+        R6_VIOLATIONS+="  $f  ($n lines, max $MAX_LINES)"$'\n'
+    fi
+done < <(find "$MAIN" -type f -name '*.kt' -print0)
+if [[ -n "$R6_VIOLATIONS" ]]; then
+    report "R6 violation — files exceed ${MAX_LINES}-line limit:"
+    printf '%s' "$R6_VIOLATIONS"
+else
+    ok "R6 no file exceeds ${MAX_LINES} lines"
+fi
+
+echo
+if (( VIOLATIONS > 0 )); then
+    echo "[arch-lint] FAILED — $VIOLATIONS rule(s) violated"
+    exit 1
+fi
+echo "[arch-lint] PASSED"
+exit 0

--- a/scripts/maintenance.sh
+++ b/scripts/maintenance.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# maintenance — weekly hygiene check.
+# Reports (does not fix) doc freshness, stale deps, untested modules, and TODO debt.
+
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+say() { echo "[maintenance] $*"; }
+section() { echo; echo "== $* =="; }
+
+section "Doc freshness (> ${YORKIE_DOC_STALE_DAYS:-30} days)"
+threshold="${YORKIE_DOC_STALE_DAYS:-30}"
+stale=$(find docs -type f -name '*.md' -mtime +"$threshold" 2>/dev/null)
+if [[ -n "$stale" ]]; then
+    echo "$stale" | sed 's/^/  /'
+else
+    echo "  no stale docs"
+fi
+
+section "TODO / FIXME debt (yorkie/src/main)"
+if command -v rg >/dev/null 2>&1; then
+    rg -n --no-heading --type kotlin -g '!**/generated/**' 'TODO|FIXME' yorkie/src/main 2>/dev/null | head -n 50 | sed 's/^/  /' || echo "  none"
+else
+    grep -rn --include='*.kt' --exclude-dir='generated' -E 'TODO|FIXME' yorkie/src/main 2>/dev/null | head -n 50 | sed 's/^/  /' || echo "  none"
+fi
+
+section "Dependency versions (gradle/libs.versions.toml)"
+if [[ -f gradle/libs.versions.toml ]]; then
+    # Print plugin and library versions for a human to review against upstream.
+    awk '/^\[versions\]/,/^\[/{ if (/^\[versions\]/) next; if (/^\[/) exit; print "  " $0 }' gradle/libs.versions.toml | grep -v '^$' | head -n 60
+else
+    echo "  libs.versions.toml not found"
+fi
+
+section "Active exec-plans"
+if [[ -d docs/exec-plans/active ]]; then
+    find docs/exec-plans/active -type f -name '*.md' -printf '  %p\n' 2>/dev/null || \
+        find docs/exec-plans/active -type f -name '*.md' -exec echo "  {}" \;
+fi
+
+section "Round reports count"
+n=0
+[[ -d docs/round-reports ]] && n=$(find docs/round-reports -type f -name '*.md' | wc -l | tr -d ' ')
+echo "  $n file(s)"
+
+section "git log since last week"
+git log --oneline --since='1 week ago' 2>/dev/null | head -n 30 | sed 's/^/  /'
+
+echo
+say "done — review the sections above"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Verify lanes for yorkie-android-sdk.
+#
+# Usage: bash scripts/verify.sh [fast|full|entropy|session]
+#
+# fast    — ktlint + architecture lint (no gradle task graph build)
+# full    — fast + android lint + unit tests + coverage
+# entropy — unused dependencies, stale docs, untested modules
+# session — full + harness_check
+
+set -u
+
+LANE="${1:-fast}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+FAILED=0
+run() {
+    # run "label" "command..."
+    local label="$1"; shift
+    echo
+    echo "==> $label"
+    echo "    \$ $*"
+    if "$@"; then
+        echo "    [ok] $label"
+    else
+        local rc=$?
+        echo "    [fail rc=$rc] $label"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+run_lane_fast() {
+    run "ktlint (kotlinter)" ./gradlew lintKotlin --no-daemon --console=plain
+    run "architecture lint" bash scripts/lint_architecture.sh
+}
+
+run_lane_full() {
+    run_lane_fast
+    run "android lint"       ./gradlew lint --no-daemon --console=plain
+    run "unit tests"         ./gradlew yorkie:testDebugUnitTest --no-daemon --console=plain
+    run "jacoco report"      ./gradlew yorkie:jacocoDebugTestReport --no-daemon --console=plain
+}
+
+run_lane_entropy() {
+    # Gradle has no bundled dead-code detector. These checks are best-effort.
+    echo
+    echo "==> entropy checks (best-effort)"
+
+    # Stale docs (>30 days) warning
+    local threshold_days="${YORKIE_DOC_STALE_DAYS:-30}"
+    local stale
+    stale=$(find docs -type f -name '*.md' -mtime +"$threshold_days" 2>/dev/null)
+    if [[ -n "$stale" ]]; then
+        echo "    [warn] docs older than $threshold_days days:"
+        echo "$stale" | sed 's/^/      /'
+    else
+        echo "    [ok] no stale docs (> $threshold_days days)"
+    fi
+
+    # Orphan TODO/FIXME scan under yorkie/src/main
+    if command -v rg >/dev/null 2>&1; then
+        local todos
+        todos=$(rg -n --no-heading --type kotlin -g '!**/generated/**' 'TODO|FIXME' yorkie/src/main 2>/dev/null | wc -l | tr -d ' ')
+    else
+        local todos
+        todos=$(grep -rn --include='*.kt' --exclude-dir='generated' -E 'TODO|FIXME' yorkie/src/main 2>/dev/null | wc -l | tr -d ' ')
+    fi
+    echo "    [info] $todos TODO/FIXME markers in yorkie/src/main (target: 0)"
+}
+
+run_lane_session() {
+    run_lane_full
+    if [[ -x scripts/harness_check.sh ]]; then
+        run "harness self-check" bash scripts/harness_check.sh
+    else
+        echo "    [skip] scripts/harness_check.sh not found or not executable"
+    fi
+}
+
+case "$LANE" in
+    fast)    run_lane_fast ;;
+    full)    run_lane_full ;;
+    entropy) run_lane_entropy ;;
+    session) run_lane_session ;;
+    *)
+        echo "Unknown lane: $LANE"
+        echo "Valid: fast | full | entropy | session"
+        exit 2
+        ;;
+esac
+
+echo
+if (( FAILED > 0 )); then
+    echo "[verify] FAILED — $FAILED check(s) failed (lane=$LANE)"
+    exit 1
+fi
+echo "[verify] PASSED (lane=$LANE)"
+exit 0


### PR DESCRIPTION
## Summary

Add harness-engineering scaffolding to yorkie-android-sdk. Team files (`CLAUDE.md`, `AGENTS.md`, `CI workflows`) are **not** modified — agent-specific instructions go in `CLAUDE.local.md`.

This PR is the base for [#301](https://github.com/yorkie-team/yorkie-android-sdk/pull/301) (RTCOLLABPLATFORM-643). Reviewing this one first lets the team evaluate the scaffolding in isolation; once merged, the feature PR's base auto-retargets to `develop`.

## What's added

**Docs**
- `CLAUDE.local.md` — harness agent-guide supplementing the team CLAUDE.md
- `docs/ARCHITECTURE.md` — explicit two-layer rule, proto I/O boundary
- `docs/GOLDEN_PRINCIPLES.md` — enforced code-hygiene rules
- `docs/progress.md`, `docs/lessons.md`, `docs/specs-backlog.md`
- `docs/specs/_template.md`, `docs/exec-plans/_template.md`
- Directory scaffold: `docs/specs/backlog/`, `docs/exec-plans/{active,completed}/`, `docs/round-reports/`

**Config**
- `harness.config.json` — verify lanes + evaluator components (unit + instrumented)
- `.work/state.json` — work state handle (seeded at `phase: idle`)
- `.gitignore` — ignore `.worktrees/`, `docs/round-reports/`, `.work/*` (keep `.work/state.json`)

**Scripts**
- `scripts/lint_architecture.sh` — R1..R6 (CRDT/JSON split, proto boundary, util→domain boundary, examples import guard, no `println`, file size 300 lines)
- `scripts/verify.sh` — fast / full / entropy / session lanes
- `scripts/init_check.sh` — env smoke test
- `scripts/harness_check.sh` — end-of-session self-check
- `scripts/maintenance.sh` — weekly hygiene report

**Pre-existing architectural findings** from the first lint run are recorded in `docs/specs-backlog.md` for future triage (CRDT→JSON imports, one util→document import, 9 files over the 300-line limit). These are starting-point observations, not blockers — no code changes here address them.

## Test plan

- [x] `bash scripts/init_check.sh` — PASSED (0 failures, 0 warnings)
- [x] `bash scripts/lint_architecture.sh` — catches pre-existing issues as expected; no new violations introduced
- [x] `./gradlew yorkie:testDebugUnitTest` — BUILD SUCCESSFUL (baseline on origin/develop)
- [ ] Nothing in `yorkie/src/main/**` is modified — no production behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)