### PR TITLE
Enable splitLevel=1 concurrent tests and add split undo/redo

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeConcurrencyTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeConcurrencyTest.kt
@@ -409,9 +409,8 @@ class JsonTreeConcurrencyTest {
         }
     }
 
-    @Ignore("should be resolved after JS SDK implementation")
     @Test
-    fun test_concurrent_split_and_split() {
+    fun test_concurrent_split_and_split_L1() {
         runBlocking {
             val root = element("r") {
                 element("p") {
@@ -444,7 +443,7 @@ class JsonTreeConcurrencyTest {
                 makeTwoRanges(Triple(3, 6, 9), Triple(9, 12, 15), "B is next to A"),
             )
 
-            val splitOperations = listOf(
+            val splitL1Operations = listOf(
                 EditOperationType(
                     RangeSelector.RangeFront,
                     EditOpCode.SplitUpdate,
@@ -473,6 +472,52 @@ class JsonTreeConcurrencyTest {
                     1,
                     "split-back-1",
                 ),
+            )
+
+            runTestConcurrency(
+                root,
+                initialXml,
+                ranges,
+                splitL1Operations,
+                splitL1Operations,
+                "concurrently-split-split-test-L1",
+            )
+        }
+    }
+
+    // splitLevel>=2 forward convergence still has unresolved offset and
+    // merge-redirect issues with nested elements.
+    @Ignore("splitLevel>=2 not yet supported; see RTCOLLABPLATFORM-651 design doc")
+    @Test
+    fun test_concurrent_split_and_split_L2() {
+        runBlocking {
+            val root = element("r") {
+                element("p") {
+                    element("p") {
+                        element("p") {
+                            element("p") {
+                                text { "abcd" }
+                            }
+                            element("p") {
+                                text { "efgh" }
+                            }
+                        }
+                        element("p") {
+                            text { "ijkl" }
+                        }
+                    }
+                }
+            }
+            val initialXml = "<r><p><p><p><p>abcd</p><p>efgh</p></p><p>ijkl</p></p></p></r>"
+            val ranges = listOf(
+                makeTwoRanges(Triple(3, 6, 9), Triple(3, 6, 9), "equal-single"),
+                makeTwoRanges(Triple(3, 9, 15), Triple(3, 9, 15), "equal-multiple"),
+                makeTwoRanges(Triple(3, 9, 15), Triple(9, 12, 15), "A contains B same level"),
+                makeTwoRanges(Triple(2, 16, 22), Triple(9, 12, 15), "A contains B multiple level"),
+                makeTwoRanges(Triple(3, 6, 9), Triple(9, 12, 15), "B is next to A"),
+            )
+
+            val splitL2Operations = listOf(
                 EditOperationType(
                     RangeSelector.RangeFront,
                     EditOpCode.SplitUpdate,
@@ -507,16 +552,19 @@ class JsonTreeConcurrencyTest {
                 root,
                 initialXml,
                 ranges,
-                splitOperations,
-                splitOperations,
-                "concurrently-split-split-test",
+                splitL2Operations,
+                splitL2Operations,
+                "concurrently-split-split-test-L2",
             )
         }
     }
 
-    @Ignore("should be resolved after JS SDK implementation")
+    // Pending: requires runTest helper fix (op2 → d2). The current
+    // scaffolding runs both ops on d1, which collapses concurrent
+    // split+edit into a sequential application that diverges on merges.
+    @Ignore("requires runTest concurrent-client fix; see RTCOLLABPLATFORM-651")
     @Test
-    fun test_concurrent_split_and_edit() {
+    fun test_concurrent_split_and_edit_L1() {
         runBlocking {
             val root = element("r") {
                 element("p") {
@@ -544,27 +592,18 @@ class JsonTreeConcurrencyTest {
             val content = element("i")
 
             val ranges = listOf(
-                // equal: <p>abcd</p>
                 makeTwoRanges(Triple(2, 5, 8), Triple(2, 5, 8), "equal"),
-                // A contains B: <p>abcd</p> - bc
                 makeTwoRanges(Triple(2, 5, 8), Triple(4, 5, 6), "A contains B"),
-                // B contains A: <p>abcd</p> - <p>abcd</p><p>efgh</p>
                 makeTwoRanges(Triple(2, 5, 8), Triple(2, 8, 14), "B contains A"),
-                // left node(text): <p>abcd</p> - ab
                 makeTwoRanges(Triple(2, 5, 8), Triple(3, 4, 5), "left node(text)"),
-                // right node(text): <p>abcd</p> - cd
                 makeTwoRanges(Triple(2, 5, 8), Triple(5, 6, 7), "right node(text)"),
-                // left node(element): <p>abcd</p><p>efgh</p> - <p>abcd</p>
                 makeTwoRanges(Triple(2, 8, 14), Triple(2, 5, 8), "left node(element)"),
-                // right node(element): <p>abcd</p><p>efgh</p> - <p>efgh</p>
                 makeTwoRanges(Triple(2, 8, 14), Triple(8, 11, 14), "right node(element)"),
-                // A -> B: <p>abcd</p> - <p>efgh</p>
                 makeTwoRanges(Triple(2, 5, 8), Triple(8, 11, 14), "A -> B"),
-                // B -> A: <p>efgh</p> - <p>abcd</p>
                 makeTwoRanges(Triple(8, 11, 14), Triple(2, 5, 8), "B -> A"),
             )
 
-            val splitOperations = listOf(
+            val splitL1Operations = listOf(
                 EditOperationType(
                     RangeSelector.RangeMiddle,
                     EditOpCode.SplitUpdate,
@@ -572,6 +611,122 @@ class JsonTreeConcurrencyTest {
                     1,
                     "split-1",
                 ),
+            )
+
+            val editOperations = listOf(
+                EditOperationType(
+                    RangeSelector.RangeFront,
+                    EditOpCode.EditUpdate,
+                    content,
+                    0,
+                    "insertFront",
+                ),
+                EditOperationType(
+                    RangeSelector.RangeMiddle,
+                    EditOpCode.EditUpdate,
+                    content,
+                    0,
+                    "insertMiddle",
+                ),
+                EditOperationType(
+                    RangeSelector.RangeBack,
+                    EditOpCode.EditUpdate,
+                    content,
+                    0,
+                    "insertBack",
+                ),
+                EditOperationType(
+                    RangeSelector.RangeAll,
+                    EditOpCode.EditUpdate,
+                    content,
+                    0,
+                    "replace",
+                ),
+                EditOperationType(
+                    RangeSelector.RangeAll,
+                    EditOpCode.EditUpdate,
+                    null,
+                    0,
+                    "delete",
+                ),
+                EditOperationType(
+                    RangeSelector.RangeAll,
+                    EditOpCode.MergeUpdate,
+                    null,
+                    0,
+                    "merge",
+                ),
+                StyleOperationType(
+                    RangeSelector.RangeAll,
+                    StyleOpCode.StyleSet,
+                    "bold",
+                    "aa",
+                    "style",
+                ),
+                StyleOperationType(
+                    RangeSelector.RangeAll,
+                    StyleOpCode.StyleRemove,
+                    "italic",
+                    "",
+                    "remove-style",
+                ),
+            )
+
+            runTestConcurrency(
+                root,
+                initialXml,
+                ranges,
+                splitL1Operations,
+                editOperations,
+                "concurrently-split-edit-test-L1",
+            )
+        }
+    }
+
+    // splitLevel>=2 split×edit tests fail due to the same nested element
+    // issues as the split×split suite above.
+    @Ignore("splitLevel>=2 not yet supported; see RTCOLLABPLATFORM-651 design doc")
+    @Test
+    fun test_concurrent_split_and_edit_L2() {
+        runBlocking {
+            val root = element("r") {
+                element("p") {
+                    element("p") {
+                        element("p") {
+                            element("p") {
+                                text { "abcd" }
+                                attrs { mapOf("italic" to "a") }
+                            }
+                            element("p") {
+                                text { "efgh" }
+                                attrs { mapOf("italic" to "a") }
+                            }
+                        }
+                        element("p") {
+                            text { "ijkl" }
+                            attrs { mapOf("italic" to "a") }
+                        }
+                    }
+                }
+            }
+            val initialXml =
+                """<r><p><p><p italic="a">abcd</p><p italic="a">efgh</p></p>""" +
+                    """<p italic="a">ijkl</p></p></r>"""
+            val content = element("i")
+
+            val ranges = listOf(
+                makeTwoRanges(Triple(2, 5, 8), Triple(2, 5, 8), "equal"),
+                makeTwoRanges(Triple(2, 5, 8), Triple(4, 5, 6), "A contains B"),
+                makeTwoRanges(Triple(2, 5, 8), Triple(2, 8, 14), "B contains A"),
+                makeTwoRanges(Triple(2, 5, 8), Triple(3, 4, 5), "left node(text)"),
+                makeTwoRanges(Triple(2, 5, 8), Triple(5, 6, 7), "right node(text)"),
+                makeTwoRanges(Triple(2, 8, 14), Triple(2, 5, 8), "left node(element)"),
+                makeTwoRanges(Triple(2, 8, 14), Triple(8, 11, 14), "right node(element)"),
+                makeTwoRanges(Triple(2, 5, 8), Triple(8, 11, 14), "A -> B"),
+                makeTwoRanges(Triple(8, 11, 14), Triple(2, 5, 8), "B -> A"),
+            )
+
+            val splitL2Operations = listOf(
                 EditOperationType(
                     RangeSelector.RangeMiddle,
                     EditOpCode.SplitUpdate,
@@ -644,9 +799,9 @@ class JsonTreeConcurrencyTest {
                 root,
                 initialXml,
                 ranges,
-                splitOperations,
+                splitL2Operations,
                 editOperations,
-                "concurrently-split-edit-test",
+                "concurrently-split-edit-test-L2",
             )
         }
     }

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeUndoTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeUndoTest.kt
@@ -479,4 +479,204 @@ class JsonTreeUndoTest {
             assertEquals(s2, d1.getRoot().getAs<JsonTree>("tree").toXml())
         }
     }
+
+    /**
+     * Verifies undo/redo for splitLevel=1 split at front/middle/back positions.
+     */
+    @Test
+    fun test_undo_and_redo_split_at_front() {
+        runSplitUndoRedoCase(
+            splitIdx = 1,
+            afterXml = "<doc><p></p><p>ABCD</p></doc>",
+        )
+    }
+
+    @Test
+    fun test_undo_and_redo_split_at_middle() {
+        runSplitUndoRedoCase(
+            splitIdx = 3,
+            afterXml = "<doc><p>AB</p><p>CD</p></doc>",
+        )
+    }
+
+    @Test
+    fun test_undo_and_redo_split_at_back() {
+        runSplitUndoRedoCase(
+            splitIdx = 5,
+            afterXml = "<doc><p>ABCD</p><p></p></doc>",
+        )
+    }
+
+    /**
+     * Verifies undo-redo-undo cycle for splitLevel=1 split returns to the
+     * pre-split state.
+     */
+    @Test
+    fun test_undo_redo_undo_split_at_middle() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree(
+                    "tree",
+                    element("doc") {
+                        element("p") { text { "ABCD" } }
+                    },
+                )
+            }.await()
+            c1.syncAsync().await()
+            val before = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").edit(3, 3, 1)
+            }.await()
+            c1.syncAsync().await()
+
+            d1.history.undoAsync().await()
+            d1.history.redoAsync().await()
+            d1.history.undoAsync().await()
+            assertEquals(before, d1.getRoot().getAs<JsonTree>("tree").toXml())
+        }
+    }
+
+    /**
+     * Verifies undo/redo for chained ops: split -> insert-text.
+     */
+    @Test
+    fun test_undo_and_redo_split_then_insert_text() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree(
+                    "tree",
+                    element("doc") {
+                        element("p") { text { "ABCD" } }
+                    },
+                )
+            }.await()
+            c1.syncAsync().await()
+            val s0 = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").edit(3, 3, 1)
+            }.await()
+            c1.syncAsync().await()
+            val s1 = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").edit(1, 1, text { "X" })
+            }.await()
+            c1.syncAsync().await()
+            val s2 = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.history.undoAsync().await()
+            assertEquals(s1, d1.getRoot().getAs<JsonTree>("tree").toXml())
+            d1.history.undoAsync().await()
+            assertEquals(s0, d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.redoAsync().await()
+            assertEquals(s1, d1.getRoot().getAs<JsonTree>("tree").toXml())
+            d1.history.redoAsync().await()
+            assertEquals(s2, d1.getRoot().getAs<JsonTree>("tree").toXml())
+        }
+    }
+
+    /**
+     * Verifies undo/redo for chained ops: split -> split.
+     */
+    @Test
+    fun test_undo_and_redo_split_then_split() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree(
+                    "tree",
+                    element("doc") {
+                        element("p") { text { "ABCD" } }
+                    },
+                )
+            }.await()
+            c1.syncAsync().await()
+            val s0 = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").edit(3, 3, 1)
+            }.await()
+            c1.syncAsync().await()
+            val s1 = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").edit(2, 2, 1)
+            }.await()
+            c1.syncAsync().await()
+            val s2 = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.history.undoAsync().await()
+            assertEquals(s1, d1.getRoot().getAs<JsonTree>("tree").toXml())
+            d1.history.undoAsync().await()
+            assertEquals(s0, d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.redoAsync().await()
+            assertEquals(s1, d1.getRoot().getAs<JsonTree>("tree").toXml())
+            d1.history.redoAsync().await()
+            assertEquals(s2, d1.getRoot().getAs<JsonTree>("tree").toXml())
+        }
+    }
+
+    /**
+     * Verifies that the redo stack is cleared when a new edit is made after a
+     * split undo.
+     */
+    @Test
+    fun test_split_undo_clears_redo_stack_on_new_edit() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree(
+                    "tree",
+                    element("doc") {
+                        element("p") { text { "ABCD" } }
+                    },
+                )
+            }.await()
+            c1.syncAsync().await()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").edit(3, 3, 1)
+            }.await()
+            c1.syncAsync().await()
+
+            d1.history.undoAsync().await()
+            assertTrue(d1.history.canRedo())
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").edit(1, 1, text { "Z" })
+            }.await()
+            c1.syncAsync().await()
+
+            assertFalse(d1.history.canRedo())
+        }
+    }
+
+    private fun runSplitUndoRedoCase(splitIdx: Int, afterXml: String) {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree(
+                    "tree",
+                    element("doc") {
+                        element("p") { text { "ABCD" } }
+                    },
+                )
+            }.await()
+            c1.syncAsync().await()
+            val before = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").edit(splitIdx, splitIdx, 1)
+            }.await()
+            c1.syncAsync().await()
+            assertEquals(afterXml, d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.undoAsync().await()
+            assertEquals(before, d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.redoAsync().await()
+            assertEquals(afterXml, d1.getRoot().getAs<JsonTree>("tree").toXml())
+        }
+    }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -443,7 +443,12 @@ internal data class CrdtTree(
             var parent = fromParent
             var left = fromLeft
             repeat(splitLevel) {
-                parent.split(this, parent.findOffset(left) + 1, issueTimeTicket, versionVector)
+                parent.split(
+                    this,
+                    parent.findOffset(left, includeRemoved = true) + 1,
+                    issueTimeTicket,
+                    versionVector,
+                )
                 left = parent
                 parent = parent.parent ?: return@repeat
             }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
@@ -48,6 +48,13 @@ internal data class TreeEditOperation(
      * Not serialised to protobuf.
      */
     val removedNodeSnapshots: List<TreeNode>? = null,
+    /**
+     * Non-zero when this is a boundary-deletion op that was generated to undo a split.
+     * Set so that its own reverse (the redo) regenerates a proper split instead of
+     * re-inserting the tombstoned boundary nodes as raw content.
+     * Not serialised to protobuf.
+     */
+    var redoSplitLevel: Int = 0,
 ) : Operation() {
     override val effectedCreatedAt = parentCreatedAt
 
@@ -133,14 +140,23 @@ internal data class TreeEditOperation(
                         .filterIsInstance<OperationInfo.TreeEditOpInfo>()
                         .firstOrNull()
                         ?.from ?: 0
-                listOf(
-                    toReverseOperation(
-                        actualFrom,
-                        fromIndex,
-                        editContents,
-                        result.removedNodes,
-                    ),
-                )
+                val isPureL1Split =
+                    splitLevel == 1 && editContents.isNullOrEmpty() && result.removedNodes.isEmpty()
+                val reverseOp =
+                    if (isPureL1Split) {
+                        toSplitReverseOperation(tree, fromIndex)
+                    } else if (splitLevel == 0) {
+                        toReverseOperation(
+                            tree,
+                            actualFrom,
+                            fromIndex,
+                            editContents,
+                            result.removedNodes,
+                        )
+                    } else {
+                        null
+                    }
+                listOfNotNull(reverseOp)
             } else {
                 emptyList()
             }
@@ -161,13 +177,32 @@ internal data class TreeEditOperation(
      *
      * [undoFromOffset]/[undoToOffset] capture the document-index range so that
      * [reconcileOperation] can adjust them when concurrent remote edits arrive.
+     *
+     * Special case: if [redoSplitLevel] > 0, this op is a boundary-deletion
+     * that undid a split. Its redo must regenerate a proper split at the
+     * merge point rather than re-inserting raw tombstoned boundary nodes.
      */
     private fun toReverseOperation(
+        tree: CrdtTree,
         actualFrom: CrdtTreePos,
         fromIndex: Int,
         editContents: List<CrdtTreeNode>?,
         removedNodes: List<CrdtTreeNode>,
     ): TreeEditOperation {
+        if (redoSplitLevel > 0) {
+            val splitFromPos = tree.findPos(fromIndex)
+            return TreeEditOperation(
+                parentCreatedAt = parentCreatedAt,
+                fromPos = splitFromPos,
+                toPos = splitFromPos,
+                contents = null,
+                splitLevel = redoSplitLevel,
+                executedAt = executedAt,
+                undoFromOffset = fromIndex,
+                undoToOffset = fromIndex,
+            )
+        }
+
         // Document-index span occupied by what was actually inserted. For undo
         // ops this comes from the freshly-rebuilt snapshot nodes, not the
         // original [contents] (which is null on undo ops). Each node
@@ -194,6 +229,43 @@ internal data class TreeEditOperation(
             undoFromOffset = reverseFromIndex,
             undoToOffset = reverseToIndex,
             removedNodeSnapshots = snapshots,
+        )
+    }
+
+    /**
+     * Builds the reverse [TreeEditOperation] for a pure splitLevel=1 split.
+     *
+     * A split creates 2*splitLevel boundary tokens (one close + one open tag
+     * per level). The reverse is a boundary-deletion: a splitLevel=0 edit
+     * that removes those tokens, merging the split elements back together.
+     *
+     * Tags [redoSplitLevel] on the returned op so that its own reverse (the
+     * redo) regenerates a proper split rather than re-inserting raw boundary
+     * nodes as content.
+     *
+     * Returns null if the boundary indices exceed the tree size (the split
+     * was a no-op due to concurrent parent deletion).
+     */
+    private fun toSplitReverseOperation(tree: CrdtTree, preEditFromIdx: Int): TreeEditOperation? {
+        val boundarySize = 2 * splitLevel
+        val reverseFromIdx = preEditFromIdx
+        val reverseToIdx = preEditFromIdx + boundarySize
+
+        if (reverseToIdx > tree.size) return null
+
+        val reverseFromPos = tree.findPos(reverseFromIdx)
+        val reverseToPos = tree.findPos(reverseToIdx)
+
+        return TreeEditOperation(
+            parentCreatedAt = parentCreatedAt,
+            fromPos = reverseFromPos,
+            toPos = reverseToPos,
+            contents = null,
+            splitLevel = 0,
+            executedAt = executedAt,
+            undoFromOffset = reverseFromIdx,
+            undoToOffset = reverseToIdx,
+            redoSplitLevel = splitLevel,
         )
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/util/IndexTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/IndexTree.kt
@@ -807,13 +807,13 @@ abstract class IndexTreeNode<T : IndexTreeNode<T>> {
         }
 
         visibleSize = childNodes.fold(0) { acc, child ->
-            acc + child.paddedSize(false)
+            acc + if (child.isRemoved) 0 else child.paddedSize(false)
         }
         totalSize = childNodes.fold(0) { acc, child ->
             acc + child.paddedSize(true)
         }
         clone.visibleSize = clone.childNodes.fold(0) { acc, child ->
-            acc + child.paddedSize(false)
+            acc + if (child.isRemoved) 0 else child.paddedSize(false)
         }
         clone.totalSize = clone.childNodes.fold(0) { acc, child ->
             acc + child.paddedSize(true)


### PR DESCRIPTION
> **RTCOLLABPLATFORM-651**: [[Android] [B5] Enable splitLevel=1 concurrent tests and add split undo/redo](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-651)

Ports https://github.com/yorkie-team/yorkie-js-sdk/pull/1219.

## Summary
- Generate boundary-deletion reverse ops for pure `splitLevel=1` Tree.Edit so split operations participate in undo/redo
- Tag the reverse op with `redoSplitLevel` so redo regenerates a proper split rather than re-inserting raw tombstoned boundary nodes
- Fix `splitElement` `visibleSize` to skip removed children, and `findOffset(left, includeRemoved=true)` so split offsets align with the underlying child list
- Enable `splitLevel=1` concurrent split×split tests (previously fully skipped); split off `splitLevel>=2` into a separate ignored suite

## Changes
- `TreeEditOperation`: add `redoSplitLevel`, `toSplitReverseOperation`, route pure L1 splits through the new reverse-op path; existing L0 path treats `redoSplitLevel>0` as a redo-as-split
- `CrdtTree`: pass `includeRemoved = true` when computing the split offset so tombstones do not desynchronise indices
- `IndexTree.splitElement`: skip removed children in `visibleSize` recomputation (matches JS fix #1220)
- `JsonTreeConcurrencyTest`: split `test_concurrent_split_and_split` into `_L1` (enabled) and `_L2` (still `@Ignore`); same for `test_concurrent_split_and_edit_*` (L1 left ignored pending a follow-up `runTest` helper fix that passes op2 to d2)
- `JsonTreeUndoTest`: 7 new tests covering front/middle/back split undo, undo-redo-undo, chained split→insert/split, and redo-stack clearing

## Test plan
- [x] `./gradlew yorkie:testDebugUnitTest lintKotlin` — clean
- [x] `JsonTreeUndoTest` — 19/19 passing on emulator (7 new split tests included)
- [x] `JsonTreeConcurrencyTest` — `test_concurrent_split_and_split_L1` enabled and passing; `test_concurrent_edit_and_edit` and the rest unchanged
- [x] `JsonTreeSplitMergeTest` — 22/22 passing (no regressions)
- [x] `JsonTreeTest` — 65/65 passing
- [x] `UndoRedoTest` — 9/9 passing

> Items run automatically by CI (lint, unit tests, coverage) are excluded.