### PR TITLE
Rename channel terminology from presence → session

### DIFF
--- a/yorkie/proto/yorkie/v1/resources.proto
+++ b/yorkie/proto/yorkie/v1/resources.proto
@@ -439,7 +439,7 @@ message ChannelEvent {
 
   Type type = 1;
   string publisher = 2;
-  int64 count = 3;
+  int64 session_count = 3;
   int64 seq = 4;
   string topic = 5;
   bytes payload = 6;

--- a/yorkie/proto/yorkie/v1/yorkie.proto
+++ b/yorkie/proto/yorkie/v1/yorkie.proto
@@ -129,7 +129,7 @@ message AttachChannelRequest {
 
 message AttachChannelResponse {
   string session_id = 1;
-  int64 count = 2;
+  int64 session_count = 2;
 }
 
 message DetachChannelRequest {
@@ -139,7 +139,7 @@ message DetachChannelRequest {
 }
 
 message DetachChannelResponse {
-  int64 count = 1;
+  int64 session_count = 1;
 }
 
 message RefreshChannelRequest {
@@ -149,7 +149,7 @@ message RefreshChannelRequest {
 }
 
 message RefreshChannelResponse {
-  int64 count = 1;
+  int64 session_count = 1;
 }
 
 message WatchChannelRequest {
@@ -165,7 +165,7 @@ message WatchChannelResponse {
 }
 
 message WatchChannelInitialized {
-  int64 count = 1;
+  int64 session_count = 1;
   int64 seq = 2;
 }
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt
@@ -37,7 +37,7 @@ class ChannelTest {
             assertEquals(channelKey, channel.getKey())
             assertEquals(ResourceStatus.Detached, channel.getStatus())
             assertFalse(channel.isAttached())
-            assertEquals(0L, channel.getCount())
+            assertEquals(0L, channel.getSessionCount())
 
             // Attach channel counter
             c1.attachChannel(channel).await()
@@ -45,7 +45,7 @@ class ChannelTest {
             // Verify attached state
             assertEquals(ResourceStatus.Attached, channel.getStatus())
             assertTrue(channel.isAttached())
-            assertEquals(1L, channel.getCount())
+            assertEquals(1L, channel.getSessionCount())
 
             // Detach channel counter
             c1.detachChannel(channel).await()
@@ -78,45 +78,45 @@ class ChannelTest {
 
             // First client attaches
             c1.attachChannel(channel1).await()
-            assertEquals(1L, channel1.getCount())
+            assertEquals(1L, channel1.getSessionCount())
 
             // Second client attaches
             c2.attachChannel(channel2).await()
-            assertEquals(2L, channel2.getCount())
+            assertEquals(2L, channel2.getSessionCount())
 
             // First client should receive the update
             withTimeout(GENERAL_TIMEOUT) {
-                while (channel1.getCount() != 2L) {
+                while (channel1.getSessionCount() != 2L) {
                     delay(50)
                 }
             }
-            assertEquals(2L, channel1.getCount())
+            assertEquals(2L, channel1.getSessionCount())
 
             // Third client attaches
             c3.attachChannel(channel3).await()
-            assertEquals(3L, channel3.getCount())
+            assertEquals(3L, channel3.getSessionCount())
 
             // Wait for all clients to sync
             withTimeout(GENERAL_TIMEOUT) {
-                while (channel1.getCount() != 3L || channel2.getCount() != 3L) {
+                while (channel1.getSessionCount() != 3L || channel2.getSessionCount() != 3L) {
                     delay(50)
                 }
             }
-            assertEquals(3L, channel1.getCount())
-            assertEquals(3L, channel2.getCount())
+            assertEquals(3L, channel1.getSessionCount())
+            assertEquals(3L, channel2.getSessionCount())
 
             // One client detaches
             c2.detachChannel(channel2).await()
-            assertEquals(2L, channel2.getCount())
+            assertEquals(2L, channel2.getSessionCount())
 
             // Other clients should see the count decrease
             withTimeout(GENERAL_TIMEOUT) {
-                while (channel1.getCount() != 2L || channel3.getCount() != 2L) {
+                while (channel1.getSessionCount() != 2L || channel3.getSessionCount() != 2L) {
                     delay(50)
                 }
             }
-            assertEquals(2L, channel1.getCount())
-            assertEquals(2L, channel3.getCount())
+            assertEquals(2L, channel1.getSessionCount())
+            assertEquals(2L, channel3.getSessionCount())
 
             // Cleanup
             c1.detachChannel(channel1).await()
@@ -161,7 +161,7 @@ class ChannelTest {
 
             // Should receive initialized event
             assertIs<ChannelEvent.Initialized>(events[0])
-            assertEquals(1L, events[0].count)
+            assertEquals(1L, events[0].sessionCount)
 
             // Second client attaches
             c2.attachChannel(channel2).await()
@@ -173,7 +173,7 @@ class ChannelTest {
 
             // Should receive count-changed event
             assertIs<ChannelEvent.Changed>(events.last())
-            assertEquals(2L, events.last().count)
+            assertEquals(2L, events.last().sessionCount)
 
             // Cleanup
             collectJob.cancel()
@@ -204,24 +204,24 @@ class ChannelTest {
             c2.attachChannel(channel2).await()
 
             withTimeout(GENERAL_TIMEOUT) {
-                while (channel1.getCount() != 2L || channel2.getCount() != 2L) {
+                while (channel1.getSessionCount() != 2L || channel2.getSessionCount() != 2L) {
                     delay(50)
                 }
             }
-            assertEquals(2L, channel1.getCount())
-            assertEquals(2L, channel2.getCount())
+            assertEquals(2L, channel1.getSessionCount())
+            assertEquals(2L, channel2.getSessionCount())
 
             // One detaches
             c1.detachChannel(channel1).await()
-            assertEquals(1L, channel1.getCount())
+            assertEquals(1L, channel1.getSessionCount())
 
             // Other channel should also see the decrease
             withTimeout(GENERAL_TIMEOUT) {
-                while (channel2.getCount() != 1L) {
+                while (channel2.getSessionCount() != 1L) {
                     delay(50)
                 }
             }
-            assertEquals(1L, channel2.getCount())
+            assertEquals(1L, channel2.getSessionCount())
 
             // Cleanup
             c2.detachChannel(channel2).await()
@@ -248,7 +248,7 @@ class ChannelTest {
 
             // Attach channel counter
             c1.attachChannel(channel).await()
-            assertEquals(1L, channel.getCount())
+            assertEquals(1L, channel.getSessionCount())
 
             // Wait for 3 heartbeat cycles (3 seconds)
             // The channel should still be active because heartbeat refreshes TTL
@@ -256,7 +256,7 @@ class ChannelTest {
 
             // Verify channel is still active
             assertTrue(channel.isAttached())
-            assertEquals(1L, channel.getCount())
+            assertEquals(1L, channel.getSessionCount())
 
             // Cleanup
             c1.detachChannel(channel).await()
@@ -281,29 +281,29 @@ class ChannelTest {
 
             // Attach client1 with manual sync mode (no watch stream)
             c1.attachChannel(p1, isRealtime = false).await()
-            assertEquals(1L, p1.getCount())
+            assertEquals(1L, p1.getSessionCount())
 
             // Attach client2 with manual sync mode
             c2.attachChannel(p2, isRealtime = false).await()
-            assertEquals(2L, p2.getCount())
+            assertEquals(2L, p2.getSessionCount())
 
             // In manual mode, p1's count doesn't update automatically
             // even though p2 was attached
             delay(500)
-            assertEquals(1L, p1.getCount())
+            assertEquals(1L, p1.getSessionCount())
 
             // Must call syncAsync() explicitly to refresh TTL and fetch latest count
             c1.syncAsync(p1).await()
-            assertEquals(2L, p1.getCount())
+            assertEquals(2L, p1.getSessionCount())
 
             // Detach p2 and verify p1 doesn't auto-update
             c2.detachChannel(p2).await()
             delay(500)
-            assertEquals(2L, p1.getCount())
+            assertEquals(2L, p1.getSessionCount())
 
             // Sync to refresh TTL and fetch latest count after c2 detached
             c1.syncAsync(p1).await()
-            assertEquals(1L, p1.getCount())
+            assertEquals(1L, p1.getSessionCount())
 
             // Cleanup
             c1.detachChannel(p1).await()
@@ -332,37 +332,37 @@ class ChannelTest {
 
             // c1: Attach with realtime mode (default)
             c1.attachChannel(realtimeChannel).await()
-            assertEquals(1L, realtimeChannel.getCount())
+            assertEquals(1L, realtimeChannel.getSessionCount())
 
             // c2: Attach with manual mode
             c2.attachChannel(manualChannel, isRealtime = false).await()
-            assertEquals(2L, manualChannel.getCount())
+            assertEquals(2L, manualChannel.getSessionCount())
 
             // c1's realtime channel should automatically receive the update
             withTimeout(GENERAL_TIMEOUT) {
-                while (realtimeChannel.getCount() != 2L) {
+                while (realtimeChannel.getSessionCount() != 2L) {
                     delay(50)
                 }
             }
-            assertEquals(2L, realtimeChannel.getCount())
+            assertEquals(2L, realtimeChannel.getSessionCount())
 
             // c2's manual channel doesn't receive updates
-            assertEquals(2L, manualChannel.getCount())
+            assertEquals(2L, manualChannel.getSessionCount())
 
             // c3: Attach another client
             c3.attachChannel(thirdChannel, isRealtime = false).await()
-            assertEquals(3L, thirdChannel.getCount())
+            assertEquals(3L, thirdChannel.getSessionCount())
 
             // c1's realtime channel receives the update automatically
             withTimeout(GENERAL_TIMEOUT) {
-                while (realtimeChannel.getCount() != 3L) {
+                while (realtimeChannel.getSessionCount() != 3L) {
                     delay(50)
                 }
             }
-            assertEquals(3L, realtimeChannel.getCount())
+            assertEquals(3L, realtimeChannel.getSessionCount())
 
             // c2's manual channel still doesn't update
-            assertEquals(2L, manualChannel.getCount())
+            assertEquals(2L, manualChannel.getSessionCount())
 
             // Cleanup
             c1.detachChannel(realtimeChannel).await()

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -367,7 +367,7 @@ public class Client(
                             request,
                             resource.getKey().attachmentBasedRequestHeader,
                         ).getOrThrow()
-                        resource.updateCount(response.count, 0L)
+                        resource.updateSessionCount(response.sessionCount, 0L)
                         attachment.updateHeartbeatTime()
                     }
                 }
@@ -714,22 +714,22 @@ public class Client(
 
     private fun handleWatchChannelResponse(channel: Channel, response: WatchChannelResponse) {
         if (response.hasInitialized()) {
-            val count = response.initialized.count
+            val sessionCount = response.initialized.sessionCount
             val seq = response.initialized.seq
-            if (channel.updateCount(count, seq)) {
+            if (channel.updateSessionCount(sessionCount, seq)) {
                 channel.publish(
-                    ChannelEvent.Initialized(count = count),
+                    ChannelEvent.Initialized(sessionCount = sessionCount),
                 )
             }
         } else if (response.hasEvent()) {
             val event = response.event
             when (event.type) {
                 PbChannelEventType.TYPE_PRESENCE -> {
-                    val count = event.count
+                    val sessionCount = event.sessionCount
                     val seq = event.seq
-                    if (channel.updateCount(count, seq)) {
+                    if (channel.updateSessionCount(sessionCount, seq)) {
                         channel.publish(
-                            ChannelEvent.Changed(count = count),
+                            ChannelEvent.Changed(sessionCount = sessionCount),
                         )
                     }
                 }
@@ -1032,7 +1032,7 @@ public class Client(
                 }
 
                 channel.setSessionId(response.sessionId)
-                channel.updateCount(response.count, 0L)
+                channel.updateSessionCount(response.sessionCount, 0L)
                 channel.applyStatus(ResourceStatus.Attached)
 
                 val syncMode = if (isRealtime != false) {
@@ -1097,7 +1097,7 @@ public class Client(
                 return@async Result.failure(it)
             }
 
-            channel.updateCount(response.count, 0L)
+            channel.updateSessionCount(response.sessionCount, 0L)
             channel.applyStatus(ResourceStatus.Detached)
             channel.close()
 

--- a/yorkie/src/main/kotlin/dev/yorkie/presence/Channel.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/presence/Channel.kt
@@ -14,16 +14,16 @@ import kotlinx.coroutines.launch
 
 sealed interface ChannelEvent : ResourceEvent {
     /**
-     * Current count value. Zero for non-count events.
+     * Current session count value. Zero for non-count events.
      */
-    val count: Long
+    val sessionCount: Long
 
     data class Changed(
-        override val count: Long,
+        override val sessionCount: Long,
     ) : ChannelEvent
 
     data class Initialized(
-        override val count: Long,
+        override val sessionCount: Long,
     ) : ChannelEvent
 
     /**
@@ -34,7 +34,7 @@ sealed interface ChannelEvent : ResourceEvent {
         val topic: String,
         val payload: String,
     ) : ChannelEvent {
-        override val count: Long = 0L
+        override val sessionCount: Long = 0L
     }
 }
 
@@ -52,7 +52,7 @@ class Channel(
     private var sessionId: String? = null
 
     @Volatile
-    private var count = 0L
+    private var sessionCount = 0L
 
     @Volatile
     private var seq = 0L
@@ -96,25 +96,48 @@ class Channel(
     }
 
     /**
-     * `getCount` returns the current count value.
+     * `getSessionCount` returns the current online session count value.
      */
-    fun getCount(): Long {
-        return count
+    fun getSessionCount(): Long {
+        return sessionCount
     }
 
     /**
-     * `updateCount` updates the count and sequence number if the sequence is newer.
-     * Returns true if the count was updated, false if the update was ignored.
+     * `getCount` returns the current online session count value.
      */
-    fun updateCount(count: Long, seq: Long): Boolean {
+    @Deprecated(
+        "Renamed to getSessionCount",
+        replaceWith = ReplaceWith("getSessionCount()"),
+    )
+    fun getCount(): Long {
+        return getSessionCount()
+    }
+
+    /**
+     * `updateSessionCount` updates the session count and sequence number if the sequence is newer.
+     * Returns true if the session count was updated, false if the update was ignored.
+     */
+    fun updateSessionCount(sessionCount: Long, seq: Long): Boolean {
         // Always accept initialization (seq === 0)
         if (seq == 0L || seq > this.seq) {
-            this.count = count
+            this.sessionCount = sessionCount
             this.seq = seq
             return true
         }
 
         return false
+    }
+
+    /**
+     * `updateCount` updates the session count and sequence number if the sequence is newer.
+     * Returns true if the session count was updated, false if the update was ignored.
+     */
+    @Deprecated(
+        "Renamed to updateSessionCount",
+        replaceWith = ReplaceWith("updateSessionCount(sessionCount, seq)"),
+    )
+    fun updateCount(count: Long, seq: Long): Boolean {
+        return updateSessionCount(count, seq)
     }
 
     /**

--- a/yorkie/src/test/kotlin/dev/yorkie/presence/ChannelTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/presence/ChannelTest.kt
@@ -8,31 +8,31 @@ import org.junit.Test
 class ChannelTest {
 
     @Test
-    fun `updateCount ignores stale sequence number`() {
+    fun `updateSessionCount ignores stale sequence number`() {
         // given
         val channel = Channel("key")
-        channel.updateCount(5L, 10L)
+        channel.updateSessionCount(5L, 10L)
 
         // when
-        val updated = channel.updateCount(3L, 9L)
+        val updated = channel.updateSessionCount(3L, 9L)
 
         // then
         assertFalse(updated)
-        assertEquals(5L, channel.getCount())
+        assertEquals(5L, channel.getSessionCount())
     }
 
     @Test
-    fun `updateCount accepts seq zero as initialization bypass`() {
+    fun `updateSessionCount accepts seq zero as initialization bypass`() {
         // given
         val channel = Channel("key")
-        channel.updateCount(5L, 10L)
+        channel.updateSessionCount(5L, 10L)
 
         // when
-        val updated = channel.updateCount(2L, 0L)
+        val updated = channel.updateSessionCount(2L, 0L)
 
         // then
         assertTrue(updated)
-        assertEquals(2L, channel.getCount())
+        assertEquals(2L, channel.getSessionCount())
     }
 
     @Test


### PR DESCRIPTION
> **RTCOLLABPLATFORM-662**: [[Android] [D1] Rename channel terminology from presence → session](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-662)

## Summary

- Sync-up task D1 from the Yorkie JS→Android roadmap.
- Ports JS PR yorkie-team/yorkie-js-sdk#1154.
- Renames the `count` field to `session_count` in channel proto messages, and renames the corresponding Kotlin API (`getCount()` → `getSessionCount()`, `updateCount()` → `updateSessionCount()`, `ChannelEvent.count` → `ChannelEvent.sessionCount`).
- Deprecated aliases added for `getCount()` and `updateCount()` to avoid a hard public-API break for existing consumers.

## Changes

- **`yorkie/proto/yorkie/v1/resources.proto`**: `ChannelEvent.count` (field 3) → `session_count`
- **`yorkie/proto/yorkie/v1/yorkie.proto`**: `AttachChannelResponse.count`, `DetachChannelResponse.count`, `RefreshChannelResponse.count`, `WatchChannelInitialized.count` → `session_count`
- **`yorkie/src/main/kotlin/dev/yorkie/presence/Channel.kt`**: `getCount()` → `getSessionCount()`, `updateCount()` → `updateSessionCount()`, internal field `count` → `sessionCount`; `ChannelEvent.count` → `ChannelEvent.sessionCount`; deprecated aliases kept
- **`yorkie/src/main/kotlin/dev/yorkie/core/Client.kt`**: Updated all call-sites to use `response.sessionCount`, `updateSessionCount()`, `getSessionCount()`, `ChannelEvent.Initialized(sessionCount = ...)`, `ChannelEvent.Changed(sessionCount = ...)`
- **`yorkie/src/test/kotlin/dev/yorkie/presence/ChannelTest.kt`**: Updated unit tests to call `updateSessionCount()`/`getSessionCount()` and renamed test method names
- **`yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt`**: Updated instrumented tests to use `getSessionCount()` and `event.sessionCount`

## Test plan

- [x] `./gradlew yorkie:testDebugUnitTest` — all unit tests pass (3 `ChannelTest` + full suite)
- [x] `./gradlew lintKotlin` — no lint errors
- [x] `ANDROID_SERIAL=emulator-5554 ./gradlew yorkie:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.yorkie.presence.ChannelTest` — 9/9 instrumented tests pass

> Items run automatically by CI (lint, unit tests, coverage) are excluded.