### PR TITLE
Fix concurrent edit×edit merge/delete divergence

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeConcurrencyTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeConcurrencyTest.kt
@@ -20,13 +20,6 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class JsonTreeConcurrencyTest {
 
-    // Concurrent merge×delete/replace diverges: when d1 merges boundary tokens
-    // and d2 concurrently deletes/replaces spanning the same boundary, the two
-    // clients end up with different tree shapes after sync. This was silently
-    // passing before RTCOLLABPLATFORM-668 because both ops ran on d1 (bug), so
-    // the test never exercised true concurrency. The underlying CRDT divergence
-    // needs a dedicated fix — see RTCOLLABPLATFORM-669.
-    @Ignore("concurrent merge×delete divergence; see RTCOLLABPLATFORM-669")
     @Test
     fun test_concurrent_edit_and_edit() {
         runBlocking {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -199,9 +199,10 @@ internal data class CrdtTree(
     private fun toCrdtTreePos(
         parentNode: CrdtTreeNode,
         leftSiblingNode: CrdtTreeNode,
+        includeRemoved: Boolean = false,
     ): TreePos<CrdtTreeNode> {
         return when {
-            parentNode.isRemoved -> {
+            !includeRemoved && parentNode.isRemoved -> {
                 var child = parentNode
                 var parent = parentNode
                 while (parent.isRemoved) {
@@ -209,15 +210,15 @@ internal data class CrdtTree(
                     parent = child.parent ?: break
                 }
 
-                val childOffset = parent.findOffset(child)
+                val childOffset = parent.findOffset(child, includeRemoved)
                 TreePos(parent, childOffset)
             }
 
             parentNode == leftSiblingNode -> TreePos(parentNode, 0)
 
             else -> {
-                var offset = parentNode.findOffset(leftSiblingNode)
-                if (!leftSiblingNode.isRemoved) {
+                var offset = parentNode.findOffset(leftSiblingNode, includeRemoved)
+                if (includeRemoved || !leftSiblingNode.isRemoved) {
                     if (leftSiblingNode.isText) {
                         return TreePos(leftSiblingNode, leftSiblingNode.paddedSize)
                     } else {
@@ -271,6 +272,35 @@ internal data class CrdtTree(
         val fromIndex = toIndex(fromParent, fromLeft)
         val fromPath = toPath(fromParent, fromLeft)
 
+        // §3 Range Narrowing — when fromLeft and toLeft are in different
+        // parents (due to a concurrent element split), follow fromLeft's
+        // insNextID chain to find a split sibling in toParent and narrow the
+        // traversal range. The original fromParent/fromLeft are preserved for
+        // merge, split, and insert steps. VV-independent for clone/root
+        // consistency.
+        var collectFromParent = fromParent
+        var collectFromLeft = fromLeft
+        if (fromLeft !== fromParent && fromParent !== toParent) {
+            var current = fromLeft
+            while (true) {
+                val nextID = current.insNextID ?: break
+                val next = findFloorNode(nextID) ?: break
+                if (next.isText) break
+                if (next.parent === toParent) {
+                    // Skip narrowing when toLeft === toParent (leftmost child
+                    // position, offset 0). The narrowed collectFromLeft would
+                    // be a child at offset >= 1, producing a backwards range
+                    // that suppresses the intended merge.
+                    if (toLeft !== toParent) {
+                        collectFromLeft = next
+                        collectFromParent = toParent
+                    }
+                    break
+                }
+                current = next
+            }
+        }
+
         val nodesToBeRemoved = mutableListOf<CrdtTreeNode>()
         val tokensToBeRemoved = mutableListOf<CrdtTreeToken>()
         val toBeMovedToFromParents = mutableListOf<CrdtTreeNode>()
@@ -280,17 +310,22 @@ internal data class CrdtTree(
         val isLocal = versionVector == null || versionVector.size() == 0
 
         traverseInPosRange(
-            fromParent = fromParent,
-            fromLeft = fromLeft,
+            fromParent = collectFromParent,
+            fromLeft = collectFromLeft,
             toParent = toParent,
             toLeft = toLeft,
+            includeRemoved = true,
         ) { (node, tokenType), ended ->
             // NOTE(hackerwins): If the node overlaps as a start tag with the
             // range then we need to move the remaining children to fromParent.
             // Fix 9: Skip merge for elements created by concurrent operations.
             // The editor didn't know about this element, so crossing into it is
             // an artifact of a concurrent split, not an intentional merge.
-            if (tokenType == TokenType.Start && !ended) {
+            // Also skip already-tombstoned nodes: when a prior merge moved their
+            // children away, treating them as a fresh merge boundary blocks the
+            // cascade-delete (03-1) from propagating the delete to those moved
+            // children. Only live nodes need the merge treatment.
+            if (tokenType == TokenType.Start && !ended && node.removedAt == null) {
                 val nodeCreationKnown = if (isLocal) {
                     true
                 } else {
@@ -715,14 +750,15 @@ internal data class CrdtTree(
         fromLeft: CrdtTreeNode,
         toParent: CrdtTreeNode,
         toLeft: CrdtTreeNode,
+        includeRemoved: Boolean = false,
         callback: (CrdtTreeToken, Boolean) -> Unit,
     ) {
-        val fromIndex = toIndex(fromParent, fromLeft)
-        val toIndex = toIndex(toParent, toLeft)
+        val fromIndex = toIndex(fromParent, fromLeft, includeRemoved)
+        val toIndex = toIndex(toParent, toLeft, includeRemoved)
         // When a concurrent merge redirects the to-position ahead of the
         // from-position, the range is empty — a prior step already handled it.
         if (fromIndex > toIndex) return
-        indexTree.tokensBetween(fromIndex, toIndex, callback)
+        indexTree.tokensBetween(fromIndex, toIndex, callback, includeRemoved)
     }
 
     fun registerNode(node: CrdtTreeNode) {
@@ -947,8 +983,15 @@ internal data class CrdtTree(
     /**
      * Converts the given [parentNode] to the index of the tree.
      */
-    fun toIndex(parentNode: CrdtTreeNode, leftSiblingNode: CrdtTreeNode): Int {
-        return indexTree.indexOf(toCrdtTreePos(parentNode, leftSiblingNode))
+    fun toIndex(
+        parentNode: CrdtTreeNode,
+        leftSiblingNode: CrdtTreeNode,
+        includeRemoved: Boolean = false,
+    ): Int {
+        return indexTree.indexOf(
+            toCrdtTreePos(parentNode, leftSiblingNode, includeRemoved),
+            includeRemoved,
+        )
     }
 
     /**


### PR DESCRIPTION
> **RTCOLLABPLATFORM-669**: [[Android] Fix concurrent edit×edit merge/delete divergence](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-669)

## Summary
- Fixes CRDT divergence when one client merges two element boundaries and another client concurrently deletes/replaces content spanning the same boundary
- Ports convergence fixes from JS SDK PR #1233 and Go SDK PR #1776

## Changes
- Pass `includeRemoved=true` to `traverseInPosRange` inside `edit()` so tombstoned merge-source nodes are visited and their moved children are cascade-deleted (step 03-1)
- Guard `toBeMergedNodes` addition with `node.removedAt == null` so visiting a tombstoned merge-source does not re-trigger merge for an already-deleted node
- Add Phase 3 Range Narrowing: when `fromLeft` and `toLeft` are in different parents (concurrent element split), follow the `insNextID` chain from `fromLeft` to find a split sibling inside `toParent` and narrow the traversal range
- Propagate `includeRemoved` flag through `toCrdtTreePos`, `toIndex`, and `traverseInPosRange` signatures
- Remove `@Ignore` from `test_concurrent_edit_and_edit`; all 7 concurrent-edit tests now pass

## Test plan
- [ ] Run `JsonTreeConcurrencyTest#test_concurrent_edit_and_edit` on the emulator (previously `@Ignore`)
- [ ] Run full `JsonTreeConcurrencyTest` suite (7 concurrent-edit tests, 0 failures)
- [ ] Run `JsonTreeTest` split/merge and undo suites to confirm no regressions

> Items run automatically by CI (lint, unit tests, coverage) are excluded.