### PR TITLE
Replace WatchDocument/WatchChannel with unified Watch RPC

### DIFF
--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -1,6 +1,6 @@
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.36'
+    image: 'yorkieteam/yorkie:0.6.48'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.6.36'
+    image: 'yorkieteam/yorkie:0.6.48'
     container_name: 'yorkie'
     restart: always
     ports:

--- a/yorkie/proto/yorkie/v1/yorkie.proto
+++ b/yorkie/proto/yorkie/v1/yorkie.proto
@@ -34,12 +34,11 @@ service YorkieService {
   rpc RemoveDocument (RemoveDocumentRequest) returns (RemoveDocumentResponse) {}
   rpc PushPullChanges (PushPullChangesRequest) returns (PushPullChangesResponse) {}
 
-  rpc WatchDocument (WatchDocumentRequest) returns (stream WatchDocumentResponse) {}
+  rpc Watch (WatchRequest) returns (stream WatchResponse) {}
 
   rpc AttachChannel (AttachChannelRequest) returns (AttachChannelResponse) {}
   rpc DetachChannel (DetachChannelRequest) returns (DetachChannelResponse) {}
   rpc RefreshChannel (RefreshChannelRequest) returns (RefreshChannelResponse) {}
-  rpc WatchChannel (WatchChannelRequest) returns (stream WatchChannelResponse) {}
 
   rpc Broadcast (BroadcastRequest) returns (BroadcastResponse) {}
 }
@@ -85,20 +84,70 @@ message DetachDocumentResponse {
   ChangePack change_pack = 2;
 }
 
