### PR TITLE
Fix split + delete divergence and splitElement tombstone handling

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeSplitMergeTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeSplitMergeTest.kt
@@ -7,7 +7,6 @@ import dev.yorkie.core.withTwoClientsAndDocuments
 import dev.yorkie.document.json.JsonTreeTest.Companion.rootTree
 import dev.yorkie.document.json.JsonTreeTest.Companion.updateAndSync
 import kotlin.test.assertEquals
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -759,7 +758,6 @@ class JsonTreeSplitMergeTest {
         }
     }
 
-    @Ignore("TODO: fix concurrent delete + split convergence on overlapping content")
     @Test
     fun test_split_with_concurrent_delete_overlapping_content() {
         withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
@@ -790,7 +788,7 @@ class JsonTreeSplitMergeTest {
                 JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p><p>cd</p></r>", d2)
             }
 
-            JsonTreeTest.assertTreesXmlEquals(d1.getRoot().rootTree().toXml(), d1, d2)
+            JsonTreeTest.assertTreesXmlEquals("<r><p>a</p><p>d</p></r>", d1, d2)
         }
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -254,9 +254,20 @@ internal data class CrdtTree(
         ) { (node, tokenType), ended ->
             // NOTE(hackerwins): If the node overlaps as a start tag with the
             // range then we need to move the remaining children to fromParent.
+            // Fix 9: Skip merge for elements created by concurrent operations.
+            // The editor didn't know about this element, so crossing into it is
+            // an artifact of a concurrent split, not an intentional merge.
             if (tokenType == TokenType.Start && !ended) {
-                toBeMergedNodes.add(node)
-                toBeMovedToFromParents.addAll(node.children)
+                val nodeCreationKnown = if (isLocal) {
+                    true
+                } else {
+                    val createdAtVV = versionVector?.get(node.createdAt.actorID)
+                    createdAtVV != null && createdAtVV >= node.createdAt.lamport
+                }
+                if (nodeCreationKnown) {
+                    toBeMergedNodes.add(node)
+                    toBeMovedToFromParents.addAll(node.children)
+                }
             }
 
             // Compute per-node creationKnown and tombstoneKnown for LWW semantics
@@ -340,8 +351,7 @@ internal data class CrdtTree(
         // 02. Delete: delete the nodes that are marked as removed.
         val gcPairs = mutableListOf<GCPair<CrdtTreeNode>>()
         nodesToBeRemoved.forEach { node ->
-            node.remove(executedAt)
-            if (node.isRemoved) {
+            if (node.remove(executedAt)) {
                 gcPairs.add(GCPair(this, node))
             }
         }
@@ -391,15 +401,13 @@ internal data class CrdtTree(
                 mergedChildIDs.forEach { childID ->
                     val child = findFloorNode(childID)
                     if (child != null && child.removedAt == null) {
-                        child.remove(executedAt)
-                        if (child.isRemoved) {
+                        if (child.remove(executedAt)) {
                             gcPairs.add(GCPair(this, child))
                         }
                         // Also tombstone descendants if the moved child is an element.
                         traverseAll(child) { n, _ ->
                             if (n !== child && n.removedAt == null) {
-                                n.remove(executedAt)
-                                if (n.isRemoved) {
+                                if (n.remove(executedAt)) {
                                     gcPairs.add(GCPair(this, n))
                                 }
                             }
@@ -1186,7 +1194,12 @@ internal data class CrdtTreeNode(
     /**
      * Clones this text node with the given [offset].
      */
-    override fun cloneText(offset: Int) = clone(offset, id.createdAt)
+    override fun cloneText(offset: Int): CrdtTreeNode {
+        return clone(offset, id.createdAt).apply {
+            mergedFrom = this@CrdtTreeNode.mergedFrom
+            mergedAt = this@CrdtTreeNode.mergedAt
+        }
+    }
 
     /**
      * Clones this element node with the given [issueTimeTicket] function.
@@ -1260,9 +1273,9 @@ internal data class CrdtTreeNode(
     }
 
     /**
-     * Marks the node as removed.
+     * Marks the node as removed. Returns true if the node was newly tombstoned.
      */
-    fun remove(executedAt: TimeTicket) {
+    fun remove(executedAt: TimeTicket): Boolean {
         val alived = removedAt == null
 
         if (alived || removedAt < executedAt) {
@@ -1271,6 +1284,7 @@ internal data class CrdtTreeNode(
         if (alived) {
             updateAncestorSize(-paddedSize())
         }
+        return alived
     }
 
     /**
@@ -1294,6 +1308,10 @@ internal data class CrdtTreeNode(
             it.removedAt = removedAt
             it.insPrevID = insPrevID
             it.insNextID = insNextID
+            it.mergedInto = mergedInto
+            it.mergedChildIDs = mergedChildIDs?.toMutableList()
+            it.mergedFrom = mergedFrom
+            it.mergedAt = mergedAt
             if (it.isText) {
                 it.value = value
             }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTreeTest.kt
@@ -412,6 +412,56 @@ class CrdtTreeTest {
         assertEquals("<root><p>ab</p><b>cd</b><p>ef</p></root>", target.toXml())
     }
 
+    @Test
+    fun `splitText preserves mergedFrom and mergedAt`() {
+        // given
+        val para = CrdtTreeElement(issuePos(), "p")
+        val text = CrdtTreeText(issuePos(), "abcd")
+        para.append(text)
+
+        val sourceID = issuePos()
+        val mergeTicket = issueTime()
+        text.mergedFrom = sourceID
+        text.mergedAt = mergeTicket
+
+        // when
+        val (right) = text.splitText(2, 0)
+
+        // then
+        assertEquals("ab", text.value)
+        assertEquals("cd", right?.value)
+        assertEquals(sourceID, right?.mergedFrom)
+        assertEquals(mergeTicket, right?.mergedAt)
+    }
+
+    @Test
+    fun `deepCopy preserves merge metadata`() {
+        // given
+        val para = CrdtTreeElement(issuePos(), "p")
+        val text = CrdtTreeText(issuePos(), "hello")
+        para.append(text)
+
+        val targetID = issuePos()
+        val sourceID = issuePos()
+        val childID = issuePos()
+        val mergeTicket = issueTime()
+
+        para.mergedInto = targetID
+        para.mergedChildIDs = mutableListOf(childID)
+        text.mergedFrom = sourceID
+        text.mergedAt = mergeTicket
+
+        // when
+        val clone = para.deepCopy()
+
+        // then
+        assertEquals(targetID, clone.mergedInto)
+        assertEquals(listOf(childID), clone.mergedChildIDs)
+        val clonedText = clone.allChildren.first()
+        assertEquals(sourceID, clonedText.mergedFrom)
+        assertEquals(mergeTicket, clonedText.mergedAt)
+    }
+
     private fun issuePos(offset: Int = 0) = CrdtTreeNodeID(issueTime(), offset)
 
     private fun CrdtTreeNode.toList() = listOf(this)


### PR DESCRIPTION
> **RTCOLLABPLATFORM-640**: [[Android] [A4] Fix split + delete divergence and splitElement tombstone handling](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-640)

Ports https://github.com/yorkie-team/yorkie-js-sdk/pull/1205.

## Summary
- Fix 9: When a delete range crosses into an element created by a concurrent split, skip merge behavior — the editor didn't know about the split element, so the boundary crossing is an artifact, not an intentional merge
- Use return value of `remove()` to detect newly tombstoned nodes, preventing duplicate GCPair entries
- Propagate `mergedFrom`/`mergedAt` through `cloneText` so split text fragments carry merge metadata; copy all four merge fields in `deepCopy`

## Changes
- `CrdtTree.kt`: Add version vector check at merge detection in `edit()` traversal (Fix 9); change `remove()` to return `Boolean` and update all call sites; propagate merge metadata in `cloneText` and `deepCopy`
- `JsonTreeSplitMergeTest.kt`: Enable previously skipped `test_split_with_concurrent_delete_overlapping_content` with explicit converged XML assertion
- `CrdtTreeTest.kt`: Add unit tests for `splitText` merge metadata propagation and `deepCopy` merge metadata preservation

## Test plan
- [ ] Verify `test_split_with_concurrent_delete_overlapping_content` passes on device (concurrent delete + split on overlapping content converges to `<r><p>a</p><p>d</p></r>`)
- [ ] Verify all 21 `JsonTreeSplitMergeTest` tests pass

> Items run automatically by CI (lint, unit tests, coverage) are excluded.