### PR TITLE
Fix multi-level split + merge divergence via mergedFrom

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeSplitMergeTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeSplitMergeTest.kt
@@ -7,6 +7,7 @@ import dev.yorkie.core.withTwoClientsAndDocuments
 import dev.yorkie.document.json.JsonTreeTest.Companion.rootTree
 import dev.yorkie.document.json.JsonTreeTest.Companion.updateAndSync
 import kotlin.test.assertEquals
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -636,6 +637,160 @@ class JsonTreeSplitMergeTest {
                 JsonTreeTest.assertTreesXmlEquals("<r><p>abcd</p></r>", d2)
             }
             JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p></r>", d1, d2)
+        }
+    }
+
+    @Test
+    fun test_cascade_delete_across_parent_after_multi_level_split() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        TreeBuilder.element("r") {
+                            element("p") {
+                                element("p") { text { "ab" } }
+                                element("p") { text { "cd" } }
+                            }
+                        },
+                    )
+                },
+                JsonTreeTest.Companion.Updater(c2, d2),
+            )
+            JsonTreeTest.assertTreesXmlEquals(
+                "<r><p><p>ab</p><p>cd</p></p></r>",
+                d1,
+                d2,
+            )
+
+            // d1: multi-level split at position 3 (splitLevel=2)
+            // d2: merge-delete from 1 to 6 (removes inner p1 and its content)
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.rootTree().edit(3, 3, 2)
+                },
+                JsonTreeTest.Companion.Updater(c2, d2) { root, _ ->
+                    root.rootTree().edit(1, 6)
+                },
+            ) {
+                JsonTreeTest.assertTreesXmlEquals(
+                    "<r><p><p>a</p></p><p><p>b</p><p>cd</p></p></r>",
+                    d1,
+                )
+                JsonTreeTest.assertTreesXmlEquals("<r><p>cd</p></r>", d2)
+            }
+
+            JsonTreeTest.assertTreesXmlEquals("<r><p>cd</p><p></p></r>", d1, d2)
+        }
+    }
+
+    @Test
+    fun test_sequential_merge_then_split() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        TreeBuilder.element("r") {
+                            element("p") { text { "ab" } }
+                            element("p") { text { "cd" } }
+                        },
+                    )
+                },
+                JsonTreeTest.Companion.Updater(c2, d2),
+            )
+            JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p><p>cd</p></r>", d1, d2)
+
+            // d1: merge two paragraphs (sequential, c2 will learn about it)
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.rootTree().edit(3, 5)
+                },
+                JsonTreeTest.Companion.Updater(c2, d2),
+            )
+            JsonTreeTest.assertTreesXmlEquals("<r><p>abcd</p></r>", d1, d2)
+
+            // d2: split the merged paragraph at ab|cd (sequential, knows about merge)
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1),
+                JsonTreeTest.Companion.Updater(c2, d2) { root, _ ->
+                    root.rootTree().edit(3, 3, 1)
+                },
+            )
+            JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p><p>cd</p></r>", d1, d2)
+        }
+    }
+
+    @Test
+    fun test_multi_level_split_with_concurrent_merge_and_text_split() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        TreeBuilder.element("r") {
+                            element("p") {
+                                element("p") { text { "ab" } }
+                                element("p") { text { "cd" } }
+                            }
+                        },
+                    )
+                },
+                JsonTreeTest.Companion.Updater(c2, d2),
+            )
+            JsonTreeTest.assertTreesXmlEquals(
+                "<r><p><p>ab</p><p>cd</p></p></r>",
+                d1,
+                d2,
+            )
+
+            // d1: multi-level split at position 3 (splitLevel=2)
+            // d2: merge the two inner paragraphs (edit 1 to 6)
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.rootTree().edit(3, 3, 2)
+                },
+                JsonTreeTest.Companion.Updater(c2, d2) { root, _ ->
+                    root.rootTree().edit(1, 6)
+                },
+            )
+
+            JsonTreeTest.assertTreesXmlEquals(d1.getRoot().rootTree().toXml(), d1, d2)
+        }
+    }
+
+    @Ignore("TODO: fix concurrent delete + split convergence on overlapping content")
+    @Test
+    fun test_split_with_concurrent_delete_overlapping_content() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        TreeBuilder.element("r") {
+                            element("p") { text { "abcd" } }
+                        },
+                    )
+                },
+                JsonTreeTest.Companion.Updater(c2, d2),
+            )
+            JsonTreeTest.assertTreesXmlEquals("<r><p>abcd</p></r>", d1, d2)
+
+            // d1: delete "bc" (positions 2-4)
+            // d2: split <p> at position 3 (between b and c) with splitLevel=1
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.rootTree().edit(2, 4)
+                },
+                JsonTreeTest.Companion.Updater(c2, d2) { root, _ ->
+                    root.rootTree().edit(3, 3, 1)
+                },
+            ) {
+                JsonTreeTest.assertTreesXmlEquals("<r><p>ad</p></r>", d1)
+                JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p><p>cd</p></r>", d2)
+            }
+
+            JsonTreeTest.assertTreesXmlEquals(d1.getRoot().rootTree().toXml(), d1, d2)
         }
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -350,6 +350,9 @@ internal data class CrdtTree(
                     }
                     ids.add(node.id)
                 }
