### PR TITLE
Add content-correctness tests for overlapping undo

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTextHistoryTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTextHistoryTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -425,6 +426,90 @@ class JsonTextHistoryTest {
 
             // After sync (no snapshot triggered), the undo stack remains intact.
             assertTrue(d1.history.canUndo())
+        }
+    }
+
+    // Case 3 correctness: d1 deletes [4,6)="45", d2 deletes [2,8)="234567"
+    // (d2's range fully contains d1's). After both undo, the expected content
+    // is "0123456789", but the undo mechanism produces "012345674589" because
+    // each client deep-copies and re-inserts its removed nodes as new CRDT
+    // nodes — the overlapping "45" is re-inserted twice.
+    //
+    // Fixing this requires un-tombstone (resurrect) semantics or node-ID-based
+    // overlap detection. Tracked as a known limitation.
+    @Ignore("known limitation: overlapping undo duplicates content; see RTCOLLABPLATFORM-652")
+    @Test
+    fun test_case3_both_undo_of_overlapping_deletes_restores_original() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewText("t").edit(0, 0, "0123456789")
+            }.await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonText>("t").edit(4, 6, "")
+            }.await()
+            d2.updateAsync { root, _ ->
+                root.getAs<JsonText>("t").edit(2, 8, "")
+            }.await()
+
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+            c1.syncAsync().await()
+
+            d1.history.undoAsync().await()
+            d2.history.undoAsync().await()
+
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+            c1.syncAsync().await()
+
+            val text1 = d1.getRoot().getAs<JsonText>("t").toString()
+            val text2 = d2.getRoot().getAs<JsonText>("t").toString()
+            assertEquals(text1, text2, "convergence")
+            assertEquals("0123456789", text1, "content correctness after both undo")
+        }
+    }
+
+    // Case 5 correctness: d1 deletes [4,8)="4567", d2 deletes [2,6)="2345"
+    // (partial overlap at "45"). After both undo, the expected content is
+    // "0123456789", but the undo mechanism produces "012345456789" because the
+    // overlapping "45" is re-inserted twice — once by each client's undo.
+    //
+    // Same root cause as Case 3. Tracked as a known limitation.
+    @Ignore("known limitation: overlapping undo duplicates content; see RTCOLLABPLATFORM-652")
+    @Test
+    fun test_case5_both_undo_of_partially_overlapping_deletes_restores_original() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewText("t").edit(0, 0, "0123456789")
+            }.await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonText>("t").edit(4, 8, "")
+            }.await()
+            d2.updateAsync { root, _ ->
+                root.getAs<JsonText>("t").edit(2, 6, "")
+            }.await()
+
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+            c1.syncAsync().await()
+
+            d1.history.undoAsync().await()
+            d2.history.undoAsync().await()
+
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+            c1.syncAsync().await()
+
+            val text1 = d1.getRoot().getAs<JsonText>("t").toString()
+            val text2 = d2.getRoot().getAs<JsonText>("t").toString()
+            assertEquals(text1, text2, "convergence")
+            assertEquals("0123456789", text1, "content correctness after both undo")
         }
     }
 }


### PR DESCRIPTION
> **RTCOLLABPLATFORM-652**: [[Android] [B6] Add content-correctness tests for overlapping undo](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-652)

Ports https://github.com/yorkie-team/yorkie-js-sdk/pull/1222.

## Summary
- Adds 2 `@Ignore`-annotated instrumented tests documenting a known limitation: overlapping deletes followed by both clients undoing produces duplicate content, not the original text
- Tests assert both convergence and content correctness so the exact failure mode is clear when the limitation is eventually fixed

## Changes
- `JsonTextHistoryTest.kt`: add `test_case3_both_undo_of_overlapping_deletes_restores_original` and `test_case5_both_undo_of_partially_overlapping_deletes_restores_original`, both annotated `@Ignore`

## Root cause documented
Each client's undo deep-copies removed RGA nodes and re-inserts them as new CRDT nodes. When two undo ranges overlap, the shared content is re-inserted twice. Fixing this requires resurrect (un-tombstone) semantics or node-ID-based overlap detection.

| Case | d1 delete | d2 delete | Expected after both undo | Actual |
|------|-----------|-----------|--------------------------|--------|
| 3 | "45" [4,6) | "234567" [2,8) | "0123456789" | "012345674589" |
| 5 | "4567" [4,8) | "2345" [2,6) | "0123456789" | "012345456789" |

## Test plan
- [x] 18 existing `JsonTextHistoryTest` tests pass
- [x] 2 new tests correctly skipped via `@Ignore`
- [x] `formatKotlin` clean
- [x] `yorkie:testDebugUnitTest` passes
- [x] `yorkie:lintKotlinAndroidTest` passes
- [x] Instrumented tests run on Pixel 3 API 33 emulator