### PR TITLE
Converge concurrent tree merge/split via forwarding pointer and cascade

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeSplitMergeTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeSplitMergeTest.kt
@@ -319,4 +319,123 @@ class JsonTreeSplitMergeTest {
             JsonTreeTest.assertTreesXmlEquals("<doc><p>ab</p></doc>", d1, d2)
         }
     }
+
+    @Test
+    fun test_side_by_side_concurrent_merge_and_merge() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        TreeBuilder.element("r") {
+                            element("p") { text { "a" } }
+                            element("p") { text { "b" } }
+                            element("p") { text { "c" } }
+                            element("p") { text { "d" } }
+                        },
+                    )
+                },
+                JsonTreeTest.Companion.Updater(c2, d2),
+            )
+            JsonTreeTest.assertTreesXmlEquals(
+                "<r><p>a</p><p>b</p><p>c</p><p>d</p></r>",
+                d1,
+                d2,
+            )
+
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.rootTree().edit(2, 4)
+                },
+                JsonTreeTest.Companion.Updater(c2, d2) { root, _ ->
+                    root.rootTree().edit(8, 10)
+                },
+            ) {
+                JsonTreeTest.assertTreesXmlEquals(
+                    "<r><p>ab</p><p>c</p><p>d</p></r>",
+                    d1,
+                )
+                JsonTreeTest.assertTreesXmlEquals(
+                    "<r><p>a</p><p>b</p><p>cd</p></r>",
+                    d2,
+                )
+            }
+            JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p><p>cd</p></r>", d1, d2)
+        }
+    }
+
+    @Test
+    fun test_concurrent_delete_after_merge_with_nested_content() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        TreeBuilder.element("r") {
+                            element("p") {
+                                element("b") { text { "a" } }
+                            }
+                            element("p") {
+                                element("b") { text { "b" } }
+                            }
+                        },
+                    )
+                },
+                JsonTreeTest.Companion.Updater(c2, d2),
+            )
+            JsonTreeTest.assertTreesXmlEquals(
+                "<r><p><b>a</b></p><p><b>b</b></p></r>",
+                d1,
+                d2,
+            )
+
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.rootTree().edit(4, 6)
+                },
+                JsonTreeTest.Companion.Updater(c2, d2) { root, _ ->
+                    root.rootTree().edit(0, 10)
+                },
+            ) {
+                JsonTreeTest.assertTreesXmlEquals(
+                    "<r><p><b>a</b><b>b</b></p></r>",
+                    d1,
+                )
+                JsonTreeTest.assertTreesXmlEquals("<r></r>", d2)
+            }
+            JsonTreeTest.assertTreesXmlEquals("<r></r>", d1, d2)
+        }
+    }
+
+    @Test
+    fun test_delete_starting_inside_merge_target() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        TreeBuilder.element("r") {
+                            element("p") { text { "ab" } }
+                            element("p") { text { "c" } }
+                        },
+                    )
+                },
+                JsonTreeTest.Companion.Updater(c2, d2),
+            )
+            JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p><p>c</p></r>", d1, d2)
+
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.rootTree().edit(3, 5)
+                },
+                JsonTreeTest.Companion.Updater(c2, d2) { root, _ ->
+                    root.rootTree().edit(3, 7)
+                },
+            ) {
+                JsonTreeTest.assertTreesXmlEquals("<r><p>abc</p></r>", d1)
+                JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p></r>", d2)
+            }
+            JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p></r>", d1, d2)
+        }
+    }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -213,6 +213,7 @@ internal data class CrdtTree(
         val nodesToBeRemoved = mutableListOf<CrdtTreeNode>()
         val tokensToBeRemoved = mutableListOf<CrdtTreeToken>()
         val toBeMovedToFromParents = mutableListOf<CrdtTreeNode>()
+        val toBeMergedNodes = mutableListOf<CrdtTreeNode>()
 
         // Treat missing or empty VersionVector as local operation.
         val isLocal = versionVector == null || versionVector.size() == 0
@@ -226,6 +227,7 @@ internal data class CrdtTree(
             // NOTE(hackerwins): If the node overlaps as a start tag with the
             // range then we need to move the remaining children to fromParent.
             if (tokenType == TokenType.Start && !ended) {
+                toBeMergedNodes.add(node)
                 toBeMovedToFromParents.addAll(node.children)
             }
 
@@ -250,14 +252,46 @@ internal data class CrdtTree(
                 }
             }
 
+            // NOTE(sejongk): If the node is removable or its parent is going to
+            // be removed, then this node should be removed.
+            // Do not cascade-delete children of merge-boundary nodes
+            // (toBeMergedNodes), because those children are moved rather than
+            // deleted.
+            val parentScheduledForDelete =
+                node.parent in nodesToBeRemoved && node.parent !in toBeMergedNodes
             if (node.canDelete(
                     executedAt,
                     creationKnown,
                     tombstoneKnown,
-                ) || node.parent in nodesToBeRemoved
+                ) || parentScheduledForDelete
             ) {
                 if (tokenType == TokenType.Text || tokenType == TokenType.Start) {
                     nodesToBeRemoved.add(node)
+
+                    // Cascade delete to split siblings created by concurrent
+                    // SplitElement. Only for element nodes.
+                    val splitHead = node.insNextID
+                    if (!node.isText && splitHead != null && node !in toBeMergedNodes) {
+                        var next = findFloorNode(splitHead)
+                        while (next != null) {
+                            val splitCreationKnown = if (isLocal) {
+                                true
+                            } else {
+                                val vv = versionVector?.get(next.createdAt.actorID)
+                                vv != null && vv >= next.createdAt.lamport
+                            }
+                            if (!splitCreationKnown) {
+                                val sibling = next
+                                nodesToBeRemoved.add(sibling)
+                                // Cascade through the full subtree, not just immediate children.
+                                traverseAll(sibling) { n, _ ->
+                                    if (n !== sibling) nodesToBeRemoved.add(n)
+                                }
+                            }
+                            val followID = next.insNextID ?: break
+                            next = findFloorNode(followID)
+                        }
+                    }
                 }
                 tokensToBeRemoved.add(TreeToken(node, tokenType))
             }
