### PR TITLE
Add undo/redo support for Text.Style operations

### DIFF
--- a/yorkie/proto/yorkie/v1/resources.proto
+++ b/yorkie/proto/yorkie/v1/resources.proto
@@ -108,6 +108,7 @@ message Operation {
     map<string, string> attributes = 4;
     TimeTicket executed_at = 5;
     map<string, TimeTicket> created_at_map_by_actor = 6 [deprecated = true];
+    repeated string attributes_to_remove = 7;
   }
   message Increase {
     TimeTicket parent_created_at = 1;

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTextHistoryTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTextHistoryTest.kt
@@ -5,6 +5,7 @@ import dev.yorkie.core.Client.SyncMode.Manual
 import dev.yorkie.core.withTwoClientsAndDocuments
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -308,6 +309,103 @@ class JsonTextHistoryTest {
             val text1 = d1.getRoot().getAs<JsonText>("text").toString()
             val text2 = d2.getRoot().getAs<JsonText>("text").toString()
             assertEquals(text1, text2)
+        }
+    }
+
+    @Test
+    fun test_undo_and_redo_style_op() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewText("text").edit(0, 0, "hello")
+            }.await()
+            c1.syncAsync().await()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonText>("text").style(0, 5, mapOf("bold" to "true"))
+            }.await()
+            c1.syncAsync().await()
+            assertEquals(
+                mapOf("bold" to "true"),
+                d1.getRoot().getAs<JsonText>("text").values.first().attributes,
+            )
+
+            assertTrue(d1.history.canUndo())
+            d1.history.undoAsync().await()
+            val attrsAfterUndo = d1.getRoot().getAs<JsonText>("text").values.first().attributes
+            assertNull(attrsAfterUndo["bold"])
+
+            assertTrue(d1.history.canRedo())
+            d1.history.redoAsync().await()
+            assertEquals(
+                mapOf("bold" to "true"),
+                d1.getRoot().getAs<JsonText>("text").values.first().attributes,
+            )
+        }
+    }
+
+    @Test
+    fun test_undo_style_restores_previous_attribute_value() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewText("text").edit(0, 0, "hello")
+            }.await()
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonText>("text").style(0, 5, mapOf("bold" to "true"))
+            }.await()
+            c1.syncAsync().await()
+            assertEquals(
+                "true",
+                d1.getRoot().getAs<JsonText>("text").values.first().attributes["bold"],
+            )
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonText>("text").style(0, 5, mapOf("bold" to "false"))
+            }.await()
+            c1.syncAsync().await()
+            assertEquals(
+                "false",
+                d1.getRoot().getAs<JsonText>("text").values.first().attributes["bold"],
+            )
+
+            d1.history.undoAsync().await()
+            assertEquals(
+                "true",
+                d1.getRoot().getAs<JsonText>("text").values.first().attributes["bold"],
+            )
+
+            d1.history.redoAsync().await()
+            assertEquals(
+                "false",
+                d1.getRoot().getAs<JsonText>("text").values.first().attributes["bold"],
+            )
+        }
+    }
+
+    @Test
+    fun test_converge_with_concurrent_style_operations() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewText("text").edit(0, 0, "hello")
+            }.await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonText>("text").style(0, 5, mapOf("bold" to "true"))
+            }.await()
+            d2.updateAsync { root, _ ->
+                root.getAs<JsonText>("text").style(0, 5, mapOf("italic" to "true"))
+            }.await()
+
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+            c1.syncAsync().await()
+
+            val attrs1 = d1.getRoot().getAs<JsonText>("text").values.first().attributes
+            val attrs2 = d2.getRoot().getAs<JsonText>("text").values.first().attributes
+            assertEquals(attrs1, attrs2)
+            assertEquals("true", attrs1["bold"])
+            assertEquals("true", attrs1["italic"])
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/api/OperationConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/OperationConverter.kt
@@ -79,6 +79,7 @@ internal fun List<PBOperation>.toOperations(): List<Operation> {
                 attributes = it.style.attributesMap,
                 parentCreatedAt = it.style.parentCreatedAt.toTimeTicket(),
                 executedAt = it.style.executedAt.toTimeTicket(),
+                attributesToRemove = it.style.attributesToRemoveList,
             )
 
             it.hasTreeEdit() -> TreeEditOperation(
@@ -187,6 +188,7 @@ internal fun Operation.toPBOperation(): PBOperation {
                     to = operation.toPos.toPBTextNodePos()
                     executedAt = operation.executedAt.toPBTimeTicket()
                     operation.attributes.forEach { attributes[it.key] = it.value }
+                    operation.attributesToRemove.forEach { attributesToRemove.add(it) }
                 }
             }
         }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtText.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtText.kt
