### PR TITLE
Fix split sibling convergence via position forwarding

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeSplitMergeTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeSplitMergeTest.kt
@@ -438,4 +438,204 @@ class JsonTreeSplitMergeTest {
             JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p></r>", d1, d2)
         }
     }
+
+    @Test
+    fun test_contained_split_and_split_at_different_levels() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        TreeBuilder.element("r") {
+                            element("p") {
+                                element("p") { text { "ab" } }
+                                element("p") { text { "c" } }
+                            }
+                        },
+                    )
+                },
+                JsonTreeTest.Companion.Updater(c2, d2),
+            )
+            JsonTreeTest.assertTreesXmlEquals(
+                "<r><p><p>ab</p><p>c</p></p></r>",
+                d1,
+                d2,
+            )
+
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.rootTree().edit(3, 3, 1)
+                },
+                JsonTreeTest.Companion.Updater(c2, d2) { root, _ ->
+                    root.rootTree().edit(5, 5, 1)
+                },
+            ) {
+                JsonTreeTest.assertTreesXmlEquals(
+                    "<r><p><p>a</p><p>b</p><p>c</p></p></r>",
+                    d1,
+                )
+                JsonTreeTest.assertTreesXmlEquals(
+                    "<r><p><p>ab</p></p><p><p>c</p></p></r>",
+                    d2,
+                )
+            }
+            JsonTreeTest.assertTreesXmlEquals(
+                "<r><p><p>a</p><p>b</p></p><p><p>c</p></p></r>",
+                d1,
+                d2,
+            )
+        }
+    }
+
+    @Test
+    fun test_side_by_side_split_and_insert() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        TreeBuilder.element("r") {
+                            element("p") { text { "ab" } }
+                        },
+                    )
+                },
+                JsonTreeTest.Companion.Updater(c2, d2),
+            )
+            JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p></r>", d1, d2)
+
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.rootTree().edit(2, 2, 1)
+                },
+                JsonTreeTest.Companion.Updater(c2, d2) { root, _ ->
+                    root.rootTree().edit(
+                        4,
+                        4,
+                        TreeBuilder.element("p") { text { "c" } },
+                    )
+                },
+            ) {
+                JsonTreeTest.assertTreesXmlEquals("<r><p>a</p><p>b</p></r>", d1)
+                JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p><p>c</p></r>", d2)
+            }
+            JsonTreeTest.assertTreesXmlEquals(
+                "<r><p>a</p><p>b</p><p>c</p></r>",
+                d1,
+                d2,
+            )
+        }
+    }
+
+    @Test
+    fun test_side_by_side_split_and_delete() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        TreeBuilder.element("r") {
+                            element("p") { text { "ab" } }
+                            element("p") { text { "c" } }
+                        },
+                    )
+                },
+                JsonTreeTest.Companion.Updater(c2, d2),
+            )
+            JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p><p>c</p></r>", d1, d2)
+
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.rootTree().edit(2, 2, 1)
+                },
+                JsonTreeTest.Companion.Updater(c2, d2) { root, _ ->
+                    root.rootTree().edit(4, 7)
+                },
+            ) {
+                JsonTreeTest.assertTreesXmlEquals(
+                    "<r><p>a</p><p>b</p><p>c</p></r>",
+                    d1,
+                )
+                JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p></r>", d2)
+            }
+            JsonTreeTest.assertTreesXmlEquals("<r><p>a</p><p>b</p></r>", d1, d2)
+        }
+    }
+
+    @Test
+    fun test_merge_with_concurrent_content_delete() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        TreeBuilder.element("r") {
+                            element("p") { text { "ab" } }
+                            element("p") { text { "cd" } }
+                        },
+                    )
+                },
+                JsonTreeTest.Companion.Updater(c2, d2),
+            )
+            JsonTreeTest.assertTreesXmlEquals(
+                "<r><p>ab</p><p>cd</p></r>",
+                d1,
+                d2,
+            )
+
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.rootTree().edit(2, 3)
+                },
+                JsonTreeTest.Companion.Updater(c2, d2) { root, _ ->
+                    root.rootTree().edit(3, 5)
+                },
+            ) {
+                JsonTreeTest.assertTreesXmlEquals(
+                    "<r><p>a</p><p>cd</p></r>",
+                    d1,
+                )
+                JsonTreeTest.assertTreesXmlEquals("<r><p>abcd</p></r>", d2)
+            }
+            JsonTreeTest.assertTreesXmlEquals("<r><p>acd</p></r>", d1, d2)
+        }
+    }
+
+    @Test
+    fun test_merge_with_concurrent_full_content_delete_in_source() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        TreeBuilder.element("r") {
+                            element("p") { text { "ab" } }
+                            element("p") { text { "cd" } }
+                        },
+                    )
+                },
+                JsonTreeTest.Companion.Updater(c2, d2),
+            )
+            JsonTreeTest.assertTreesXmlEquals(
+                "<r><p>ab</p><p>cd</p></r>",
+                d1,
+                d2,
+            )
+
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.rootTree().edit(5, 7)
+                },
+                JsonTreeTest.Companion.Updater(c2, d2) { root, _ ->
+                    root.rootTree().edit(3, 5)
+                },
+            ) {
+                JsonTreeTest.assertTreesXmlEquals(
+                    "<r><p>ab</p><p></p></r>",
+                    d1,
+                )
+                JsonTreeTest.assertTreesXmlEquals("<r><p>abcd</p></r>", d2)
+            }
+            JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p></r>", d1, d2)
+        }
+    }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -82,11 +82,25 @@ internal data class CrdtTree(
         )
 
         val (from, diffFrom) = findNodesAndSplitText(range.first, executedAt)
