### PR TITLE
Fix SplitElement divergence on concurrent split inside merge range

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeSplitMergeTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeSplitMergeTest.kt
@@ -791,4 +791,42 @@ class JsonTreeSplitMergeTest {
             JsonTreeTest.assertTreesXmlEquals("<r><p>a</p><p>d</p></r>", d1, d2)
         }
     }
+
+    // Regression test for https://github.com/yorkie-team/yorkie/issues/1726.
+    // When one client splits inside a block that the other client merges,
+    // replicas must converge to the same tree.
+    @Test
+    fun test_contained_split_and_merge_same_block() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        TreeBuilder.element("r") {
+                            element("p") { text { "ab" } }
+                            element("p") { text { "cd" } }
+                        },
+                    )
+                },
+                JsonTreeTest.Companion.Updater(c2, d2),
+            )
+            JsonTreeTest.assertTreesXmlEquals("<r><p>ab</p><p>cd</p></r>", d1, d2)
+
+            // d1: split first paragraph at a|b (position 2, splitLevel=1)
+            // d2: merge both paragraphs by deleting the boundary (positions 3-5)
+            updateAndSync(
+                JsonTreeTest.Companion.Updater(c1, d1) { root, _ ->
+                    root.rootTree().edit(2, 2, 1)
+                },
+                JsonTreeTest.Companion.Updater(c2, d2) { root, _ ->
+                    root.rootTree().edit(3, 5)
+                },
+            ) {
+                JsonTreeTest.assertTreesXmlEquals("<r><p>a</p><p>b</p><p>cd</p></r>", d1)
+                JsonTreeTest.assertTreesXmlEquals("<r><p>abcd</p></r>", d2)
+            }
+
+            JsonTreeTest.assertTreesXmlEquals(d1.getRoot().rootTree().toXml(), d1, d2)
+        }
+    }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -1243,10 +1243,12 @@ internal data class CrdtTreeNode(
     }
 
     /**
-     * Returns true when [child] was moved here by a merge that is concurrent
-     * with the current split operation. In that case the child should stay in
-     * the original (left) node rather than being moved to the split sibling,
-     * so that a later sequential split lands them correctly.
+     * Returns true when [child] was moved here by a concurrent merge and
+     * its merge source is a child of this node. When the source is local
+     * to this level the content must stay in the original (left) node so
+     * that it is not incorrectly split away. When the source is external
+     * (e.g. a sibling that was merged in) the child flows naturally to the
+     * split (right) node.
      *
      * Only applies for remote splits (non-null, non-empty [versionVector]).
      * Local splits always know about all prior operations, so never veto.
@@ -1254,11 +1256,13 @@ internal data class CrdtTreeNode(
     override fun shouldKeepChildInLeft(
         child: CrdtTreeNode,
         versionVector: VersionVector?,
+        allChildren: List<CrdtTreeNode>,
     ): Boolean {
         if (versionVector == null || versionVector.size() == 0) return false
         val mergedAt = child.mergedAt ?: return false
-        child.mergedFrom ?: return false
-        return !versionVector.afterOrEqual(mergedAt)
+        val mergedFrom = child.mergedFrom ?: return false
+        if (versionVector.afterOrEqual(mergedAt)) return false
+        return allChildren.any { sibling -> sibling.id == mergedFrom }
     }
 
     fun setAttributes(

--- a/yorkie/src/main/kotlin/dev/yorkie/util/IndexTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/IndexTree.kt
@@ -778,24 +778,20 @@ abstract class IndexTreeNode<T : IndexTreeNode<T>> {
 
         clone.childNodes.clear()
 
-        // Fix 8: Keep merge-moved children in the original (left) node when
-        // the merge is concurrent with this split. A child should stay left if
-        // it carries a mergedFrom marker whose mergedAt ticket is not covered
-        // by the editor's versionVector (i.e. the editor did not know about
-        // the merge when it issued the split). The boundary check prevents
-        // veto when the split position itself is inside merged content.
+        // Fix 8 (revised): Keep merge-moved children in the original (left)
+        // node when the merge is concurrent with this split. The decision is
+        // per-child: if the child's merge source is itself a child of this
+        // node, the content was local to this level and must stay left. If
+        // the source is external (e.g., a sibling element that was merged),
+        // the content flows naturally to the split (right) node.
         val hasVersionVector = versionVector != null && versionVector.size() > 0
-        val boundaryNode = if (offset > 0) childNodes.getOrNull(offset - 1) else null
-        val boundaryIsMerged = boundaryNode != null &&
-            shouldKeepChildInLeft(boundaryNode, versionVector)
+        val allChildNodes = childNodes.toList()
 
         val movedToLeft = mutableListOf<T>()
         repeat(childNodes.size - offset) {
             val rightChild = childNodes.removeAt(offset)
-            // Veto moving this child to the clone if it was moved here by a
-            // concurrent merge and the split did not know about it.
-            if (!boundaryIsMerged && hasVersionVector &&
-                shouldKeepChildInLeft(rightChild, versionVector)
+            if (hasVersionVector &&
+                shouldKeepChildInLeft(rightChild, versionVector, allChildNodes)
             ) {
                 movedToLeft.add(rightChild)
             } else {
@@ -840,8 +836,14 @@ abstract class IndexTreeNode<T : IndexTreeNode<T>> {
      * Returns true when [child] should be kept in the original (left) node
      * rather than moved to the split sibling. Subclasses override this to
      * implement merge-aware split semantics. The default always returns false.
+     *
+     * @param allChildren snapshot of all children (left + right) before the split.
      */
-    open fun shouldKeepChildInLeft(child: T, versionVector: VersionVector?): Boolean = false
+    open fun shouldKeepChildInLeft(
+        child: T,
+        versionVector: VersionVector?,
+        allChildren: List<T>,
+    ): Boolean = false
 
     private fun insertAfterInternal(targetNode: T, newNode: T) {
         check(!isText) {


### PR DESCRIPTION
> **RTCOLLABPLATFORM-641**: [[Android] [A5] Fix SplitElement divergence on concurrent split inside merge range](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-641)

Ports https://github.com/yorkie-team/yorkie-js-sdk/pull/1206.

## Summary
- Replaces the `boundaryIsMerged` heuristic in `splitElement` with a `sourceIsChild` check: a concurrent merge-moved child stays in the original (left) node only when its merge source is itself a child of the element being split; external sources flow naturally to the split (right) node
- Adds `allChildren` parameter to `shouldKeepChildInLeft` so the per-child decision has access to the full pre-split child list for the source lookup
- Adds regression test `test_contained_split_and_merge_same_block` covering the scenario where one client splits inside a block the other client merges

## Changes
- `IndexTree.splitElement`: remove `boundaryNode`/`boundaryIsMerged` computation; snapshot `allChildNodes` before splitting and pass to `shouldKeepChildInLeft`
- `IndexTree.shouldKeepChildInLeft`: add `allChildren: List<T>` parameter to signature
- `CrdtTreeNode.shouldKeepChildInLeft`: implement `sourceIsChild` check — return true only when `mergedFrom` ID matches a sibling in `allChildren`
- `JsonTreeSplitMergeTest`: add `test_contained_split_and_merge_same_block` instrumented test

## Test plan
- [ ] `test_contained_split_and_merge_same_block` — concurrent split at `a|b` and merge of both paragraphs converges on both replicas

> Items run automatically by CI (lint, unit tests, coverage) are excluded.