@@ -131,10 +131,24 @@ internal data class CrdtText(
         }
 
         val gcPairs = mutableListOf<GCPair<RhtNode>>()
+        val prevAttributes = mutableMapOf<String, String>()
+        val newAttributeKeys = mutableListOf<String>()
+        var capturedPrev = false
         val changes = toBeStyleds
             .filterNot { it.isRemoved }
             .map { node ->
                 val (fromIndex, toIndex) = rgaTreeSplit.findIndexesFromRange(node.createPosRange())
+                if (!capturedPrev) {
+                    val attrs = node.value.getAttrs()
+                    for ((key, _) in attributes) {
+                        if (attrs.has(key)) {
+                            prevAttributes[key] = attrs[key]!!
+                        } else {
+                            newAttributeKeys.add(key)
+                        }
+                    }
+                    capturedPrev = true
+                }
                 attributes.forEach {
                     val prev = node.value.setAttribute(it.key, it.value, executedAt).prev
                     prev?.let {
@@ -156,7 +170,71 @@ internal data class CrdtText(
                 )
             }
 
-        return TextStyleResult(changes, gcPairs, diff)
+        return TextStyleResult(changes, gcPairs, diff, prevAttributes, newAttributeKeys)
+    }
+
+    /**
+     * Removes style attributes in [attributesToRemove] from nodes in [range].
+     * Returns [TextStyleResult] with previous values of removed attributes for reverse op construction.
+     */
+    @SuppressLint("VisibleForTests")
+    fun removeStyle(
+        range: RgaTreeSplitPosRange,
+        attributesToRemove: List<String>,
+        executedAt: TimeTicket,
+        versionVector: VersionVector? = null,
+    ): TextStyleResult {
+        var diff = DataSize(data = 0, meta = 0)
+
+        val (_, toRight, diffTo) = rgaTreeSplit.findNodeWithSplit(range.second, executedAt)
+        val (_, fromRight, diffFrom) = rgaTreeSplit.findNodeWithSplit(range.first, executedAt)
+
+        diff = addDataSizes(diff, diffTo, diffFrom)
+
+        val nodes = rgaTreeSplit.findBetween(fromRight, toRight)
+        val toBeStyleds = nodes.mapNotNull { node ->
+            val actorID = node.createdAt.actorID
+            val clientLamportAtChange = versionVector?.let {
+                versionVector.get(actorID) ?: 0L
+            } ?: MAX_LAMPORT
+
+            node.takeIf { it.canStyle(executedAt, clientLamportAtChange) }
+        }
+
+        val gcPairs = mutableListOf<GCPair<RhtNode>>()
+        val prevAttributes = mutableMapOf<String, String>()
+        var capturedPrev = false
+        val changes = toBeStyleds
+            .filterNot { it.isRemoved }
+            .map { node ->
+                val (fromIndex, toIndex) = rgaTreeSplit.findIndexesFromRange(node.createPosRange())
+                if (!capturedPrev) {
+                    val attrs = node.value.getAttrs()
+                    for (key in attributesToRemove) {
+                        if (attrs.has(key)) {
+                            prevAttributes[key] = attrs[key]!!
+                        }
+                    }
+                    capturedPrev = true
+                }
+                for (key in attributesToRemove) {
+                    val removedNodes = node.value.getAttrs().remove(key, executedAt)
+                    for (rhtNode in removedNodes) {
+                        gcPairs.add(GCPair(node.value, rhtNode))
+                        diff = addDataSizes(diff, rhtNode.dataSize)
+                    }
+                }
+                TextChange(
+                    TextChangeType.Style,
+                    executedAt.actorID,
+                    fromIndex,
+                    toIndex,
+                    null,
+                    emptyMap(),
+                )
+            }
+
+        return TextStyleResult(changes, gcPairs, diff, prevAttributes)
     }
 
     /**

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TextInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TextInfo.kt
@@ -119,4 +119,6 @@ internal data class TextStyleResult(
     val textChanges: List<TextChange>,
     val gcPairs: List<GCPair<RhtNode>>,
     val dataSize: DataSize,
+    val prevAttributes: Map<String, String> = emptyMap(),
+    val attributesToRemove: List<String> = emptyList(),
 )

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt
@@ -14,6 +14,7 @@ internal data class StyleOperation(
     val attributes: Map<String, String>,
     override var parentCreatedAt: TimeTicket,
     override var executedAt: TimeTicket,
+    val attributesToRemove: List<String> = emptyList(),
 ) : Operation() {
 
     override val effectedCreatedAt: TimeTicket
@@ -26,19 +27,45 @@ internal data class StyleOperation(
     ): ExecutionResult {
         val parentObject = root.findByCreatedAt(parentCreatedAt)
         return if (parentObject is CrdtText) {
-            val result = parentObject.style(
-                RgaTreeSplitPosRange(fromPos, toPos),
-                attributes,
-                executedAt,
-                versionVector,
-            )
-            val changes = result.textChanges
+            val allChanges = mutableListOf<dev.yorkie.document.crdt.TextChange>()
+            val reversePrevAttributes = mutableMapOf<String, String>()
+            val reverseAttrsToRemove = mutableListOf<String>()
 
-            root.acc(result.dataSize)
+            if (attributesToRemove.isNotEmpty()) {
+                val result = parentObject.removeStyle(
+                    RgaTreeSplitPosRange(fromPos, toPos),
+                    attributesToRemove,
+                    executedAt,
+                    versionVector,
+                )
+                root.acc(result.dataSize)
+                result.gcPairs.forEach(root::registerGCPair)
+                allChanges.addAll(result.textChanges)
+                reversePrevAttributes.putAll(result.prevAttributes)
+            }
 
-            result.gcPairs.forEach(root::registerGCPair)
+            if (attributes.isNotEmpty()) {
+                val result = parentObject.style(
+                    RgaTreeSplitPosRange(fromPos, toPos),
+                    attributes,
+                    executedAt,
+                    versionVector,
+                )
+                root.acc(result.dataSize)
+                result.gcPairs.forEach(root::registerGCPair)
+                allChanges.addAll(result.textChanges)
+                reversePrevAttributes.putAll(result.prevAttributes)
+                reverseAttrsToRemove.addAll(result.attributesToRemove)
+            }
+
+            val reverseOps = if (source == OpSource.Local || source == OpSource.UndoRedo) {
+                buildReverseOps(reversePrevAttributes, reverseAttrsToRemove)
+            } else {
+                emptyList()
+            }
+
             ExecutionResult(
-                opInfos = changes.map {
+                opInfos = allChanges.map {
                     OperationInfo.StyleOpInfo(
                         it.from,
                         it.to,
@@ -46,12 +73,47 @@ internal data class StyleOperation(
                         root.createPath(parentCreatedAt),
                     )
                 },
+                reverseOps = reverseOps,
             )
         } else {
             parentObject ?: logError(TAG, "fail to find $parentCreatedAt")
             logError(TAG, "fail to execute, only Text can execute style")
             ExecutionResult(opInfos = emptyList())
         }
+    }
+
+    private fun buildReverseOps(
+        prevAttributes: Map<String, String>,
+        attrsToRemove: List<String>,
+    ): List<Operation> {
+        if (prevAttributes.isEmpty() && attrsToRemove.isEmpty()) return emptyList()
+        val reverseOp = when {
+            prevAttributes.isNotEmpty() && attrsToRemove.isNotEmpty() -> StyleOperation(
+                fromPos = fromPos,
+                toPos = toPos,
+                attributes = prevAttributes,
+                parentCreatedAt = parentCreatedAt,
+                executedAt = executedAt,
+                attributesToRemove = attrsToRemove,
+            )
+            attrsToRemove.isNotEmpty() -> StyleOperation(
+                fromPos = fromPos,
+                toPos = toPos,
+                attributes = emptyMap(),
+                parentCreatedAt = parentCreatedAt,
+                executedAt = executedAt,
+                attributesToRemove = attrsToRemove,
+            )
+            else -> StyleOperation(
+                fromPos = fromPos,
+                toPos = toPos,
+                attributes = prevAttributes,
+                parentCreatedAt = parentCreatedAt,
+                executedAt = executedAt,
+                attributesToRemove = emptyList(),
+            )
+        }
+        return listOf(reverseOp)
     }
 
     companion object {

--- a/yorkie/src/test/kotlin/dev/yorkie/document/operation/StyleOperationReverseTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/operation/StyleOperationReverseTest.kt
@@ -1,0 +1,175 @@
+package dev.yorkie.document.operation
+
+import dev.yorkie.document.crdt.CrdtObject
+import dev.yorkie.document.crdt.CrdtRoot
+import dev.yorkie.document.crdt.CrdtText
+import dev.yorkie.document.crdt.ElementRht
+import dev.yorkie.document.crdt.RgaTreeSplit
+import dev.yorkie.document.time.TimeTicket
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class StyleOperationReverseTest {
+
+    private val rootTicket = TimeTicket(1L, 0u, "actor-0")
+    private val textTicket = TimeTicket(2L, 0u, "actor-0")
+
+    private fun makeTicket(lamport: Long): TimeTicket = TimeTicket(lamport, 0u, "actor-0")
+
+    private fun buildTextRoot(): Pair<CrdtText, CrdtRoot> {
+        val text = CrdtText(RgaTreeSplit(), textTicket)
+        val obj = CrdtObject(createdAt = rootTicket, memberNodes = ElementRht())
+        val root = CrdtRoot(obj)
+        root.rootObject.set("text", text, textTicket)
+        root.registerElement(text, root.rootObject)
+        return text to root
+    }
+
+    @Test
+    fun `reverse of style sets previous attribute values`() {
+        // given: "hello" with bold=true
+        val (text, root) = buildTextRoot()
+        text.edit(text.indexRangeToPosRange(0, 0), "hello", makeTicket(3), mapOf("bold" to "true"))
+
+        // when: style range to bold=false
+        val range = text.indexRangeToPosRange(0, 5)
+        val op = StyleOperation(
+            fromPos = range.first,
+            toPos = range.second,
+            attributes = mapOf("bold" to "false"),
+            parentCreatedAt = textTicket,
+            executedAt = makeTicket(4),
+        )
+        val result = op.execute(root, OpSource.Local, null)
+
+        // then: reverse op restores bold=true
+        assertEquals(1, result.reverseOps.size)
+        val reverseOp = result.reverseOps[0] as StyleOperation
+        assertEquals(mapOf("bold" to "true"), reverseOp.attributes)
+        assertTrue(reverseOp.attributesToRemove.isEmpty())
+    }
+
+    @Test
+    fun `reverse of style on unstyled range produces remove-style op`() {
+        // given: "hello" with no attributes
+        val (text, root) = buildTextRoot()
+        text.edit(text.indexRangeToPosRange(0, 0), "hello", makeTicket(3))
+
+        // when: set bold=true on the range
+        val range = text.indexRangeToPosRange(0, 5)
+        val op = StyleOperation(
+            fromPos = range.first,
+            toPos = range.second,
+            attributes = mapOf("bold" to "true"),
+            parentCreatedAt = textTicket,
+            executedAt = makeTicket(4),
+        )
+        val result = op.execute(root, OpSource.Local, null)
+
+        // then: reverse op removes the newly added attribute
+        assertEquals(1, result.reverseOps.size)
+        val reverseOp = result.reverseOps[0] as StyleOperation
+        assertTrue(reverseOp.attributes.isEmpty())
+        assertEquals(listOf("bold"), reverseOp.attributesToRemove)
+    }
+
+    @Test
+    fun `reverse of removeStyle restores previous attribute value`() {
+        // given: "hello" with bold=true
+        val (text, root) = buildTextRoot()
+        text.edit(text.indexRangeToPosRange(0, 0), "hello", makeTicket(3), mapOf("bold" to "true"))
+
+        // when: remove bold via attributesToRemove
+        val range = text.indexRangeToPosRange(0, 5)
+        val op = StyleOperation(
+            fromPos = range.first,
+            toPos = range.second,
+            attributes = emptyMap(),
+            parentCreatedAt = textTicket,
+            executedAt = makeTicket(4),
+            attributesToRemove = listOf("bold"),
+        )
+        val result = op.execute(root, OpSource.Local, null)
+
+        // then: reverse op restores bold=true
+        assertEquals(1, result.reverseOps.size)
+        val reverseOp = result.reverseOps[0] as StyleOperation
+        assertEquals(mapOf("bold" to "true"), reverseOp.attributes)
+        assertTrue(reverseOp.attributesToRemove.isEmpty())
+    }
+
+    @Test
+    fun `no reverse op generated for remote source`() {
+        // given: "hello"
+        val (text, root) = buildTextRoot()
+        text.edit(text.indexRangeToPosRange(0, 0), "hello", makeTicket(3), mapOf("bold" to "true"))
+
+        // when: remote style operation
+        val range = text.indexRangeToPosRange(0, 5)
+        val op = StyleOperation(
+            fromPos = range.first,
+            toPos = range.second,
+            attributes = mapOf("bold" to "false"),
+            parentCreatedAt = textTicket,
+            executedAt = makeTicket(4),
+        )
+        val result = op.execute(root, OpSource.Remote, null)
+
+        // then: no reverse op for remote
+        assertTrue(result.reverseOps.isEmpty())
+    }
+
+    @Test
+    fun `style then undo restores original attributes`() {
+        // given: "hello" with bold=true
+        val (text, root) = buildTextRoot()
+        val insertTicket = makeTicket(3)
+        text.edit(text.indexRangeToPosRange(0, 0), "hello", insertTicket, mapOf("bold" to "true"))
+
+        // when: apply style (bold=false)
+        val range = text.indexRangeToPosRange(0, 5)
+        val applyTicket = makeTicket(4)
+        val applyOp = StyleOperation(
+            fromPos = range.first,
+            toPos = range.second,
+            attributes = mapOf("bold" to "false"),
+            parentCreatedAt = textTicket,
+            executedAt = applyTicket,
+        )
+        val applyResult = applyOp.execute(root, OpSource.Local, null)
+        assertEquals("false", text.values.first().attributes["bold"])
+
+        // then: execute reverse op to undo
+        val reverseOp = applyResult.reverseOps[0] as StyleOperation
+        reverseOp.executedAt = makeTicket(5)
+        reverseOp.execute(root, OpSource.UndoRedo, null)
+        assertEquals("true", text.values.first().attributes["bold"])
+    }
+
+    @Test
+    fun `add style then undo removes attribute`() {
+        // given: "hello" with no attributes
+        val (text, root) = buildTextRoot()
+        text.edit(text.indexRangeToPosRange(0, 0), "hello", makeTicket(3))
+
+        // when: add bold=true
+        val range = text.indexRangeToPosRange(0, 5)
+        val applyOp = StyleOperation(
+            fromPos = range.first,
+            toPos = range.second,
+            attributes = mapOf("bold" to "true"),
+            parentCreatedAt = textTicket,
+            executedAt = makeTicket(4),
+        )
+        val applyResult = applyOp.execute(root, OpSource.Local, null)
+        assertEquals("true", text.values.first().attributes["bold"])
+
+        // then: reverse op removes bold
+        val reverseOp = applyResult.reverseOps[0] as StyleOperation
+        reverseOp.executedAt = makeTicket(5)
+        reverseOp.execute(root, OpSource.UndoRedo, null)
+        val attrs = text.values.first().attributes
+        assertTrue(!attrs.containsKey("bold"))
+    }
+}


### PR DESCRIPTION
> **RTCOLLABPLATFORM-649**: [[Android] [B3] Add undo/redo support for Text.Style operations](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-649)

Ports https://github.com/yorkie-team/yorkie-js-sdk/pull/1174.

## Summary
- `StyleOperation.execute()` now builds a reverse `StyleOperation` at execute time for `Local` and `UndoRedo` sources
- `CrdtText.style()` returns previous attribute values so the reverse op can restore them; attributes being set for the first time produce a reverse remove-style, and attributes being overwritten produce a reverse set-style restoring the prior value
- `CrdtText.removeStyle()` added (parallel to `CrdtTree.removeStyle`) so the reverse of a set-style that introduced new keys can clean them up
- Proto `Style` message gains `attributes_to_remove` (field 7) for mixed set/remove reverse ops to round-trip correctly over the wire

## Changes
- `yorkie/proto/yorkie/v1/resources.proto`: added `attributes_to_remove = 7` to `Operation.Style`
- `yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtText.kt`: capture previous attributes in `style()`; add `removeStyle()`
- `yorkie/src/main/kotlin/dev/yorkie/document/crdt/TextInfo.kt`: extend `TextStyleResult` with `prevAttributes` and `attributesToRemove`
- `yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt`: add `attributesToRemove` field; generate reverse op
- `yorkie/src/main/kotlin/dev/yorkie/api/OperationConverter.kt`: serialize/deserialize `attributesToRemove` for `StyleOperation`
- `yorkie/src/test/kotlin/dev/yorkie/document/operation/StyleOperationReverseTest.kt`: unit tests for reverse op generation
- `yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTextHistoryTest.kt`: instrumented tests for style undo/redo and concurrent convergence

## Test plan
- [ ] Verify style undo/redo in the rich-text-editor example app

> Items run automatically by CI (lint, unit tests, coverage) are excluded.