+                // Record source parent for split-skip check (Fix 8).
+                node.mergedFrom = oldParent.id
+                node.mergedAt = executedAt
                 // Detach from old parent to prevent ghost references. Swallow
                 // NoSuchElementException: a cascade delete of a split sibling
                 // may have already detached the child.
@@ -403,7 +406,7 @@ internal data class CrdtTree(
             var parent = fromParent
             var left = fromLeft
             repeat(splitLevel) {
-                parent.split(this, parent.findOffset(left) + 1, issueTimeTicket)
+                parent.split(this, parent.findOffset(left) + 1, issueTimeTicket, versionVector)
                 left = parent
                 parent = parent.parent ?: return@repeat
             }
@@ -1148,6 +1151,21 @@ internal data class CrdtTreeNode(
      */
     var mergedChildIDs: MutableList<CrdtTreeNodeID>? = null
 
+    /**
+     * Runtime-only reverse pointer recording the source parent this node was
+     * moved from during a merge. Used by splitElement to keep merge-moved
+     * children in the original node instead of moving them to the split sibling
+     * when the merge is concurrent with the split.
+     */
+    var mergedFrom: CrdtTreeNodeID? = null
+
+    /**
+     * Runtime-only timestamp recording when the merge that moved this node
+     * was executed. Compared against the split editor's [VersionVector] to
+     * detect concurrency.
+     */
+    var mergedAt: TimeTicket? = null
+
     val rhtNodes: Iterable<RhtNode>
         get() = _attributes
 
@@ -1181,11 +1199,12 @@ internal data class CrdtTreeNode(
         tree: CrdtTree,
         offset: Int,
         issueTimeTicket: (() -> TimeTicket)? = null,
+        versionVector: VersionVector? = null,
     ): Pair<CrdtTreeNode?, DataSize> {
         val (split, diff) = if (isText) {
             splitText(offset, id.offset)
         } else {
-            splitElement(offset, requireNotNull(issueTimeTicket))
+            splitElement(offset, versionVector, requireNotNull(issueTimeTicket))
         }
 
         val node = this
@@ -1291,6 +1310,23 @@ internal data class CrdtTreeNode(
         }
         val nodeExisted = createdAt.lamport <= clientLamportAtChange
         return nodeExisted && (removedAt == null || executedAt > removedAt)
+    }
+
+    /**
+     * Returns true when [child] should stay in the original (left) node rather
+     * than moving to the split sibling. Vetoes the move when the child was
+     * relocated by a concurrent merge that the split editor did not yet know
+     * about (checked via [versionVector]). Local splits always know about all
+     * prior operations, so never veto.
+     */
+    override fun shouldKeepChildInLeft(
+        child: CrdtTreeNode,
+        versionVector: VersionVector?,
+    ): Boolean {
+        if (versionVector == null || versionVector.size() == 0) return false
+        val mergedAt = child.mergedAt ?: return false
+        child.mergedFrom ?: return false
+        return !versionVector.afterOrEqual(mergedAt)
     }
 
     override fun delete(node: RhtNode) {

--- a/yorkie/src/main/kotlin/dev/yorkie/util/IndexTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/IndexTree.kt
@@ -1,6 +1,7 @@
 package dev.yorkie.util
 
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.document.time.VersionVector
 
 /**
  * About `index`, `path`, `size` and `TreePos` in crdt.IndexTree.
@@ -759,7 +760,11 @@ abstract class IndexTreeNode<T : IndexTreeNode<T>> {
         )
     }
 
-    fun splitElement(offset: Int, issueTimeTicket: () -> TimeTicket): Pair<T?, DataSize> {
+    fun splitElement(
+        offset: Int,
+        versionVector: VersionVector? = null,
+        issueTimeTicket: () -> TimeTicket,
+    ): Pair<T?, DataSize> {
         var diff = DataSize(
             data = 0,
             meta = 0,
@@ -772,11 +777,39 @@ abstract class IndexTreeNode<T : IndexTreeNode<T>> {
         clone.updateAncestorSize(clone.paddedSize(true), true)
 
         clone.childNodes.clear()
+
+        // Fix 8: Keep merge-moved children in the original (left) node when
+        // the merge is concurrent with this split. A child should stay left if
+        // it carries a mergedFrom marker whose mergedAt ticket is not covered
+        // by the editor's versionVector (i.e. the editor did not know about
+        // the merge when it issued the split). The boundary check prevents
+        // veto when the split position itself is inside merged content.
+        val hasVersionVector = versionVector != null && versionVector.size() > 0
+        val boundaryNode = if (offset > 0) childNodes.getOrNull(offset - 1) else null
+        val boundaryIsMerged = boundaryNode != null &&
+            shouldKeepChildInLeft(boundaryNode, versionVector)
+
+        val movedToLeft = mutableListOf<T>()
         repeat(childNodes.size - offset) {
             val rightChild = childNodes.removeAt(offset)
-            clone.childNodes.add(rightChild)
-            rightChild.parent = clone
+            // Veto moving this child to the clone if it was moved here by a
+            // concurrent merge and the split did not know about it.
+            if (!boundaryIsMerged && hasVersionVector &&
+                shouldKeepChildInLeft(rightChild, versionVector)
+            ) {
+                movedToLeft.add(rightChild)
+            } else {
+                clone.childNodes.add(rightChild)
+                rightChild.parent = clone
+            }
         }
+        // Re-insert the vetoed children at the end of the left node
+        // (they stay in this.childNodes, with corrected parent pointer).
+        movedToLeft.forEach { child ->
+            childNodes.add(child)
+            child.parent = this as T
+        }
+
         visibleSize = childNodes.fold(0) { acc, child ->
             acc + child.paddedSize(false)
         }
@@ -802,6 +835,13 @@ abstract class IndexTreeNode<T : IndexTreeNode<T>> {
             second = diff,
         )
     }
+
+    /**
+     * Returns true when [child] should be kept in the original (left) node
+     * rather than moved to the split sibling. Subclasses override this to
+     * implement merge-aware split semantics. The default always returns false.
+     */
+    open fun shouldKeepChildInLeft(child: T, versionVector: VersionVector?): Boolean = false
 
     private fun insertAfterInternal(targetNode: T, newNode: T) {
         check(!isText) {


### PR DESCRIPTION
> **RTCOLLABPLATFORM-639**: [[Android] [A3] Fix multi-level split + merge divergence via mergedFrom](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-639)

## Summary
- Sync-up task **A3** from the Yorkie JS→Android [roadmap](https://wiki.navercorp.com/pages/viewpage.action?pageId=5131863864). Builds on A1 ([#303](https://github.com/yorkie-team/yorkie-android-sdk/pull/303)) and A2 ([#304](https://github.com/yorkie-team/yorkie-android-sdk/pull/304)).
- Ports JS [#1204](https://github.com/yorkie-team/yorkie-js-sdk/pull/1204) (Fix 8).
- Fixes the multi-level convergence gap where a node moved by a merge on one replica was wrongly relocated to a new split sibling on another replica.

## Changes

### `CrdtTree.kt`
- `CrdtTreeNode` gains two reverse-pointer fields: `mergedFrom: CrdtTreeNodeID?` and `mergedAt: TimeTicket?` — set on each child that was moved during the merge step of `edit()`.
- `split()` now takes a `versionVector` and forwards it.
- New `shouldKeepChildInLeft` override uses `VersionVector.afterOrEqual` to detect when a concurrent split editor did not know about the merge that moved the child — in that case the child stays in the original (left) node.

### `IndexTree.kt`
- `splitElement` accepts `versionVector`.
- Fix 8 logic introduces a `movedToLeft` veto list so children whose `mergedFrom`/`mergedAt` indicates an unseen merge stay put instead of being shoved into the new split sibling.
- New `shouldKeepChildInLeft` open hook with default `false`.

### Regression tests
Three new active tests in `JsonTreeSplitMergeTest.kt`, ported from JS PR #1204:
- `test_cascade_delete_across_parent_after_multi_level_split`
- `test_sequential_merge_then_split`
- `test_multi_level_split_with_concurrent_merge_and_text_split`

One additional `@Ignore`'d test for a known remaining edge case beyond Fix 8's scope.

## Test plan
- [ ] Instrumented: `./gradlew yorkie:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.yorkie.document.json.JsonTreeSplitMergeTest,dev.yorkie.document.json.JsonTreeConcurrencyTest,dev.yorkie.document.json.JsonTreeTest` — `JsonTreeSplitMergeTest` 21 passed, 1 `@Ignore`'d (out of scope for Fix 8); existing pre-existing skips elsewhere preserved.

> Items run automatically by CI (lint, unit tests, coverage) are excluded.