@@ -277,7 +311,64 @@ internal data class CrdtTree(
         }
 
         // 03. Merge: move the nodes that are marked as moved.
-        toBeMovedToFromParents.filter { it.removedAt == null }.forEach(fromParent::append)
+        toBeMovedToFromParents.filter { it.removedAt == null }.forEach { node ->
+            // Record the child ID on its actual source parent only.
+            val oldParent = node.parent
+            if (oldParent != null) {
+                val src = toBeMergedNodes.firstOrNull { it === oldParent }
+                if (src != null) {
+                    val ids = src.mergedChildIDs ?: mutableListOf<CrdtTreeNodeID>().also {
+                        src.mergedChildIDs = it
+                    }
+                    ids.add(node.id)
+                }
+                // Detach from old parent to prevent ghost references. Swallow
+                // NoSuchElementException: a cascade delete of a split sibling
+                // may have already detached the child.
+                try {
+                    oldParent.detachChild(node)
+                } catch (_: NoSuchElementException) {
+                    // Child already detached, skip.
+                }
+            }
+            fromParent.append(node)
+        }
+        // Set forwarding pointer on merge-source nodes so future insertions
+        // that land on the tombstoned parent redirect to the merge target.
+        toBeMergedNodes.forEach { src -> src.mergedInto = fromParent.id }
+
+        // 03-1. Propagate deletes to children moved by prior merges. When a
+        // merge-source node is fully deleted (not itself a merge boundary),
+        // its former children in the merge target should also be deleted.
+        // Skip when mergedInto points to fromParent (concurrent merge).
+        nodesToBeRemoved.forEach { node ->
+            val mergedInto = node.mergedInto
+            val mergedChildIDs = node.mergedChildIDs
+            if (mergedInto != null &&
+                !mergedChildIDs.isNullOrEmpty() &&
+                node !in toBeMergedNodes &&
+                mergedInto != fromParent.id
+            ) {
+                mergedChildIDs.forEach { childID ->
+                    val child = findFloorNode(childID)
+                    if (child != null && child.removedAt == null) {
+                        child.remove(executedAt)
+                        if (child.isRemoved) {
+                            gcPairs.add(GCPair(this, child))
+                        }
+                        // Also tombstone descendants if the moved child is an element.
+                        traverseAll(child) { n, _ ->
+                            if (n !== child && n.removedAt == null) {
+                                n.remove(executedAt)
+                                if (n.isRemoved) {
+                                    gcPairs.add(GCPair(this, n))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         // 04. Split: split the element nodes for the given split level.
         if (splitLevel > 0 && issueTimeTicket != null) {
@@ -539,6 +630,9 @@ internal data class CrdtTree(
     ) {
         val fromIndex = toIndex(fromParent, fromLeft)
         val toIndex = toIndex(toParent, toLeft)
+        // When a concurrent merge redirects the to-position ahead of the
+        // from-position, the range is empty — a prior step already handled it.
+        if (fromIndex > toIndex) return
         indexTree.tokensBetween(fromIndex, toIndex, callback)
     }
 
@@ -573,6 +667,33 @@ internal data class CrdtTree(
         val realParent =
             leftSibling.parent.takeIf { leftSibling.parent != null && !isLeftMost }
                 ?: parent
+
+        // 02-1. If the parent has been tombstoned by a merge, redirect to the
+        // merge destination using the forwarding pointer.
+        val mergedIntoID = realParent.mergedInto
+        if (realParent.isRemoved && isLeftMost && mergedIntoID != null) {
+            val mergeTarget = findFloorNode(mergedIntoID)
+            if (mergeTarget != null && !mergeTarget.isRemoved) {
+                val mergedChildIDs = realParent.mergedChildIDs
+                if (!mergedChildIDs.isNullOrEmpty()) {
+                    val firstChild = findFloorNode(mergedChildIDs.first())
+                    if (firstChild?.parent == mergeTarget) {
+                        // Use allChildren consistently to avoid visible/total offset mismatch.
+                        val allCh = mergeTarget.allChildren
+                        val offset = allCh.indexOf(firstChild)
+                        val redirectedLeft = if (offset <= 0) mergeTarget else allCh[offset - 1]
+                        return Pair(
+                            first = Pair(mergeTarget, redirectedLeft),
+                            second = diff,
+                        )
+                    }
+                }
+                return Pair(
+                    first = Pair(mergeTarget, mergeTarget),
+                    second = diff,
+                )
+            }
+        }
 
         // 03. Split text node if the left node is a text node.
         if (leftSibling.isText) {
@@ -953,6 +1074,21 @@ internal data class CrdtTreeNode(
     var insPrevID: CrdtTreeNodeID? = null
 
     var insNextID: CrdtTreeNodeID? = null
+
+    /**
+     * Runtime-only forwarding pointer set when this node is tombstoned by a
+     * merge. Records which parent received the children so that later
+     * insertions landing on this tombstoned parent redirect to the merge
+     * destination.
+     */
+    var mergedInto: CrdtTreeNodeID? = null
+
+    /**
+     * Runtime-only IDs of children moved during a merge. Propagates
+     * concurrent deletes of this node to children already relocated under
+     * [mergedInto].
+     */
+    var mergedChildIDs: MutableList<CrdtTreeNodeID>? = null
 
     val rhtNodes: Iterable<RhtNode>
         get() = _attributes

--- a/yorkie/src/main/kotlin/dev/yorkie/util/IndexTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/IndexTree.kt
@@ -671,8 +671,37 @@ abstract class IndexTreeNode<T : IndexTreeNode<T>> {
 
     /**
      * Removes the given [child] (physically purges it from the tree).
+     *
+     * Returns silently when [child] is no longer a child of this node: a
+     * prior [detachChild] from a concurrent merge can have moved it out
+     * before GC purge reaches the same node.
      */
     fun removeChild(child: T) {
+        check(!isText) {
+            "Text node cannot have children"
+        }
+
+        val offset = childNodes.indexOf(child).takeUnless { it == -1 } ?: return
+
+        childNodes.removeAt(offset)
+
+        // NOTE(hackerwins): Decrease totalSize including removed nodes
+        // since this node is being purged (physically removed from tree).
+        child.updateAncestorSize(-child.paddedSize(true), true)
+
+        child.parent = null
+    }
+
+    /**
+     * Detaches the given alive [child] from this node for moving between
+     * parents (i.e. merge). Updates both `visibleSize` and `totalSize`.
+     *
+     * Differs from [removeChild], which only updates `totalSize` because
+     * it is used on tombstoned children during GC purge. Throws
+     * [NoSuchElementException] when [child] is not present — callers that
+     * may race with a prior detach must wrap in `try`/`catch`.
+     */
+    fun detachChild(child: T) {
         check(!isText) {
             "Text node cannot have children"
         }
@@ -682,8 +711,7 @@ abstract class IndexTreeNode<T : IndexTreeNode<T>> {
 
         childNodes.removeAt(offset)
 
-        // NOTE(hackerwins): Decrease totalSize including removed nodes
-        // since this node is being purged (physically removed from tree).
+        child.updateAncestorSize(-child.paddedSize())
         child.updateAncestorSize(-child.paddedSize(true), true)
 
         child.parent = null


### PR DESCRIPTION
> **RTCOLLABPLATFORM-637**: [[Android] [A1] Fix convergence bugs in concurrent tree merge/split](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-637)

## Summary
- Sync-up task **A1** from the Yorkie JS→Android [roadmap](https://wiki.navercorp.com/pages/viewpage.action?pageId=5131863864). Foundation for A2–A6.
- Ports JS [#1202](https://github.com/yorkie-team/yorkie-js-sdk/pull/1202) (mirrors Go [#1722](https://github.com/yorkie-team/yorkie/pull/1722)).
- Fixes six interacting convergence gaps around concurrent merge/split traffic in `CrdtTree.edit`.

## Changes
### `IndexTree.kt`
- `IndexTreeNode.removeChild` returns silently when the child is already gone — a prior `detachChild` from a concurrent merge could have moved it out before GC purge reaches the same node.
- New `IndexTreeNode.detachChild` — moves an alive child between parents, updating both `visibleSize` and `totalSize`. Unlike `removeChild` (used during GC purge for tombstoned nodes), `detachChild` throws `NoSuchElementException` on a missing child; callers race with cascade delete must `try`-catch.

### `CrdtTree.kt`
- `CrdtTreeNode` gains two runtime-only fields:
  - `mergedInto: CrdtTreeNodeID?` — forwarding pointer on the tombstoned merge-source.
  - `mergedChildIDs: MutableList<CrdtTreeNodeID>?` — IDs of children moved during merge.
- `findNodesAndSplitText` redirects insertions whose parent is a tombstoned merge-source to the merge target via `mergedInto`, using `allChildren.indexOf` for a consistent offset.
- `edit` now:
  1. Captures merge-boundary nodes into `toBeMergedNodes` before copying their children.
  2. Skips cascade-delete of merge-boundary children (they get moved, not deleted).
  3. Cascade-deletes unknown split siblings through the `insNextID` chain (full subtree via `traverseAll`).
  4. Move phase: records each moved child on its source parent's `mergedChildIDs`, calls `detachChild` (swallows `NoSuchElementException`), then sets `mergedInto = fromParent.id` on every merge-source.
  5. New step 03-1: propagates deletes to children moved by a prior merge when the merge-source itself is deleted (skipped when `mergedInto == fromParent.id`).
- `traverseInPosRange` returns early when a prior merge redirects the to-position ahead of the from-position.

### Regression tests
Three new instrumented tests in `JsonTreeSplitMergeTest.kt`, ported from JS PR #1202:
- `test_side_by_side_concurrent_merge_and_merge`
- `test_concurrent_delete_after_merge_with_nested_content`
- `test_delete_starting_inside_merge_target`

## Test plan
- [ ] Instrumented: `./gradlew yorkie:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.yorkie.document.json.JsonTreeConcurrencyTest,dev.yorkie.document.json.JsonTreeTest,dev.yorkie.document.json.JsonTreeSplitMergeTest` — 82 tests, 2 pre-existing skips unrelated to this change, 0 failed on Pixel_6_API_33.
- [ ] `test_concurrent_split_and_split` / `test_concurrent_split_and_edit` remain `@Ignore`'d — these rely on split-specific fixes coming in A2–A5.

> Items run automatically by CI (lint, unit tests, coverage) are excluded.
