### PR TITLE
Mirror tree merge snapshot encoding fix from Go SDK

### DIFF
--- a/yorkie/proto/yorkie/v1/resources.proto
+++ b/yorkie/proto/yorkie/v1/resources.proto
@@ -254,6 +254,8 @@ message TreeNode {
   TreeNodeID ins_next_id = 6;
   int32 depth = 7;
   map<string, NodeAttr> attributes = 8;
+  TreeNodeID merged_from = 9;
+  TimeTicket merged_at = 10;
 }
 
 message TreeNodes {

--- a/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
@@ -11,6 +11,7 @@ import dev.yorkie.api.v1.JSONElementKt.tree
 import dev.yorkie.api.v1.NodeAttr
 import dev.yorkie.api.v1.jSONElement
 import dev.yorkie.api.v1.jSONElementSimple
+import dev.yorkie.api.v1.mergedAtOrNull
 import dev.yorkie.api.v1.movedAtOrNull
 import dev.yorkie.api.v1.nodeAttr
 import dev.yorkie.api.v1.rGANode
@@ -248,6 +249,7 @@ internal fun List<PBTreeNode>.toCrdtTreeRootNode(): CrdtTreeNode? {
 }
 
 internal fun PBTreeNode.toCrdtTreeNode(): CrdtTreeNode {
+    val pbNode = this
     val id = id.toCrdtTreeNodeID()
     val convertedRemovedAt = removedAtOrNull?.toTimeTicket()
     return if (type == IndexTreeNode.DEFAULT_TEXT_TYPE) {
@@ -260,12 +262,16 @@ internal fun PBTreeNode.toCrdtTreeNode(): CrdtTreeNode {
         )
     }.apply {
         convertedRemovedAt?.let(::remove)
-        if (hasInsPrevId()) {
-            insPrevID = insPrevId.toCrdtTreeNodeID()
+        if (pbNode.hasInsPrevId()) {
+            insPrevID = pbNode.insPrevId.toCrdtTreeNodeID()
         }
-        if (hasInsNextId()) {
-            insNextID = insNextId.toCrdtTreeNodeID()
+        if (pbNode.hasInsNextId()) {
+            insNextID = pbNode.insNextId.toCrdtTreeNodeID()
         }
+        if (pbNode.hasMergedFrom()) {
+            mergedFrom = pbNode.mergedFrom.toCrdtTreeNodeID()
+        }
+        mergedAt = pbNode.mergedAtOrNull?.toTimeTicket() ?: convertedRemovedAt
     }
 }
 
@@ -367,6 +373,12 @@ internal fun CrdtTreeNode.toPBTreeNodes(): List<PBTreeNode> {
                 }
                 depth = nodeDepth
                 attributes.putAll(node.rhtNodes.toPBRht())
+                node.mergedFrom?.let {
+                    mergedFrom = it.toPBTreeNodeID()
+                }
+                node.mergedAt?.let {
+                    mergedAt = it.toPBTimeTicket()
+                }
             }
             add(pbTreeNode)
         }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -58,6 +58,22 @@ internal data class CrdtTree(
         indexTree.traverseAll { node, _ ->
             nodeMapByID[node.id] = node
         }
+        rebuildMergeState()
+    }
+
+    private fun rebuildMergeState() {
+        indexTree.traverseAll { node, _ ->
+            val mergedFromID = node.mergedFrom ?: return@traverseAll
+            val source = findFloorNode(mergedFromID) ?: return@traverseAll
+            val target = node.parent ?: return@traverseAll
+            source.mergedInto = target.id
+            val ids = source.mergedChildIDs ?: mutableListOf<CrdtTreeNodeID>().also {
+                source.mergedChildIDs = it
+            }
+            if (!ids.contains(node.id)) {
+                ids.add(node.id)
+            }
+        }
     }
 
     val size: Int

--- a/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
@@ -510,6 +510,53 @@ class ConverterTest {
         assertEquals(document.getRoot().tree().toXml(), obj.toXml())
     }
 
+    @Test
+    fun `should persist merge state across bytes roundtrip`() {
+        // given: a tree where one child was moved by a merge
+        val ticket0 = InitialTimeTicket
+        val ticket1 = TimeTicket(lamport = 1, delimiter = 0u, actorID = ActorID.INITIAL_ACTOR_ID)
+        val ticket2 = TimeTicket(lamport = 2, delimiter = 0u, actorID = ActorID.INITIAL_ACTOR_ID)
+        val ticket3 = TimeTicket(lamport = 3, delimiter = 0u, actorID = ActorID.INITIAL_ACTOR_ID)
+
+        val rootID = CrdtTreeNodeID(ticket0, 0)
+        val targetID = CrdtTreeNodeID(ticket1, 0)
+        val sourceID = CrdtTreeNodeID(ticket2, 0)
+        val childID = CrdtTreeNodeID(ticket3, 0)
+
+        val root = CrdtTreeElement(rootID, DEFAULT_ROOT_TYPE)
+        val target = CrdtTreeElement(targetID, "p")
+        val source = CrdtTreeElement(sourceID, "p")
+        val child = CrdtTreeText(childID, "hello")
+
+        root.append(target)
+        root.append(source)
+        target.append(child)
+
+        // simulate a merge: child moved from source to target
+        child.mergedFrom = sourceID
+        child.mergedAt = ticket2
+        source.mergedInto = targetID
+        source.mergedChildIDs = mutableListOf(childID)
+        source.remove(ticket2)
+
+        val original = CrdtTree(root, ticket0)
+
+        // when: roundtrip through bytes
+        val bytes = original.toByteString()
+        val restored = bytes.toCrdtTree()
+
+        // then: mergedFrom and mergedAt survive on the moved child
+        val restoredTarget = restored.findFloorNode(targetID)
+        val restoredChild = restoredTarget?.allChildren?.firstOrNull()
+        assertEquals(sourceID, restoredChild?.mergedFrom)
+        assertEquals(ticket2, restoredChild?.mergedAt)
+
+        // then: mergedInto is rebuilt on the tombstoned source
+        val restoredSource = restored.findFloorNode(sourceID)
+        assertEquals(targetID, restoredSource?.mergedInto)
+        assertEquals(listOf(childID), restoredSource?.mergedChildIDs?.toList())
+    }
+
     private class TestOperation(
         override var parentCreatedAt: TimeTicket,
         override var executedAt: TimeTicket,


### PR DESCRIPTION
> **RTCOLLABPLATFORM-642**: [[Android] [A6] Mirror tree merge snapshot encoding fix from Go SDK](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-642)

Ports https://github.com/yorkie-team/yorkie-js-sdk/pull/1210 (which itself ports [yorkie-team/yorkie#1729](https://github.com/yorkie-team/yorkie/pull/1729)).

## Summary
- `CrdtTreeNode` carried four runtime-only merge fields (`mergedFrom`, `mergedAt`, `mergedInto`, `mergedChildIDs`) that were never written to the snapshot encoding. A replica that loaded a document from a server-built snapshot between a remote merge and a concurrent insert would silently drop the insert.
- Add `merged_from` (#9) and `merged_at` (#10) optional fields to the `TreeNode` proto message so merge-time causal state survives snapshot roundtrips.
- Add a `rebuildMergeState` post-load pass in `CrdtTree.init` that reconstructs the runtime `mergedInto` and `mergedChildIDs` caches from the persisted `mergedFrom` values.

## Changes
- `yorkie/proto/yorkie/v1/resources.proto` — add `merged_from` (#9) and `merged_at` (#10) to `TreeNode`
- `api/ElementConverter.kt` — `toPBTreeNodes` writes both fields; `toCrdtTreeNode` reads them (falls back to `removedAt` for `mergedAt` on old snapshots)
- `document/crdt/CrdtTree.kt` — add `rebuildMergeState` called from `init` after `nodeMapByID` is populated
- `test/api/ConverterTest.kt` — regression test verifying `mergedFrom`/`mergedAt` survive a bytes roundtrip and `rebuildMergeState` reconstructs `mergedInto`/`mergedChildIDs`

## Test plan
- [x] New unit test `should persist merge state across bytes roundtrip` passes
- [x] `JsonTreeTest` — 65 tests, 0 failures
- [x] `JsonTreeSplitMergeTest` — 22 tests, 0 failures
- [x] `JsonTreeConcurrencyTest` — 7 tests (2 skipped), 0 failures
- [x] Full unit test suite — 0 failures

> Items run automatically by CI (lint, unit tests, coverage) are excluded.