-message WatchDocumentRequest {
+message WatchRequest {
   string client_id = 1;
-  string document_id = 2;
+  repeated ResourceDescriptor resources = 2;
 }
 
-message WatchDocumentResponse {
-  message Initialization {
-    repeated string client_ids = 1;
+message ResourceDescriptor {
+  oneof resource {
+    DocumentDescriptor document = 1;
+    ChannelDescriptor channel = 2;
   }
+}
 
+message DocumentDescriptor {
+  string document_id = 1;
+}
+
+message ChannelDescriptor {
+  string channel_key = 1;
+}
+
+message WatchResponse {
   oneof body {
-    Initialization initialization = 1;
-    DocEvent event = 2;
+    WatchInitialization initialization = 1;
+    WatchEvent event = 2;
   }
+}
+
+message WatchInitialization {
+  repeated ResourceInit resource_inits = 1;
+}
+
+message ResourceInit {
+  oneof init {
+    DocumentInit document_init = 1;
+    ChannelInit channel_init = 2;
+  }
+}
+
+message DocumentInit {
+  string document_id = 1;
+  repeated string client_ids = 2;
+}
+
+message ChannelInit {
+  string channel_key = 1;
+  int64 session_count = 2;
+  int64 seq = 3;
+}
+
+message WatchEvent {
+  oneof event {
+    DocWatchEvent doc_event = 1;
+    ChannelWatchEvent channel_event = 2;
+  }
+}
+
+message DocWatchEvent {
+  string document_id = 1;
+  DocEvent event = 2;
+}
+
+message ChannelWatchEvent {
+  string channel_key = 1;
+  ChannelEvent event = 2;
 }
 
 message RemoveDocumentRequest {
@@ -150,23 +199,6 @@ message RefreshChannelRequest {
 
 message RefreshChannelResponse {
   int64 session_count = 1;
-}
-
-message WatchChannelRequest {
-  string client_id = 1;
-  string channel_key = 2;
-}
-
-message WatchChannelResponse {
-  oneof body {
-    WatchChannelInitialized initialized = 1;
-    ChannelEvent event = 2;
-  }
-}
-
-message WatchChannelInitialized {
-  int64 session_count = 1;
-  int64 seq = 2;
 }
 
 message BroadcastRequest {

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/ClientTest.kt
@@ -844,16 +844,17 @@ class ClientTest {
                 root.setNewText("t").edit(0, 0, "a")
             }.await()
 
+            fun JsonObject.rootText() = getAs<JsonText>("t")
+
             withTimeout(GENERAL_TIMEOUT) {
-                while (d2SyncEvents.isEmpty()) {
+                while (d2SyncEvents.isEmpty() ||
+                    runCatching { d2.getRoot().rootText().toString() }.getOrNull() != "a"
+                ) {
                     delay(50)
                 }
             }
 
-            fun JsonObject.rootText() = getAs<JsonText>("t")
-
             assertIs<SyncStatusChanged.Synced>(d2SyncEvents.last())
-            delay(100L)
             assertEquals("a", d1.getRoot().rootText().toString())
             assertEquals("a", d2.getRoot().rootText().toString())
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/DocumentTest.kt
@@ -770,13 +770,14 @@ class DocumentTest {
             assertEquals(c1ID, document3StatusChangedList[0].actorID)
 
             client2.activateAsync().await()
+            val c2IDAfterReactivate = client2.requireClientId()
             client2.attachDocument(document4, syncMode = Manual).await()
 
             delay(100L)
 
             assertEquals(1, document4StatusChangedList.size)
             assertEquals(ResourceStatus.Attached, document4StatusChangedList[0].docStatus)
-            assertEquals(c2ID, document4StatusChangedList[0].actorID)
+            assertEquals(c2IDAfterReactivate, document4StatusChangedList[0].actorID)
 
             // 5. Can receive DocumentStatus.Removed event when removed
             client1.removeDocument(document3).await()

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/TestUtils.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 
 const val DEFAULT_SNAPSHOT_THRESHOLD = 1_000
-const val GENERAL_TIMEOUT = 3_000L
+const val GENERAL_TIMEOUT = 10_000L
 
 /**
  * Gets a test configuration value from instrumentation arguments.

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/presence/DocPresenceTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/presence/DocPresenceTest.kt
@@ -782,7 +782,11 @@ class DocPresenceTest {
                 d1.events.filterIsInstance<Others>().toList(d1Events)
             }
 
-            delay(1000)
+            withTimeout(GENERAL_TIMEOUT) {
+                while (d1Events.isEmpty()) {
+                    delay(50)
+                }
+            }
 
             assertEquals(
                 expected = 1,

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -17,21 +17,22 @@ import dev.yorkie.api.toChangePack
 import dev.yorkie.api.toPBChangePack
 import dev.yorkie.api.v1.ActivateClientRequest
 import dev.yorkie.api.v1.DocEventType
-import dev.yorkie.api.v1.WatchChannelResponse
-import dev.yorkie.api.v1.WatchDocumentResponse
+import dev.yorkie.api.v1.WatchResponse
 import dev.yorkie.api.v1.YorkieServiceClient
 import dev.yorkie.api.v1.YorkieServiceClientInterface
 import dev.yorkie.api.v1.attachChannelRequest
 import dev.yorkie.api.v1.attachDocumentRequest
 import dev.yorkie.api.v1.broadcastRequest
+import dev.yorkie.api.v1.channelDescriptor
 import dev.yorkie.api.v1.deactivateClientRequest
 import dev.yorkie.api.v1.detachChannelRequest
 import dev.yorkie.api.v1.detachDocumentRequest
+import dev.yorkie.api.v1.documentDescriptor
 import dev.yorkie.api.v1.pushPullChangesRequest
 import dev.yorkie.api.v1.refreshChannelRequest
 import dev.yorkie.api.v1.removeDocumentRequest
-import dev.yorkie.api.v1.watchChannelRequest
-import dev.yorkie.api.v1.watchDocumentRequest
+import dev.yorkie.api.v1.resourceDescriptor
+import dev.yorkie.api.v1.watchRequest
 import dev.yorkie.document.Document
 import dev.yorkie.document.Document.Event.AuthError
 import dev.yorkie.document.Document.Event.AuthError.AuthErrorMethod.PushPull
@@ -395,8 +396,8 @@ public class Client(
     }
 
     /**
-     * runWatchLoop() runs the watch loop for the given document. The watch loop
-     * listens to the events of the given document from the server.
+     * Runs the watch loop for the given resource. The watch loop
+     * listens to events from the server via the unified Watch RPC.
      */
     private fun runWatchLoop(key: String) {
         scope.launch(activationJob) {
@@ -411,17 +412,9 @@ public class Client(
             attachment.watchJobHolder = WatchJobHolder(
                 attachment.resource.getKey(),
                 when (attachment.resource) {
-                    is Document -> {
-                        createDocumentWatchJob(attachment)
-                    }
-
-                    is Channel -> {
-                        createChannelWatchJob(attachment)
-                    }
-
-                    else -> {
-                        throw IllegalArgumentException("attachment resource type is not correct")
-                    }
+                    is Document -> createDocumentWatchJob(attachment)
+                    is Channel -> createChannelWatchJob(attachment)
+                    else -> throw IllegalArgumentException("unknown attachment resource type")
                 },
             )
         }
@@ -439,20 +432,18 @@ public class Client(
                 latestStream.safeClose()
 
                 val stream = withTimeoutOrNull(streamTimeout) {
-                    service.watchDocument(
-                        documentKey.attachmentBasedRequestHeader,
-                    ).also {
+                    service.watch(documentKey.attachmentBasedRequestHeader).also {
                         latestStream = it
                     }
                 } ?: continue
 
                 val streamJob = launch(start = CoroutineStart.UNDISPATCHED) {
-                    val channel = stream.responseChannel()
+                    val responseChannel = stream.responseChannel()
                     while (!stream.isReceiveClosed() &&
-                        !channel.isClosedForReceive && shouldContinue
+                        !responseChannel.isClosedForReceive && shouldContinue
                     ) {
                         withTimeoutOrNull(streamTimeout) {
-                            val receiveResult = channel.receiveCatching()
+                            val receiveResult = responseChannel.receiveCatching()
                             receiveResult.onSuccess {
                                 handleWatchDocumentResponse(
                                     documentKey = documentKey,
@@ -464,13 +455,12 @@ public class Client(
                                     stream.safeClose()
                                     return@onFailure
                                 }
-                                shouldContinue =
-                                    handleWatchDocumentStreamFailure(
-                                        document = document,
-                                        stream = stream,
-                                        cause = it,
-                                        cancelled = attachment.cancelled,
-                                    )
+                                shouldContinue = handleWatchDocumentStreamFailure(
+                                    document = document,
+                                    stream = stream,
+                                    cause = it,
+                                    cancelled = attachment.cancelled,
+                                )
                             }.onClosed {
                                 handleWatchDocumentStreamFailure(
                                     document = document,
@@ -492,15 +482,17 @@ public class Client(
                     }
                 }
                 stream.sendAndClose(
-                    watchDocumentRequest {
+                    watchRequest {
                         clientId = requireClientId()
-                        documentId = attachment.resourceId
+                        resources += resourceDescriptor {
+                            this.document = documentDescriptor {
+                                documentId = attachment.resourceId
+                            }
+                        }
                     },
                 )
 
-                document.publish(
-                    StreamConnectionChanged.Connected,
-                )
+                document.publish(StreamConnectionChanged.Connected)
 
                 if (attachment.changeEventReceived != null) {
                     attachment.changeEventReceived = true
@@ -518,28 +510,37 @@ public class Client(
         }
     }
 
-    private suspend fun handleWatchDocumentResponse(
-        documentKey: String,
-        response: WatchDocumentResponse,
-    ) {
+    private suspend fun handleWatchDocumentResponse(documentKey: String, response: WatchResponse) {
         if (response.hasInitialization()) {
             val document = attachments[documentKey]?.resource as? Document ?: return
-            val clientIDs = response.initialization.clientIdsList
-            document.publishEvent(
-                Initialized(
-                    document.allPresences.value.filterKeys { it in clientIDs }.asPresences(),
-                ),
-            )
-            document.setOnlineClients(clientIDs.toSet())
+            for (ri in response.initialization.resourceInitsList) {
+                if (!ri.hasDocumentInit()) continue
+                val clientIDs = ri.documentInit.clientIdsList
+                document.publishEvent(
+                    Initialized(
+                        document.allPresences.value.filterKeys { it in clientIDs }.asPresences(),
+                    ),
+                )
+                document.setOnlineClients(clientIDs.toSet())
+                val selfId = requireClientId()
+                for (clientID in document.allPresences.value.keys) {
+                    if (clientID != selfId && clientID !in clientIDs) {
+                        document.clearPresence(clientID)
+                    }
+                }
+            }
             return
         }
 
+        if (!response.hasEvent()) return
         val watchEvent = response.event
-        val eventType = checkNotNull(watchEvent.type)
-        // only single key will be received since 0.3.1 server.
+        if (!watchEvent.hasDocEvent()) return
+
+        val docWatchEvent = watchEvent.docEvent
+        val eventType = checkNotNull(docWatchEvent.event.type)
         val attachment = attachments[documentKey] ?: return
         val document = attachment.resource as? Document ?: return
-        val publisher = watchEvent.publisher
+        val publisher = docWatchEvent.event.publisher
 
         when (eventType) {
             DocEventType.DOC_EVENT_TYPE_DOCUMENT_WATCHED -> {
@@ -548,8 +549,6 @@ public class Client(
                 ) {
                     return
                 }
-                // NOTE(chacha912): We added to onlineClients, but we won't trigger watched event
-                // unless we also know their initial presence data at this point.
                 val presence = document.allPresences.value[publisher]
                 if (presence != null) {
                     document.publishEvent(Others.Watched(PresenceInfo(publisher, presence)))
@@ -558,12 +557,10 @@ public class Client(
             }
 
             DocEventType.DOC_EVENT_TYPE_DOCUMENT_UNWATCHED -> {
-                // NOTE(chacha912): There is no presence,
-                // when PresenceChange(clear) is applied before unwatching. In that case,
-                // the 'unwatched' event is triggered while handling the PresenceChange.
                 val presence = document.presences.value[publisher] ?: return
                 document.publishEvent(Others.Unwatched(PresenceInfo(publisher, presence)))
                 document.removeOnlineClient(publisher)
+                document.clearPresence(publisher)
             }
 
             DocEventType.DOC_EVENT_TYPE_DOCUMENT_CHANGED -> {
@@ -573,8 +570,8 @@ public class Client(
             }
 
             DocEventType.DOC_EVENT_TYPE_DOCUMENT_BROADCAST -> {
-                val topic = response.event.body.topic
-                val payload = response.event.body.payload.toStringUtf8()
+                val topic = docWatchEvent.event.body.topic
+                val payload = docWatchEvent.event.body.payload.toStringUtf8()
                 document.publishEvent(
                     Document.Event.Broadcast(
                         actorID = publisher,
@@ -591,8 +588,8 @@ public class Client(
     }
 
     /**
-     * handleWatchStreamFailure() handles the failure of the watch stream.
-     * return true if the stream should be reconnected, false otherwise.
+     * Handles a failure on the document watch stream.
+     * Returns true if the stream should be reconnected, false otherwise.
      */
     private suspend fun handleWatchDocumentStreamFailure(
         document: Document,
@@ -604,16 +601,13 @@ public class Client(
         stream.safeClose()
 
         cause?.let {
-            sendWatchAttachmentResourceStreamException(
-                tag = "Client.WatchDocument",
-                t = it,
-            )
+            sendWatchAttachmentResourceStreamException(tag = "Client.Watch", t = it)
         }
 
         if (handleDocumentAuthenticationError(
                 exception = cause,
                 document = document,
-                method = AuthError.AuthErrorMethod.WatchDocument,
+                method = AuthError.AuthErrorMethod.Watch,
             ) && !cancelled
         ) {
             coroutineContext.ensureActive()
@@ -627,9 +621,7 @@ public class Client(
 
     private suspend fun onWatchDocumentStreamCanceled(document: Document) {
         if (document.getStatus() == ResourceStatus.Attached && status.value is Status.Activated) {
-            document.publishEvent(
-                Initialized(document.presences.value),
-            )
+            document.publishEvent(Initialized(document.presences.value))
             document.setOnlineClients(emptySet())
             document.publishEvent(StreamConnectionChanged.Disconnected)
         }
@@ -647,9 +639,7 @@ public class Client(
                 latestStream.safeClose()
 
                 val stream = withTimeoutOrNull(streamTimeout) {
-                    service.watchChannel(
-                        channelKey.attachmentBasedRequestHeader,
-                    ).also {
+                    service.watch(channelKey.attachmentBasedRequestHeader).also {
                         latestStream = it
                     }
                 } ?: continue
@@ -661,22 +651,18 @@ public class Client(
                         withTimeoutOrNull(streamTimeout) {
                             val receiveResult = responseChannel.receiveCatching()
                             receiveResult.onSuccess {
-                                handleWatchChannelResponse(
-                                    channel = channel,
-                                    response = it,
-                                )
+                                handleWatchChannelResponse(channel = channel, response = it)
                                 shouldContinue = true
                             }.onFailure {
                                 if (receiveResult.isClosed) {
                                     stream.safeClose()
                                     return@onFailure
                                 }
-                                shouldContinue =
-                                    handleWatchChannelStreamFailure(
-                                        stream = stream,
-                                        cause = it,
-                                        cancelled = attachment.cancelled,
-                                    )
+                                shouldContinue = handleWatchChannelStreamFailure(
+                                    stream = stream,
+                                    cause = it,
+                                    cancelled = attachment.cancelled,
+                                )
                             }.onClosed {
                                 handleWatchChannelStreamFailure(
                                     stream = stream,
@@ -696,9 +682,13 @@ public class Client(
                     }
                 }
                 stream.sendAndClose(
-                    watchChannelRequest {
+                    watchRequest {
                         clientId = requireClientId()
-                        this.channelKey = channelKey
+                        resources += resourceDescriptor {
+                            this.channel = channelDescriptor {
+                                this.channelKey = channelKey
+                            }
+                        }
                     },
                 )
                 streamJob.join()
@@ -712,47 +702,51 @@ public class Client(
         }
     }
 
-    private fun handleWatchChannelResponse(channel: Channel, response: WatchChannelResponse) {
-        if (response.hasInitialized()) {
-            val sessionCount = response.initialized.sessionCount
-            val seq = response.initialized.seq
-            if (channel.updateSessionCount(sessionCount, seq)) {
+    private fun handleWatchChannelResponse(channel: Channel, response: WatchResponse) {
+        if (response.hasInitialization()) {
+            for (ri in response.initialization.resourceInitsList) {
+                if (!ri.hasChannelInit()) continue
+                val sessionCount = ri.channelInit.sessionCount
+                val seq = ri.channelInit.seq
+                if (channel.updateSessionCount(sessionCount, seq)) {
+                    channel.publish(ChannelEvent.Initialized(sessionCount = sessionCount))
+                }
+            }
+            return
+        }
+
+        if (!response.hasEvent()) return
+        val watchEvent = response.event
+        if (!watchEvent.hasChannelEvent()) return
+
+        val event = watchEvent.channelEvent.event
+        when (event.type) {
+            PbChannelEventType.TYPE_PRESENCE -> {
+                val sessionCount = event.sessionCount
+                val seq = event.seq
+                if (channel.updateSessionCount(sessionCount, seq)) {
+                    channel.publish(ChannelEvent.Changed(sessionCount = sessionCount))
+                }
+            }
+
+            PbChannelEventType.TYPE_BROADCAST -> {
                 channel.publish(
-                    ChannelEvent.Initialized(sessionCount = sessionCount),
+                    ChannelEvent.Broadcast(
+                        actorID = event.publisher.takeIf { it.isNotEmpty() },
+                        topic = event.topic,
+                        payload = event.payload.toStringUtf8(),
+                    ),
                 )
             }
-        } else if (response.hasEvent()) {
-            val event = response.event
-            when (event.type) {
-                PbChannelEventType.TYPE_PRESENCE -> {
-                    val sessionCount = event.sessionCount
-                    val seq = event.seq
-                    if (channel.updateSessionCount(sessionCount, seq)) {
-                        channel.publish(
-                            ChannelEvent.Changed(sessionCount = sessionCount),
-                        )
-                    }
-                }
 
-                PbChannelEventType.TYPE_BROADCAST -> {
-                    channel.publish(
-                        ChannelEvent.Broadcast(
-                            actorID = event.publisher.takeIf { it.isNotEmpty() },
-                            topic = event.topic,
-                            payload = event.payload.toStringUtf8(),
-                        ),
-                    )
-                }
-
-                else -> {
-                    // nothing to do
-                }
+            else -> {
+                // nothing to do
             }
         }
     }
 
     /**
-     * handleWatchChannelStreamFailure() handles the failure of the channel watch stream.
+     * Handles a failure on the channel watch stream.
      * Returns true if the stream should be reconnected, false otherwise.
      */
     private suspend fun handleWatchChannelStreamFailure(
@@ -763,10 +757,7 @@ public class Client(
         stream.safeClose()
 
         cause?.let {
-            sendWatchAttachmentResourceStreamException(
-                tag = "Client.WatchChannel",
-                t = it,
-            )
+            sendWatchAttachmentResourceStreamException(tag = "Client.Watch", t = it)
         }
 
         val handleAuthenticationError =

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -840,6 +840,10 @@ public class Document(
         onlineClients.value -= actorID
     }
 
+    internal fun clearPresence(actorID: String) {
+        _presences.value = _presences.value - actorID
+    }
+
     /**
      * `getVersionVector` returns the version vector of document
      */
@@ -1012,7 +1016,7 @@ public class Document(
         ) : Event {
             enum class AuthErrorMethod(val value: String) {
                 PushPull("PushPull"),
-                WatchDocument("WatchDocument"),
+                Watch("Watch"),
                 Broadcast("Broadcast"),
             }
         }

--- a/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
@@ -33,12 +33,10 @@ import dev.yorkie.api.v1.RefreshChannelRequest
 import dev.yorkie.api.v1.RefreshChannelResponse
 import dev.yorkie.api.v1.RemoveDocumentRequest
 import dev.yorkie.api.v1.RemoveDocumentResponse
+import dev.yorkie.api.v1.ResourceDescriptor
 import dev.yorkie.api.v1.ValueType
-import dev.yorkie.api.v1.WatchChannelRequest
-import dev.yorkie.api.v1.WatchChannelResponse
-import dev.yorkie.api.v1.WatchDocumentRequest
-import dev.yorkie.api.v1.WatchDocumentResponse
-import dev.yorkie.api.v1.WatchDocumentResponseKt.initialization
+import dev.yorkie.api.v1.WatchRequest
+import dev.yorkie.api.v1.WatchResponse
 import dev.yorkie.api.v1.YorkieServiceClientInterface
 import dev.yorkie.api.v1.activateClientResponse
 import dev.yorkie.api.v1.attachChannelResponse
@@ -47,18 +45,23 @@ import dev.yorkie.api.v1.broadcastResponse
 import dev.yorkie.api.v1.change
 import dev.yorkie.api.v1.changePack
 import dev.yorkie.api.v1.channelEvent
+import dev.yorkie.api.v1.channelInit
+import dev.yorkie.api.v1.channelWatchEvent
 import dev.yorkie.api.v1.deactivateClientResponse
 import dev.yorkie.api.v1.detachChannelResponse
 import dev.yorkie.api.v1.detachDocumentResponse
 import dev.yorkie.api.v1.docEvent
+import dev.yorkie.api.v1.docWatchEvent
+import dev.yorkie.api.v1.documentInit
 import dev.yorkie.api.v1.jSONElementSimple
 import dev.yorkie.api.v1.operation
 import dev.yorkie.api.v1.pushPullChangesResponse
 import dev.yorkie.api.v1.refreshChannelResponse
 import dev.yorkie.api.v1.removeDocumentResponse
-import dev.yorkie.api.v1.watchChannelInitialized
-import dev.yorkie.api.v1.watchChannelResponse
-import dev.yorkie.api.v1.watchDocumentResponse
+import dev.yorkie.api.v1.resourceInit
+import dev.yorkie.api.v1.watchEvent
+import dev.yorkie.api.v1.watchInitialization
+import dev.yorkie.api.v1.watchResponse
 import dev.yorkie.document.change.Change
 import dev.yorkie.document.change.ChangeID
 import dev.yorkie.document.crdt.CrdtPrimitive
@@ -117,7 +120,6 @@ class MockYorkieService(
             )
         }
         if (request.changePack.documentKey == AUTH_ERROR_DOCUMENT_KEY) {
-            // Create ErrorInfo with unauthenticated error code
             val errorInfo = ErrorInfo.newBuilder()
                 .putMetadata("code", ErrUnauthenticated.codeString)
                 .build()
@@ -226,11 +228,11 @@ class MockYorkieService(
     }
 
     @OptIn(DelicateCoroutinesApi::class)
-    override suspend fun watchDocument(
+    override suspend fun watch(
         headers: Headers,
-    ): ServerOnlyStreamInterface<WatchDocumentRequest, WatchDocumentResponse> {
-        return object : ServerOnlyStreamInterface<WatchDocumentRequest, WatchDocumentResponse> {
-            private var responseChannel = Channel<WatchDocumentResponse>()
+    ): ServerOnlyStreamInterface<WatchRequest, WatchResponse> {
+        return object : ServerOnlyStreamInterface<WatchRequest, WatchResponse> {
+            private var responseChannel = Channel<WatchResponse>()
 
             override fun isClosed(): Boolean {
                 return responseChannel.isClosedForSend
@@ -244,9 +246,9 @@ class MockYorkieService(
                 responseChannel.close()
             }
 
-            override fun responseChannel(): ReceiveChannel<WatchDocumentResponse> {
+            override fun responseChannel(): ReceiveChannel<WatchResponse> {
                 return responseChannel.takeUnless { it.isClosedForReceive || it.isClosedForSend }
-                    ?: Channel<WatchDocumentResponse>().also { responseChannel = it }
+                    ?: Channel<WatchResponse>().also { responseChannel = it }
             }
 
             override fun responseHeaders(): Deferred<Headers> {
@@ -257,56 +259,134 @@ class MockYorkieService(
                 return CompletableDeferred(emptyMap())
             }
 
-            override suspend fun sendAndClose(input: WatchDocumentRequest): Result<Unit> {
+            override suspend fun sendAndClose(input: WatchRequest): Result<Unit> {
                 return runCatching {
-                    val key = input.documentId
                     val clientId = input.clientId
+                    val isDocumentWatch = input.resourcesList.any {
+                        it.resourceCase == ResourceDescriptor.ResourceCase.DOCUMENT
+                    }
                     CoroutineScope(Dispatchers.Default).launch {
-                        if (responseChannel.isClosedForSend) {
-                            return@launch
+                        if (responseChannel.isClosedForSend) return@launch
+                        if (isDocumentWatch) {
+                            handleDocumentWatch(input, clientId)
+                        } else {
+                            handleChannelWatch()
                         }
-                        responseChannel.trySend(
-                            watchDocumentResponse {
-                                initialization = initialization {
-                                    clientIds.add(TEST_ACTOR_ID)
-                                }
-                            },
-                        )
-                        delay(50)
-                        if (key == WATCH_SYNC_ERROR_DOCUMENT_KEY) {
-                            responseChannel.close(
-                                ConnectException(customError[WATCH_SYNC_ERROR_DOCUMENT_KEY]!!),
+                    }
+                }
+            }
+
+            private suspend fun handleDocumentWatch(input: WatchRequest, clientId: String) {
+                val documentId = input.resourcesList
+                    .firstOrNull { it.resourceCase == ResourceDescriptor.ResourceCase.DOCUMENT }
+                    ?.document?.documentId ?: return
+
+                responseChannel.trySend(
+                    watchResponse {
+                        initialization = watchInitialization {
+                            resourceInits.add(
+                                resourceInit {
+                                    documentInit = documentInit {
+                                        this.documentId = documentId
+                                        clientIds.add(TEST_ACTOR_ID)
+                                    }
+                                },
                             )
-                            return@launch
                         }
-                        responseChannel.trySend(
-                            watchDocumentResponse {
+                    },
+                )
+                delay(50)
+                if (documentId == WATCH_SYNC_ERROR_DOCUMENT_KEY) {
+                    responseChannel.close(
+                        ConnectException(customError[WATCH_SYNC_ERROR_DOCUMENT_KEY]!!),
+                    )
+                    return
+                }
+                responseChannel.trySend(
+                    watchResponse {
+                        event = watchEvent {
+                            docEvent = docWatchEvent {
+                                this.documentId = documentId
                                 event = docEvent {
                                     type = DocEventType.DOC_EVENT_TYPE_DOCUMENT_CHANGED
                                     publisher = clientId
                                 }
-                            },
-                        )
-                        delay(1_000)
-                        responseChannel.trySend(
-                            watchDocumentResponse {
+                            }
+                        }
+                    },
+                )
+                delay(1_000)
+                responseChannel.trySend(
+                    watchResponse {
+                        event = watchEvent {
+                            docEvent = docWatchEvent {
+                                this.documentId = documentId
                                 event = docEvent {
                                     type = DocEventType.DOC_EVENT_TYPE_DOCUMENT_WATCHED
                                     publisher = clientId
                                 }
-                            },
-                        )
-                        delay(2_000)
-                        responseChannel.trySend(
-                            watchDocumentResponse {
+                            }
+                        }
+                    },
+                )
+                delay(2_000)
+                responseChannel.trySend(
+                    watchResponse {
+                        event = watchEvent {
+                            docEvent = docWatchEvent {
+                                this.documentId = documentId
                                 event = docEvent {
                                     type = DocEventType.DOC_EVENT_TYPE_DOCUMENT_UNWATCHED
                                     publisher = clientId
                                 }
-                            },
-                        )
-                    }
+                            }
+                        }
+                    },
+                )
+            }
+
+            private suspend fun handleChannelWatch() {
+                responseChannel.trySend(
+                    watchResponse {
+                        initialization = watchInitialization {
+                            resourceInits.add(
+                                resourceInit {
+                                    channelInit = channelInit {}
+                                },
+                            )
+                        }
+                    },
+                )
+                delay(50)
+                repeat(3) {
+                    responseChannel.trySend(
+                        watchResponse {
+                            event = watchEvent {
+                                channelEvent = channelWatchEvent {
+                                    event = channelEvent {
+                                        type = PbChannelEventType.TYPE_PRESENCE
+                                    }
+                                }
+                            }
+                        },
+                    )
+                    delay(1_000)
                 }
+                delay(500)
+                responseChannel.trySend(
+                    watchResponse {
+                        event = watchEvent {
+                            channelEvent = channelWatchEvent {
+                                event = channelEvent {
+                                    type = PbChannelEventType.TYPE_BROADCAST
+                                    publisher = ""
+                                    topic = "test-topic"
+                                    payload = ByteString.copyFromUtf8("test-payload")
+                                }
+                            }
+                        }
+                    },
+                )
             }
         }
     }
@@ -342,93 +422,6 @@ class MockYorkieService(
             headers = emptyMap(),
             trailers = emptyMap(),
         )
-    }
-
-    @OptIn(DelicateCoroutinesApi::class)
-    override suspend fun watchChannel(
-        headers: Headers,
-    ): ServerOnlyStreamInterface<WatchChannelRequest, WatchChannelResponse> {
-        return object : ServerOnlyStreamInterface<WatchChannelRequest, WatchChannelResponse> {
-            private var responseChannel =
-                kotlinx.coroutines.channels.Channel<WatchChannelResponse>()
-
-            override fun isClosed(): Boolean {
-                return responseChannel.isClosedForSend
-            }
-
-            override fun isReceiveClosed(): Boolean {
-                return responseChannel.isClosedForReceive
-            }
-
-            override suspend fun receiveClose() {
-                responseChannel.close()
-            }
-
-            override fun responseChannel(): ReceiveChannel<WatchChannelResponse> {
-                return responseChannel.takeUnless { it.isClosedForReceive || it.isClosedForSend }
-                    ?: kotlinx.coroutines.channels.Channel<WatchChannelResponse>()
-                        .also { responseChannel = it }
-            }
-
-            override fun responseHeaders(): Deferred<Headers> {
-                return CompletableDeferred(emptyMap())
-            }
-
-            override fun responseTrailers(): Deferred<Headers> {
-                return CompletableDeferred(emptyMap())
-            }
-
-            override suspend fun sendAndClose(input: WatchChannelRequest): Result<Unit> {
-                return runCatching {
-                    CoroutineScope(Dispatchers.Default).launch {
-                        if (responseChannel.isClosedForSend) {
-                            return@launch
-                        }
-                        responseChannel.trySend(
-                            watchChannelResponse {
-                                initialized = watchChannelInitialized {}
-                            },
-                        )
-                        delay(50)
-                        responseChannel.trySend(
-                            watchChannelResponse {
-                                event = channelEvent {
-                                    type = PbChannelEventType.TYPE_PRESENCE
-                                }
-                            },
-                        )
-                        delay(1_000)
-                        responseChannel.trySend(
-                            watchChannelResponse {
-                                event = channelEvent {
-                                    type = PbChannelEventType.TYPE_PRESENCE
-                                }
-                            },
-                        )
-                        delay(2_000)
-                        responseChannel.trySend(
-                            watchChannelResponse {
-                                event = channelEvent {
-                                    type = PbChannelEventType.TYPE_PRESENCE
-                                }
-                            },
-                        )
-                        delay(500)
-                        responseChannel.trySend(
-                            watchChannelResponse {
-                                event = channelEvent {
-                                    type = PbChannelEventType.TYPE_BROADCAST
-                                    publisher = input.clientId
-                                    topic = "test-topic"
-                                    payload =
-                                        ByteString.copyFromUtf8("test-payload")
-                                }
-                            },
-                        )
-                    }
-                }
-            }
-        }
     }
 
     override suspend fun removeDocument(


### PR DESCRIPTION
> **RTCOLLABPLATFORM-663**: [[Android] [D2] Replace WatchDocument/WatchChannel with unified Watch RPC](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-663)

## Summary
- Ports yorkie-team/yorkie-js-sdk#1161 to Android, replacing two separate server-streaming RPCs (`WatchDocument` + `WatchChannel`) with a single unified `Watch` RPC
- The unified RPC accepts a `repeated ResourceDescriptor` (document or channel) and returns tagged `WatchResponse` messages (`WatchInitialization` or `WatchEvent`)
- Stale presences are pruned on watch initialization; peer presence is cleared on `DOCUMENT_UNWATCHED`

## Changes
- **`yorkie.proto`**: Replace `WatchDocument` and `WatchChannel` RPCs with unified `Watch` RPC; add new message types for the unified API (`WatchRequest`, `WatchResponse`, `ResourceDescriptor`, `DocumentDescriptor`, `ChannelDescriptor`, `WatchInitialization`, `ResourceInit`, `DocumentInit`, `ChannelInit`, `WatchEvent`, `DocWatchEvent`, `ChannelWatchEvent`)
- **`Client.kt`**: Update `createDocumentWatchJob` and `createChannelWatchJob` to call `service.watch()` with a `WatchRequest`; rewrite response handlers to parse the new response shape; update `AuthErrorMethod` from `WatchDocument` → `Watch`
- **`Document.kt`**: Add `internal fun clearPresence(actorID: String)` used to prune stale presences on watch init and on `DOCUMENT_UNWATCHED` events
- **`MockYorkieService.kt`**: Replace `watchDocument()` + `watchChannel()` mocks with a unified `watch()` mock that dispatches based on resource type in the request
- **`docker-compose.yml`**: Bump server image `0.6.36` → `0.6.48` (first release with unified Watch API, yorkie-team/yorkie#1666)

## Test plan
- [ ] All unit tests pass: `./gradlew yorkie:testDebugUnitTest`
- [ ] All instrumented tests pass against server v0.6.48: `./gradlew yorkie:connectedDebugAndroidTest`