-        val (fromParent, fromLeft) = from
+        val (fromParent, fromLeftRaw) = from
         val (to, diffTo) = findNodesAndSplitText(range.second, executedAt)
-        val (toParent, toLeft) = to
+        val (toParent, toLeftRaw) = to
 
         diff = addDataSizes(diff, diffTo, diffFrom)
+
+        // Advance past split siblings the editor did not know about so range
+        // boundaries land after every unseen split product. Skip when leftRaw
+        // equals the parent (leftmost-child sentinel).
+        val fromLeft = if (fromLeftRaw === fromParent) {
+            fromLeftRaw
+        } else {
+            advancePastUnknownSplitSiblings(fromLeftRaw, versionVector)
+        }
+        val toLeft = if (toLeftRaw === toParent) {
+            toLeftRaw
+        } else {
+            advancePastUnknownSplitSiblings(toLeftRaw, versionVector)
+        }
 
         val changes = mutableListOf<TreeChange>()
 
@@ -201,11 +215,25 @@ internal data class CrdtTree(
 
         // 01. find nodes from the given range and split nodes.
         val (from, diffFrom) = findNodesAndSplitText(range.first, executedAt)
-        val (fromParent, fromLeft) = from
+        val (fromParent, fromLeftRaw) = from
         val (to, diffTo) = findNodesAndSplitText(range.second, executedAt)
-        val (toParent, toLeft) = to
+        val (toParent, toLeftRaw) = to
 
         diff = addDataSizes(diff, diffTo, diffFrom)
+
+        // 01-1. Advance past split siblings the editor did not know about so
+        // range boundaries land after every unseen split product. Skip when
+        // leftRaw equals the parent (leftmost-child sentinel).
+        val fromLeft = if (fromLeftRaw === fromParent) {
+            fromLeftRaw
+        } else {
+            advancePastUnknownSplitSiblings(fromLeftRaw, versionVector)
+        }
+        val toLeft = if (toLeftRaw === toParent) {
+            toLeftRaw
+        } else {
+            advancePastUnknownSplitSiblings(toLeftRaw, versionVector)
+        }
 
         val fromIndex = toIndex(fromParent, fromLeft)
         val fromPath = toPath(fromParent, fromLeft)
@@ -740,6 +768,36 @@ internal data class CrdtTree(
      * must still fire because the node WAS split — [CrdtTreeNode.insNextID]
      * is only set by SplitElement.
      */
+    /**
+     * Walks the [CrdtTreeNode.insNextID] chain from [node], returning the last
+     * element-type sibling whose creation the editor did not know about.
+     * Stops at text nodes, on a sibling whose parent differs from the current
+     * node's parent (moved by a higher-level split), or as soon as a known
+     * sibling is encountered. Treats null or empty [versionVector] as a local
+     * operation and returns [node] unchanged.
+     */
+    private fun advancePastUnknownSplitSiblings(
+        node: CrdtTreeNode,
+        versionVector: VersionVector?,
+    ): CrdtTreeNode {
+        if (versionVector == null || versionVector.size() == 0) return node
+
+        var current = node
+        while (true) {
+            val nextID = current.insNextID ?: return current
+            val next = findFloorNode(nextID) ?: return current
+            if (next.isText) return current
+            if (next.parent !== current.parent) return current
+
+            val actorID = next.id.createdAt.actorID
+            val knownLamport = versionVector.get(actorID)
+            val isUnknown = knownLamport == null || knownLamport < next.id.createdAt.lamport
+            if (!isUnknown) return current
+
+            current = next
+        }
+    }
+
     private fun hasUnknownSplitSibling(node: CrdtTreeNode, versionVector: VersionVector): Boolean {
         val insNextID = node.insNextID ?: return false
         val next = findFloorNode(insNextID) ?: return false


### PR DESCRIPTION
> **RTCOLLABPLATFORM-638**: [[Android] [A2] Fix split sibling convergence via position forwarding](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-638)

## Summary
- Sync-up task **A2** from the Yorkie JS→Android [roadmap](https://wiki.navercorp.com/pages/viewpage.action?pageId=5131863864). Builds on A1 ([#303](https://github.com/yorkie-team/yorkie-android-sdk/pull/303)).
- Ports JS [#1203](https://github.com/yorkie-team/yorkie-js-sdk/pull/1203) (mirrors Go [#1723](https://github.com/yorkie-team/yorkie/pull/1723)).
- Fixes range-boundary divergence when a peer split a node the editor never saw.

## Changes
### `CrdtTree.kt`
- New private helper `advancePastUnknownSplitSiblings(node, versionVector)` — walks the `insNextID` chain, returning the last element-type sibling whose creation lamport exceeds anything `versionVector` recorded for that actor. Stops at text nodes, parent change (higher-level split moved the sibling elsewhere), or the first known sibling. Returns the input unchanged for local ops (`null` or empty `versionVector`).
- `edit` (step 01-1) and `style` now rename their destructured pair to `fromLeftRaw` / `toLeftRaw`, then forward through the helper to produce `fromLeft` / `toLeft` before `traverseInPosRange`. Skipped when `leftRaw === parent` (leftmost-child sentinel — `parent` itself is the "left" indicator).

### Regression tests
Five new instrumented tests in `JsonTreeSplitMergeTest.kt`, ported from JS PR #1203:
- `test_contained_split_and_split_at_different_levels` — inner split boundary lands after the outer split sibling.
- `test_side_by_side_split_and_insert` — sibling insert ends up after both split products.
- `test_side_by_side_split_and_delete` — concurrent delete leaves the split sibling's children intact.
- `test_merge_with_concurrent_content_delete` — `<p>acd</p>` after concurrent merge + content delete.
- `test_merge_with_concurrent_full_content_delete_in_source` — `<p>ab</p>` after merge + full source delete.

## Test plan
- [ ] Instrumented: `./gradlew yorkie:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.yorkie.document.json.JsonTreeSplitMergeTest,dev.yorkie.document.json.JsonTreeConcurrencyTest,dev.yorkie.document.json.JsonTreeTest` — 89 tests, 2 pre-existing skips (`test_concurrent_split_and_split` / `test_concurrent_split_and_edit`, still parked for A3–A5), 0 failed on Pixel_6_API_33.

> Items run automatically by CI (lint, unit tests, coverage) are excluded.
