### PR TITLE
Implement revision management

### DIFF
--- a/yorkie/proto/yorkie/v1/resources.proto
+++ b/yorkie/proto/yorkie/v1/resources.proto
@@ -471,3 +471,11 @@ message Rule {
   string path = 1;
   string type = 2;
 }
+
+message RevisionSummary {
+  string id = 1;
+  string label = 2;
+  string description = 3;
+  string snapshot = 4;
+  google.protobuf.Timestamp created_at = 5;
+}

--- a/yorkie/proto/yorkie/v1/yorkie.proto
+++ b/yorkie/proto/yorkie/v1/yorkie.proto
@@ -36,6 +36,10 @@ service YorkieService {
 
   rpc Watch (WatchRequest) returns (stream WatchResponse) {}
 
+  rpc CreateRevision (CreateRevisionRequest) returns (CreateRevisionResponse) {}
+  rpc ListRevisions (ListRevisionsRequest) returns (ListRevisionsResponse) {}
+  rpc RestoreRevision (RestoreRevisionRequest) returns (RestoreRevisionResponse) {}
+
   rpc AttachChannel (AttachChannelRequest) returns (AttachChannelResponse) {}
   rpc DetachChannel (DetachChannelRequest) returns (DetachChannelResponse) {}
   rpc RefreshChannel (RefreshChannelRequest) returns (RefreshChannelResponse) {}
@@ -209,4 +213,36 @@ message BroadcastRequest {
 }
 
 message BroadcastResponse {
+}
+
+message CreateRevisionRequest {
+  string client_id = 1;
+  string document_id = 2;
+  string label = 3;
+  string description = 4;
+}
+
+message CreateRevisionResponse {
+  RevisionSummary revision = 1;
+}
+
+message ListRevisionsRequest {
+  string client_id = 1;
+  string document_id = 2;
+  int32 page_size = 3;
+  int32 offset = 4;
+  bool is_forward = 5;
+}
+
+message ListRevisionsResponse {
+  repeated RevisionSummary revisions = 1;
+}
+
+message RestoreRevisionRequest {
+  string client_id = 1;
+  string document_id = 2;
+  string revision_id = 4;
+}
+
+message RestoreRevisionResponse {
 }

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/RevisionTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/RevisionTest.kt
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith
 class RevisionTest {
 
     @Test
-    fun `can create a revision and list revisions`() {
+    fun can_create_a_revision_and_list_revisions() {
         runBlocking {
             val client = createClient()
             val key = UUID.randomUUID().toString().toDocKey()
@@ -83,7 +83,7 @@ class RevisionTest {
     }
 
     @Test
-    fun `can paginate revisions`() {
+    fun can_paginate_revisions() {
         runBlocking {
             val client = createClient()
             val key = UUID.randomUUID().toString().toDocKey()
@@ -117,7 +117,7 @@ class RevisionTest {
     }
 
     @Test
-    fun `can restore document to a revision`() {
+    fun can_restore_document_to_a_revision() {
         runBlocking {
             val client = createClient()
             val key = UUID.randomUUID().toString().toDocKey()
@@ -157,7 +157,7 @@ class RevisionTest {
     }
 
     @Test
-    fun `restore propagates to other clients`() {
+    fun restore_propagates_to_other_clients() {
         withTwoClientsAndDocuments(
             syncMode = Manual,
         ) { c1, c2, d1, d2, _ ->

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/RevisionTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/RevisionTest.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2025 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.yorkie.core
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.yorkie.core.Client.SyncMode.Manual
+import dev.yorkie.document.Document
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RevisionTest {
+
+    @Test
+    fun `can create a revision and list revisions`() {
+        runBlocking {
+            val client = createClient()
+            val key = UUID.randomUUID().toString().toDocKey()
+            val doc = Document(key)
+
+            client.activateAsync().await()
+            client.attachDocument(doc, syncMode = Manual).await()
+
+            // given — initial content synced to server
+            doc.updateAsync { root, _ ->
+                root["k1"] = "v1"
+            }.await()
+            client.syncAsync().await()
+
+            // when — create first revision
+            val rev1 = client.createRevision(doc, "v1.0", "First revision").await()
+
+            // then
+            assertNotNull(rev1)
+            assertEquals("v1.0", rev1.label)
+            assertEquals("First revision", rev1.description)
+            assertTrue(rev1.id.isNotEmpty())
+
+            // given — more changes
+            doc.updateAsync { root, _ ->
+                root["k2"] = "v2"
+            }.await()
+            client.syncAsync().await()
+
+            // when — create second revision
+            val rev2 = client.createRevision(doc, "v2.0", "Second revision").await()
+
+            // then
+            assertEquals("v2.0", rev2.label)
+
+            // when — list all revisions
+            val revisions = client.listRevisions(doc).await()
+
+            // then — newest-first order
+            assertTrue(revisions.size >= 2)
+            assertEquals("v2.0", revisions[0].label)
+            assertEquals("v1.0", revisions[1].label)
+
+            client.detachDocument(doc).await()
+            client.deactivateAsync().await()
+            doc.close()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `can paginate revisions`() {
+        runBlocking {
+            val client = createClient()
+            val key = UUID.randomUUID().toString().toDocKey()
+            val doc = Document(key)
+
+            client.activateAsync().await()
+            client.attachDocument(doc, syncMode = Manual).await()
+
+            // given — create 5 revisions
+            for (i in 1..5) {
+                doc.updateAsync { root, _ -> root["count"] = i }.await()
+                client.syncAsync().await()
+                client.createRevision(doc, "v$i.0", "Revision $i").await()
+            }
+
+            // when — page 1
+            val firstPage = client.listRevisions(doc, pageSize = 3).await()
+            // then
+            assertEquals(3, firstPage.size)
+
+            // when — page 2
+            val secondPage = client.listRevisions(doc, pageSize = 3, offset = 3).await()
+            // then
+            assertEquals(2, secondPage.size)
+
+            client.detachDocument(doc).await()
+            client.deactivateAsync().await()
+            doc.close()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `can restore document to a revision`() {
+        runBlocking {
+            val client = createClient()
+            val key = UUID.randomUUID().toString().toDocKey()
+            val doc = Document(key)
+
+            client.activateAsync().await()
+            client.attachDocument(doc, syncMode = Manual).await()
+
+            // given — create initial state and snapshot it
+            doc.updateAsync { root, _ ->
+                root["k1"] = "v1"
+                root["k2"] = "v2"
+            }.await()
+            client.syncAsync().await()
+            val revision = client.createRevision(doc, "v1.0", "Initial state").await()
+
+            // given — modify document after snapshot
+            doc.updateAsync { root, _ ->
+                root["k1"] = "modified"
+                root["k2"] = "v3"
+            }.await()
+            client.syncAsync().await()
+            assertEquals("""{"k1":"modified","k2":"v3"}""", doc.toJson())
+
+            // when — restore to snapshot
+            client.restoreRevision(doc, revision.id).await()
+            client.syncAsync().await()
+
+            // then — document content matches the snapshot
+            assertEquals("""{"k1":"v1","k2":"v2"}""", doc.toJson())
+
+            client.detachDocument(doc).await()
+            client.deactivateAsync().await()
+            doc.close()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `restore propagates to other clients`() {
+        withTwoClientsAndDocuments(
+            syncMode = Manual,
+        ) { c1, c2, d1, d2, _ ->
+            // given — both clients have initial state
+            d1.updateAsync { root, _ ->
+                root["k1"] = "v1"
+                root["k2"] = "v2"
+            }.await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+            assertEquals("""{"k1":"v1","k2":"v2"}""", d1.toJson())
+            assertEquals("""{"k1":"v1","k2":"v2"}""", d2.toJson())
+
+            // given — c1 creates a revision of the current state
+            val revision = c1.createRevision(d1, "v1.0", "Initial state").await()
+
+            // given — c1 makes changes
+            d1.updateAsync { root, _ ->
+                root["k1"] = "modified"
+                root["k2"] = "v3"
+            }.await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+            assertEquals("""{"k1":"modified","k2":"v3"}""", d1.toJson())
+            assertEquals("""{"k1":"modified","k2":"v3"}""", d2.toJson())
+
+            // when — c1 restores and syncs
+            c1.restoreRevision(d1, revision.id).await()
+            c1.syncAsync().await()
+
+            // when — c2 syncs to receive restore
+            c2.syncAsync().await()
+
+            // then — both clients converge to the restored state
+            assertEquals("""{"k1":"v1","k2":"v2"}""", d1.toJson())
+            assertEquals("""{"k1":"v1","k2":"v2"}""", d2.toJson())
+        }
+    }
+}

--- a/yorkie/src/main/kotlin/dev/yorkie/api/RevisionConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/RevisionConverter.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.yorkie.api
+
+import dev.yorkie.core.RevisionSummary
+import java.util.Date
+import dev.yorkie.api.v1.RevisionSummary as PbRevisionSummary
+
+/**
+ * Converts a protobuf [PbRevisionSummary] to a [RevisionSummary].
+ */
+internal fun PbRevisionSummary.toRevisionSummary(): RevisionSummary {
+    return RevisionSummary(
+        id = id,
+        label = label,
+        description = description,
+        snapshot = snapshot,
+        createdAt = if (hasCreatedAt()) Date(createdAt.seconds * 1_000) else Date(),
+    )
+}

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -15,6 +15,7 @@ import com.google.protobuf.ByteString
 import dev.yorkie.api.fromSchemaRules
 import dev.yorkie.api.toChangePack
 import dev.yorkie.api.toPBChangePack
+import dev.yorkie.api.toRevisionSummary
 import dev.yorkie.api.v1.ActivateClientRequest
 import dev.yorkie.api.v1.DocEventType
 import dev.yorkie.api.v1.WatchResponse
@@ -24,14 +25,17 @@ import dev.yorkie.api.v1.attachChannelRequest
 import dev.yorkie.api.v1.attachDocumentRequest
 import dev.yorkie.api.v1.broadcastRequest
 import dev.yorkie.api.v1.channelDescriptor
+import dev.yorkie.api.v1.createRevisionRequest
 import dev.yorkie.api.v1.deactivateClientRequest
 import dev.yorkie.api.v1.detachChannelRequest
 import dev.yorkie.api.v1.detachDocumentRequest
 import dev.yorkie.api.v1.documentDescriptor
+import dev.yorkie.api.v1.listRevisionsRequest
 import dev.yorkie.api.v1.pushPullChangesRequest
 import dev.yorkie.api.v1.refreshChannelRequest
 import dev.yorkie.api.v1.removeDocumentRequest
 import dev.yorkie.api.v1.resourceDescriptor
+import dev.yorkie.api.v1.restoreRevisionRequest
 import dev.yorkie.api.v1.watchRequest
 import dev.yorkie.document.Document
 import dev.yorkie.document.Document.Event.AuthError
@@ -47,6 +51,7 @@ import dev.yorkie.presence.Channel
 import dev.yorkie.presence.ChannelEvent
 import dev.yorkie.presence.Presence
 import dev.yorkie.util.Logger.Companion.log
+import dev.yorkie.util.Logger.Companion.logDebug
 import dev.yorkie.util.Logger.Companion.logError
 import dev.yorkie.util.OperationResult
 import dev.yorkie.util.SUCCESS
@@ -1211,6 +1216,134 @@ public class Client(
                 document.applyChangePack(pack)
                 detachInternal(documentKey)
             }
+            SUCCESS
+        }
+    }
+
+    /**
+     * Creates a revision snapshot for the given [document] with the given [label] and
+     * optional [description]. The document must be attached to this client.
+     */
+    public fun createRevision(
+        document: Document,
+        label: String,
+        description: String = "",
+    ): Deferred<RevisionSummary> {
+        return scope.async {
+            checkYorkieError(
+                isActive,
+                YorkieException(ErrClientNotActivated, "client is not active"),
+            )
+
+            val documentKey = document.getKey()
+            val attachment = attachments[documentKey]
+                ?: throw YorkieException(
+                    ErrDocumentNotAttached,
+                    "document($documentKey) is not attached",
+                )
+
+            val request = createRevisionRequest {
+                clientId = requireClientId()
+                documentId = attachment.resourceId
+                this.label = label
+                this.description = description
+            }
+            val response = service.createRevision(
+                request,
+                documentKey.attachmentBasedRequestHeader,
+            ).getOrThrow()
+
+            if (!response.hasRevision()) {
+                throw YorkieException(
+                    YorkieException.Code.ErrInvalidArgument,
+                    "revision is not returned",
+                )
+            }
+
+            logDebug("CR", "c:\"${options.key}\" creates revision d:\"$documentKey\" l:\"$label\"")
+            response.revision.toRevisionSummary()
+        }
+    }
+
+    /**
+     * Lists revisions for the given [document]. The document must be attached.
+     *
+     * @param pageSize maximum number of revisions to return (default 10).
+     * @param offset number of revisions to skip for pagination (default 0).
+     * @param isForward when true, returns oldest-first; false (default) returns newest-first.
+     */
+    public fun listRevisions(
+        document: Document,
+        pageSize: Int = 10,
+        offset: Int = 0,
+        isForward: Boolean = false,
+    ): Deferred<List<RevisionSummary>> {
+        return scope.async {
+            checkYorkieError(
+                isActive,
+                YorkieException(ErrClientNotActivated, "client is not active"),
+            )
+
+            val documentKey = document.getKey()
+            val attachment = attachments[documentKey]
+                ?: throw YorkieException(
+                    ErrDocumentNotAttached,
+                    "document($documentKey) is not attached",
+                )
+
+            val request = listRevisionsRequest {
+                clientId = requireClientId()
+                documentId = attachment.resourceId
+                this.pageSize = pageSize
+                this.offset = offset
+                this.isForward = isForward
+            }
+            val response = service.listRevisions(
+                request,
+                documentKey.attachmentBasedRequestHeader,
+            ).getOrThrow()
+
+            logDebug(
+                "LR",
+                "c:\"${options.key}\" lists revisions d:\"$documentKey\"" +
+                    " count:${response.revisionsCount}",
+            )
+            response.revisionsList.map { it.toRevisionSummary() }
+        }
+    }
+
+    /**
+     * Restores the given [document] to the state captured by the revision with [revisionId].
+     * The document must be attached to this client.
+     */
+    public fun restoreRevision(document: Document, revisionId: String): Deferred<OperationResult> {
+        return scope.async {
+            checkYorkieError(
+                isActive,
+                YorkieException(ErrClientNotActivated, "client is not active"),
+            )
+
+            val documentKey = document.getKey()
+            val attachment = attachments[documentKey]
+                ?: throw YorkieException(
+                    ErrDocumentNotAttached,
+                    "document($documentKey) is not attached",
+                )
+
+            val request = restoreRevisionRequest {
+                clientId = requireClientId()
+                documentId = attachment.resourceId
+                this.revisionId = revisionId
+            }
+            service.restoreRevision(
+                request,
+                documentKey.attachmentBasedRequestHeader,
+            ).getOrThrow()
+
+            logDebug(
+                "RR",
+                "c:\"${options.key}\" restores revision d:\"$documentKey\" r:\"$revisionId\"",
+            )
             SUCCESS
         }
     }

--- a/yorkie/src/main/kotlin/dev/yorkie/core/RevisionSummary.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/RevisionSummary.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.yorkie.core
+
+import java.util.Date
+
+/**
+ * Represents a document revision for version management.
+ * Stores a snapshot of document content at a specific point in time,
+ * enabling rollback, audit, and version history tracking.
+ */
+public data class RevisionSummary(
+    /** Unique identifier of the revision. */
+    val id: String,
+    /** User-friendly name for this revision. */
+    val label: String,
+    /** Detailed explanation of this revision. */
+    val description: String,
+    /** Serialized document content (JSON) at this revision point. */
+    val snapshot: String,
+    /** Time when this revision was created. */
+    val createdAt: Date,
+)

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -434,6 +434,104 @@ class ClientTest {
         assertEquals(ResourceStatus.Detached, document.getStatus())
     }
 
+    @Test
+    fun `createRevision fails when client is not active`() = runTest {
+        val document = Document(NORMAL_DOCUMENT_KEY)
+
+        val exception = assertFailsWith<YorkieException> {
+            target.createRevision(document, "v1.0").await()
+        }
+        assertEquals(YorkieException.Code.ErrClientNotActivated, exception.code)
+    }
+
+    @Test
+    fun `createRevision fails when document is not attached`() = runTest {
+        target.activateAsync().await()
+        val document = Document(NORMAL_DOCUMENT_KEY)
+
+        val exception = assertFailsWith<YorkieException> {
+            target.createRevision(document, "v1.0").await()
+        }
+        assertEquals(ErrDocumentNotAttached, exception.code)
+    }
+
+    @Test
+    fun `createRevision returns revision summary with expected label and description`() = runTest {
+        target.activateAsync().await()
+        val document = Document(NORMAL_DOCUMENT_KEY)
+        target.attachDocument(document, syncMode = Manual).await()
+
+        val revision = target.createRevision(document, "v1.0", "First release").await()
+
+        assertEquals("v1.0", revision.label)
+        assertEquals("First release", revision.description)
+        assertTrue(revision.id.isNotEmpty())
+    }
+
+    @Test
+    fun `listRevisions fails when client is not active`() = runTest {
+        val document = Document(NORMAL_DOCUMENT_KEY)
+
+        val exception = assertFailsWith<YorkieException> {
+            target.listRevisions(document).await()
+        }
+        assertEquals(YorkieException.Code.ErrClientNotActivated, exception.code)
+    }
+
+    @Test
+    fun `listRevisions fails when document is not attached`() = runTest {
+        target.activateAsync().await()
+        val document = Document(NORMAL_DOCUMENT_KEY)
+
+        val exception = assertFailsWith<YorkieException> {
+            target.listRevisions(document).await()
+        }
+        assertEquals(ErrDocumentNotAttached, exception.code)
+    }
+
+    @Test
+    fun `listRevisions returns empty list when no revisions exist`() = runTest {
+        target.activateAsync().await()
+        val document = Document(NORMAL_DOCUMENT_KEY)
+        target.attachDocument(document, syncMode = Manual).await()
+
+        val revisions = target.listRevisions(document).await()
+
+        assertTrue(revisions.isEmpty())
+    }
+
+    @Test
+    fun `restoreRevision fails when client is not active`() = runTest {
+        val document = Document(NORMAL_DOCUMENT_KEY)
+
+        val exception = assertFailsWith<YorkieException> {
+            target.restoreRevision(document, "revision-id").await()
+        }
+        assertEquals(YorkieException.Code.ErrClientNotActivated, exception.code)
+    }
+
+    @Test
+    fun `restoreRevision fails when document is not attached`() = runTest {
+        target.activateAsync().await()
+        val document = Document(NORMAL_DOCUMENT_KEY)
+
+        val exception = assertFailsWith<YorkieException> {
+            target.restoreRevision(document, "revision-id").await()
+        }
+        assertEquals(ErrDocumentNotAttached, exception.code)
+    }
+
+    @Test
+    fun `restoreRevision succeeds when client is active and document is attached`() = runTest {
+        target.activateAsync().await()
+        val document = Document(NORMAL_DOCUMENT_KEY)
+        target.attachDocument(document, syncMode = Manual).await()
+
+        val result = target.restoreRevision(document, "test-revision-id").await()
+
+        assertTrue(result.isSuccess)
+    }
+
     private fun assertIsTestActorID(clientId: String) {
         assertEquals(TEST_ACTOR_ID, clientId)
     }

--- a/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
@@ -18,6 +18,8 @@ import dev.yorkie.api.v1.AttachDocumentRequest
 import dev.yorkie.api.v1.AttachDocumentResponse
 import dev.yorkie.api.v1.BroadcastRequest
 import dev.yorkie.api.v1.BroadcastResponse
+import dev.yorkie.api.v1.CreateRevisionRequest
+import dev.yorkie.api.v1.CreateRevisionResponse
 import dev.yorkie.api.v1.DeactivateClientRequest
 import dev.yorkie.api.v1.DeactivateClientResponse
 import dev.yorkie.api.v1.DetachChannelRequest
@@ -25,6 +27,8 @@ import dev.yorkie.api.v1.DetachChannelResponse
 import dev.yorkie.api.v1.DetachDocumentRequest
 import dev.yorkie.api.v1.DetachDocumentResponse
 import dev.yorkie.api.v1.DocEventType
+import dev.yorkie.api.v1.ListRevisionsRequest
+import dev.yorkie.api.v1.ListRevisionsResponse
 import dev.yorkie.api.v1.OperationKt.remove
 import dev.yorkie.api.v1.OperationKt.set
 import dev.yorkie.api.v1.PushPullChangesRequest
@@ -34,6 +38,8 @@ import dev.yorkie.api.v1.RefreshChannelResponse
 import dev.yorkie.api.v1.RemoveDocumentRequest
 import dev.yorkie.api.v1.RemoveDocumentResponse
 import dev.yorkie.api.v1.ResourceDescriptor
+import dev.yorkie.api.v1.RestoreRevisionRequest
+import dev.yorkie.api.v1.RestoreRevisionResponse
 import dev.yorkie.api.v1.ValueType
 import dev.yorkie.api.v1.WatchRequest
 import dev.yorkie.api.v1.WatchResponse
@@ -47,6 +53,7 @@ import dev.yorkie.api.v1.changePack
 import dev.yorkie.api.v1.channelEvent
 import dev.yorkie.api.v1.channelInit
 import dev.yorkie.api.v1.channelWatchEvent
+import dev.yorkie.api.v1.createRevisionResponse
 import dev.yorkie.api.v1.deactivateClientResponse
 import dev.yorkie.api.v1.detachChannelResponse
 import dev.yorkie.api.v1.detachDocumentResponse
@@ -54,11 +61,14 @@ import dev.yorkie.api.v1.docEvent
 import dev.yorkie.api.v1.docWatchEvent
 import dev.yorkie.api.v1.documentInit
 import dev.yorkie.api.v1.jSONElementSimple
+import dev.yorkie.api.v1.listRevisionsResponse
 import dev.yorkie.api.v1.operation
 import dev.yorkie.api.v1.pushPullChangesResponse
 import dev.yorkie.api.v1.refreshChannelResponse
 import dev.yorkie.api.v1.removeDocumentResponse
 import dev.yorkie.api.v1.resourceInit
+import dev.yorkie.api.v1.restoreRevisionResponse
+import dev.yorkie.api.v1.revisionSummary
 import dev.yorkie.api.v1.watchEvent
 import dev.yorkie.api.v1.watchInitialization
 import dev.yorkie.api.v1.watchResponse
@@ -457,6 +467,46 @@ class MockYorkieService(
         headers: Headers,
     ): ResponseMessage<BroadcastResponse> {
         return ResponseMessage.Success(broadcastResponse { }, emptyMap(), emptyMap())
+    }
+
+    override suspend fun createRevision(
+        request: CreateRevisionRequest,
+        headers: Headers,
+    ): ResponseMessage<CreateRevisionResponse> {
+        return ResponseMessage.Success(
+            createRevisionResponse {
+                revision = revisionSummary {
+                    id = "test-revision-id"
+                    label = request.label
+                    description = request.description
+                    snapshot = "{}"
+                }
+            },
+            emptyMap(),
+            emptyMap(),
+        )
+    }
+
+    override suspend fun listRevisions(
+        request: ListRevisionsRequest,
+        headers: Headers,
+    ): ResponseMessage<ListRevisionsResponse> {
+        return ResponseMessage.Success(
+            listRevisionsResponse {},
+            emptyMap(),
+            emptyMap(),
+        )
+    }
+
+    override suspend fun restoreRevision(
+        request: RestoreRevisionRequest,
+        headers: Headers,
+    ): ResponseMessage<RestoreRevisionResponse> {
+        return ResponseMessage.Success(
+            restoreRevisionResponse {},
+            emptyMap(),
+            emptyMap(),
+        )
     }
 
     companion object {


### PR DESCRIPTION
> **RTCOLLABPLATFORM-653**: [[Android] [C1] Implement revision management](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-653)

Ports https://github.com/yorkie-team/yorkie-js-sdk/pull/1127.

## Summary
- Introduce `RevisionSummary` as the public data class representing a document revision snapshot
- Add `CreateRevision`, `ListRevisions`, and `RestoreRevision` RPCs to the proto and wire them to three new `Client` methods
- Bump Docker server to `0.6.48` (earliest available image with revision RPCs)

## Changes
- `resources.proto` — add `RevisionSummary` message
- `yorkie.proto` — add three revision RPCs and their request/response messages
- `RevisionSummary.kt` — new public data class in `core/`
- `RevisionConverter.kt` — `PbRevisionSummary.toRevisionSummary()` converter
- `Client.kt` — `createRevision`, `listRevisions`, `restoreRevision` public methods
- `MockYorkieService.kt` — stub implementations for all three RPCs
- `ClientTest.kt` (unit) — guard-condition tests (not-active, not-attached, happy path)
- `RevisionTest.kt` (instrumented) — create/list, pagination, restore, cross-client propagation
- `docker/docker-compose.yml`, `docker/docker-compose-ci.yml` — server `0.6.35` → `0.6.48`

## Test plan
- [ ] Run instrumented tests against a local Yorkie server (`docker compose -f docker/docker-compose.yml up -d`)
- [ ] Verify `createRevision` returns a `RevisionSummary` with correct label/description
- [ ] Verify `listRevisions` returns results newest-first by default
- [ ] Verify `restoreRevision` restores document content and propagates to a second client

> Items run automatically by CI (lint, unit tests, coverage) are excluded.