### PR TITLE
Add undo/redo support for TreeStyleOperation

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeUndoTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeUndoTest.kt
@@ -279,4 +279,204 @@ class JsonTreeUndoTest {
             // canUndo() remains true after both edit reverses are popped.
         }
     }
+
+    /**
+     * Verifies undo/redo for setting an attribute that did not previously exist.
+     */
+    @Test
+    fun test_undo_and_redo_tree_style_set_new_attribute() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree(
+                    "tree",
+                    element("doc") {
+                        element("p") { text { "AB" } }
+                    },
+                )
+            }.await()
+            c1.syncAsync().await()
+
+            val before = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").style(0, 1, mapOf("bold" to "true"))
+            }.await()
+            c1.syncAsync().await()
+
+            val after = d1.getRoot().getAs<JsonTree>("tree").toXml()
+            assertTrue(after.contains("bold"))
+
+            d1.history.undoAsync().await()
+            assertEquals(before, d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.redoAsync().await()
+            assertEquals(after, d1.getRoot().getAs<JsonTree>("tree").toXml())
+        }
+    }
+
+    /**
+     * Verifies undo/redo for overwriting an existing attribute.
+     */
+    @Test
+    fun test_undo_and_redo_tree_style_overwrite_attribute() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree(
+                    "tree",
+                    element("doc") {
+                        element("p") {
+                            attr { "color" to "blue" }
+                            text { "AB" }
+                        }
+                    },
+                )
+            }.await()
+            c1.syncAsync().await()
+
+            val before = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").style(0, 1, mapOf("color" to "red"))
+            }.await()
+            c1.syncAsync().await()
+
+            val after = d1.getRoot().getAs<JsonTree>("tree").toXml()
+            assertTrue(after.contains("color=\"red\""))
+
+            d1.history.undoAsync().await()
+            assertEquals(before, d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.redoAsync().await()
+            assertEquals(after, d1.getRoot().getAs<JsonTree>("tree").toXml())
+        }
+    }
+
+    /**
+     * Verifies undo/redo for removeStyle.
+     */
+    @Test
+    fun test_undo_and_redo_tree_remove_style() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree(
+                    "tree",
+                    element("doc") {
+                        element("p") {
+                            attr { "bold" to "true" }
+                            text { "AB" }
+                        }
+                    },
+                )
+            }.await()
+            c1.syncAsync().await()
+
+            val before = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").removeStyle(0, 1, listOf("bold"))
+            }.await()
+            c1.syncAsync().await()
+
+            val after = d1.getRoot().getAs<JsonTree>("tree").toXml()
+            assertFalse(after.contains("bold"))
+
+            d1.history.undoAsync().await()
+            assertEquals(before, d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.redoAsync().await()
+            assertEquals(after, d1.getRoot().getAs<JsonTree>("tree").toXml())
+        }
+    }
+
+    /**
+     * Verifies undo/redo for a chain of style operations.
+     */
+    @Test
+    fun test_undo_and_redo_tree_style_chain() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree(
+                    "tree",
+                    element("doc") {
+                        element("p") {
+                            attr { "bold" to "true" }
+                            text { "AB" }
+                        }
+                        element("p") { text { "CD" } }
+                    },
+                )
+            }.await()
+            c1.syncAsync().await()
+
+            val s0 = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").style(0, 1, mapOf("italic" to "true"))
+            }.await()
+            c1.syncAsync().await()
+            val s1 = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").style(3, 4, mapOf("color" to "red"))
+            }.await()
+            c1.syncAsync().await()
+            val s2 = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.history.undoAsync().await()
+            assertEquals(s1, d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.undoAsync().await()
+            assertEquals(s0, d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.redoAsync().await()
+            assertEquals(s1, d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.redoAsync().await()
+            assertEquals(s2, d1.getRoot().getAs<JsonTree>("tree").toXml())
+        }
+    }
+
+    /**
+     * Verifies undo/redo for a mixed edit + style chain.
+     */
+    @Test
+    fun test_undo_and_redo_tree_style_after_edit() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree(
+                    "tree",
+                    element("doc") {
+                        element("p") { text { "AB" } }
+                    },
+                )
+            }.await()
+            c1.syncAsync().await()
+
+            val s0 = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").edit(1, 1, text { "X" })
+            }.await()
+            c1.syncAsync().await()
+            val s1 = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").style(0, 1, mapOf("italic" to "true"))
+            }.await()
+            c1.syncAsync().await()
+            val s2 = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.history.undoAsync().await()
+            assertEquals(s1, d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.undoAsync().await()
+            assertEquals(s0, d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.redoAsync().await()
+            assertEquals(s1, d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.redoAsync().await()
+            assertEquals(s2, d1.getRoot().getAs<JsonTree>("tree").toXml())
+        }
+    }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -105,6 +105,9 @@ internal data class CrdtTree(
         val changes = mutableListOf<TreeChange>()
 
         val gcPairs = mutableListOf<GCPair<RhtNode>>()
+        val prevAttributes = mutableMapOf<String, String>()
+        val newAttrKeys = mutableListOf<String>()
+        var capturedPrev = false
         traverseInPosRange(
             fromParent = fromParent,
             fromLeft = fromLeft,
@@ -120,6 +123,18 @@ internal data class CrdtTree(
                     hasUnknownSplitSibling(node, versionVector)
                 ) {
                     return@traverseInPosRange
+                }
+
+                if (!capturedPrev) {
+                    val attrs = node.getAttrs()
+                    for ((key, _) in attributes) {
+                        if (attrs.has(key)) {
+                            prevAttributes[key] = attrs[key]!!
+                        } else {
+                            newAttrKeys.add(key)
+                        }
+                    }
+                    capturedPrev = true
                 }
 
                 val parentOfNode = requireNotNull(node.parent)
@@ -156,7 +171,13 @@ internal data class CrdtTree(
                 }
             }
         }
-        return TreeOperationResult(changes, gcPairs, diff)
+        return TreeOperationResult(
+            changes,
+            gcPairs,
+            diff,
+            prevAttributes = prevAttributes,
+            attributesToRemove = newAttrKeys,
+        )
     }
 
     private fun toPath(parentNode: CrdtTreeNode, leftSiblingNode: CrdtTreeNode): List<Int> {
@@ -629,6 +650,8 @@ internal data class CrdtTree(
 
         val changes = mutableListOf<TreeChange>()
         val gcPairs = mutableListOf<GCPair<RhtNode>>()
+        val prevAttributes = mutableMapOf<String, String>()
+        var capturedPrev = false
         traverseInPosRange(fromParent, fromLeft, toParent, toLeft) { (node, tokenType), _ ->
             val actorID = node.createdAt.actorID
             val clientLamportAtChange = getClientInfoForChange(actorID, versionVector)
@@ -643,6 +666,16 @@ internal data class CrdtTree(
                     hasUnknownSplitSibling(node, versionVector)
                 ) {
                     return@traverseInPosRange
+                }
+
+                if (!capturedPrev) {
+                    val attrs = node.getAttrs()
+                    for (key in attributeToRemove) {
+                        if (attrs.has(key)) {
+                            prevAttributes[key] = attrs[key]!!
+                        }
+                    }
+                    capturedPrev = true
                 }
 
                 attributeToRemove.forEach { key ->
@@ -665,7 +698,7 @@ internal data class CrdtTree(
                 ).let(changes::add)
             }
         }
-        return TreeOperationResult(changes, gcPairs, diff)
+        return TreeOperationResult(changes, gcPairs, diff, prevAttributes = prevAttributes)
     }
 
     private fun traverseInPosRange(

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TreeInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TreeInfo.kt
@@ -87,4 +87,14 @@ internal data class TreeOperationResult(
      * [dev.yorkie.document.operation.TreeEditOperation] for undo/redo.
      */
     val removedNodes: List<CrdtTreeNode> = emptyList(),
+    /**
+     * Previous attribute values captured from the first styled node in the
+     * range.  Used to build the reverse style operation for undo/redo.
+     */
+    val prevAttributes: Map<String, String> = emptyMap(),
+    /**
+     * Keys of attributes that did not previously exist on the first styled
+     * node.  The reverse op must remove them to restore the prior state.
+     */
+    val attributesToRemove: List<String> = emptyList(),
 )

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeStyleOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeStyleOperation.kt
@@ -36,56 +36,103 @@ internal data class TreeStyleOperation(
             return ExecutionResult(opInfos = emptyList())
         }
 
-        return when {
+        val reversePrevAttributes = mutableMapOf<String, String>()
+        val reverseAttrsToRemove = mutableListOf<String>()
+
+        val opInfos = when {
             attributes?.isNotEmpty() == true -> {
-                val (changes, gcPairs, diff) = tree.style(
+                val result = tree.style(
                     fromPos to toPos,
                     attributes,
                     executedAt,
                     versionVector,
                 )
 
-                root.acc(diff)
+                root.acc(result.dataSize)
+                result.gcPairs.forEach(root::registerGCPair)
 
-                gcPairs.forEach(root::registerGCPair)
-                ExecutionResult(
-                    opInfos = changes.map {
-                        TreeStyleOpInfo(
-                            it.from,
-                            it.to,
-                            it.fromPath,
-                            it.toPath,
-                            it.attributes.orEmpty(),
-                            path = root.createPath(parentCreatedAt),
-                        )
-                    },
-                )
+                reversePrevAttributes.putAll(result.prevAttributes)
+                reverseAttrsToRemove.addAll(result.attributesToRemove)
+
+                result.changes.map {
+                    TreeStyleOpInfo(
+                        it.from,
+                        it.to,
+                        it.fromPath,
+                        it.toPath,
+                        it.attributes.orEmpty(),
+                        path = root.createPath(parentCreatedAt),
+                    )
+                }
             }
 
             attributesToRemove?.isNotEmpty() == true -> {
-                val (changes, gcPairs) = tree.removeStyle(
+                val result = tree.removeStyle(
                     fromPos to toPos,
                     attributesToRemove,
                     executedAt,
                     versionVector,
                 )
-                gcPairs.forEach(root::registerGCPair)
-                ExecutionResult(
-                    opInfos = changes.map {
-                        TreeStyleOpInfo(
-                            it.from,
-                            it.to,
-                            it.fromPath,
-                            it.toPath,
-                            attributesToRemove = it.attributesToRemove.orEmpty(),
-                            path = root.createPath(parentCreatedAt),
-                        )
-                    },
-                )
+                result.gcPairs.forEach(root::registerGCPair)
+
+                reversePrevAttributes.putAll(result.prevAttributes)
+
+                result.changes.map {
+                    TreeStyleOpInfo(
+                        it.from,
+                        it.to,
+                        it.fromPath,
+                        it.toPath,
+                        attributesToRemove = it.attributesToRemove.orEmpty(),
+                        path = root.createPath(parentCreatedAt),
+                    )
+                }
             }
 
-            else -> ExecutionResult(opInfos = emptyList())
+            else -> emptyList()
         }
+
+        val reverseOps = if (source == OpSource.Local || source == OpSource.UndoRedo) {
+            buildReverseOps(reversePrevAttributes, reverseAttrsToRemove)
+        } else {
+            emptyList()
+        }
+
+        return ExecutionResult(opInfos = opInfos, reverseOps = reverseOps)
+    }
+
+    private fun buildReverseOps(
+        prevAttributes: Map<String, String>,
+        attrsToRemove: List<String>,
+    ): List<Operation> {
+        if (prevAttributes.isEmpty() && attrsToRemove.isEmpty()) return emptyList()
+        val reverseOp = when {
+            prevAttributes.isNotEmpty() && attrsToRemove.isNotEmpty() -> TreeStyleOperation(
+                parentCreatedAt = parentCreatedAt,
+                fromPos = fromPos,
+                toPos = toPos,
+                executedAt = executedAt,
+                attributes = prevAttributes,
+                attributesToRemove = attrsToRemove,
+            )
+            attrsToRemove.isNotEmpty() -> TreeStyleOperation(
+                parentCreatedAt = parentCreatedAt,
+                fromPos = fromPos,
+                toPos = toPos,
+                executedAt = executedAt,
+                attributes = null,
+                attributesToRemove = attrsToRemove,
+            )
+            else -> TreeStyleOperation(
+                parentCreatedAt = parentCreatedAt,
+                fromPos = fromPos,
+                toPos = toPos,
+                executedAt = executedAt,
+                attributes = prevAttributes,
+                attributesToRemove = null,
+            )
+        }
+        return listOf(reverseOp)
     }
 
     companion object {


### PR DESCRIPTION
> **RTCOLLABPLATFORM-650**: [[Android] [B4] Add undo/redo support for TreeStyleOperation](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-650)

Ports https://github.com/yorkie-team/yorkie-js-sdk/pull/1221.

## Summary
- `CrdtTree.style()` and `removeStyle()` now capture previous attribute values from the first styled node in the traversal range, returning them in `TreeOperationResult`
- `TreeStyleOperation.execute()` builds a reverse `TreeStyleOperation` from that captured state when `source` is `Local` or `UndoRedo`, matching the pattern used by `StyleOperation` for `CrdtText` (B3)
- New fields `prevAttributes` and `attributesToRemove` added to `TreeOperationResult` with default values, keeping all existing destructuring callers unaffected

## Changes
- `TreeInfo.kt`: added `prevAttributes` and `attributesToRemove` fields to `TreeOperationResult`
- `CrdtTree.kt`: capture prev attributes in `style()` and `removeStyle()` traversal loops
- `TreeStyleOperation.kt`: generate reverse op via `buildReverseOps()` for local/undo-redo sources
- `JsonTreeUndoTest.kt`: 5 new instrumented tests covering set-new-attr, overwrite-attr, remove-style, style-chain, and mixed edit+style undo/redo

## Test plan
- [ ] `test_undo_and_redo_tree_style_set_new_attribute` — new attr is removed on undo, restored on redo
- [ ] `test_undo_and_redo_tree_style_overwrite_attribute` — previous value restored on undo
- [ ] `test_undo_and_redo_tree_remove_style` — removed attr restored on undo
- [ ] `test_undo_and_redo_tree_style_chain` — sequential style ops undo/redo correctly
- [ ] `test_undo_and_redo_tree_style_after_edit` — mixed edit + style undo/redo preserves intermediate state

> Items run automatically by CI (lint, unit tests, coverage) are excluded.