### PR TITLE
Add GetRevision for retrieving specific revisions

### DIFF
--- a/yorkie/proto/yorkie/v1/yorkie.proto
+++ b/yorkie/proto/yorkie/v1/yorkie.proto
@@ -37,6 +37,7 @@ service YorkieService {
   rpc Watch (WatchRequest) returns (stream WatchResponse) {}
 
   rpc CreateRevision (CreateRevisionRequest) returns (CreateRevisionResponse) {}
+  rpc GetRevision (GetRevisionRequest) returns (GetRevisionResponse) {}
   rpc ListRevisions (ListRevisionsRequest) returns (ListRevisionsResponse) {}
   rpc RestoreRevision (RestoreRevisionRequest) returns (RestoreRevisionResponse) {}
 
@@ -223,6 +224,16 @@ message CreateRevisionRequest {
 }
 
 message CreateRevisionResponse {
+  RevisionSummary revision = 1;
+}
+
+message GetRevisionRequest {
+  string client_id = 1;
+  string document_id = 2;
+  string revision_id = 3;
+}
+
+message GetRevisionResponse {
   RevisionSummary revision = 1;
 }
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/RevisionTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/RevisionTest.kt
@@ -117,6 +117,64 @@ class RevisionTest {
     }
 
     @Test
+    fun can_retrieve_a_specific_revision_by_id() {
+        runBlocking {
+            val client = createClient()
+            val key = UUID.randomUUID().toString().toDocKey()
+            val doc = Document(key)
+
+            client.activateAsync().await()
+            client.attachDocument(doc, syncMode = Manual).await()
+
+            // given — initial state synced and snapshotted
+            doc.updateAsync { root, _ ->
+                root["k1"] = "v1"
+                root["k2"] = "v2"
+            }.await()
+            client.syncAsync().await()
+            val rev1 = client.createRevision(doc, "v1.0", "First revision").await()
+            assertNotNull(rev1)
+
+            // given — further changes and a second revision
+            doc.updateAsync { root, _ ->
+                root["k2"] = "modified"
+                root["k3"] = "v3"
+            }.await()
+            client.syncAsync().await()
+            val rev2 = client.createRevision(doc, "v2.0", "Second revision").await()
+            assertNotNull(rev2)
+
+            // when — retrieve the first revision by id
+            val retRev1 = client.getRevision(doc, rev1.id).await()
+
+            // then — first revision matches the snapshot at that point
+            assertNotNull(retRev1)
+            assertEquals(rev1.id, retRev1.id)
+            assertEquals("v1.0", retRev1.label)
+            assertEquals("First revision", retRev1.description)
+            assertEquals("""{"k1":"v1","k2":"v2"}""", retRev1.snapshot)
+
+            // when — retrieve the second revision by id
+            val retRev2 = client.getRevision(doc, rev2.id).await()
+
+            // then — second revision matches the later snapshot
+            assertNotNull(retRev2)
+            assertEquals(rev2.id, retRev2.id)
+            assertEquals("v2.0", retRev2.label)
+            assertEquals("Second revision", retRev2.description)
+            assertEquals("""{"k1":"v1","k2":"modified","k3":"v3"}""", retRev2.snapshot)
+
+            // then — the two snapshots differ
+            assertTrue(retRev1.snapshot != retRev2.snapshot)
+
+            client.detachDocument(doc).await()
+            client.deactivateAsync().await()
+            doc.close()
+            client.close()
+        }
+    }
+
+    @Test
     fun can_restore_document_to_a_revision() {
         runBlocking {
             val client = createClient()

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -30,6 +30,7 @@ import dev.yorkie.api.v1.deactivateClientRequest
 import dev.yorkie.api.v1.detachChannelRequest
 import dev.yorkie.api.v1.detachDocumentRequest
 import dev.yorkie.api.v1.documentDescriptor
+import dev.yorkie.api.v1.getRevisionRequest
 import dev.yorkie.api.v1.listRevisionsRequest
 import dev.yorkie.api.v1.pushPullChangesRequest
 import dev.yorkie.api.v1.refreshChannelRequest
@@ -1309,6 +1310,49 @@ public class Client(
                     " count:${response.revisionsCount}",
             )
             response.revisionsList.map { it.toRevisionSummary() }
+        }
+    }
+
+    /**
+     * Retrieves the revision identified by [revisionId] for the given [document],
+     * including its full snapshot. The document must be attached to this client.
+     */
+    public fun getRevision(document: Document, revisionId: String): Deferred<RevisionSummary> {
+        return scope.async {
+            checkYorkieError(
+                isActive,
+                YorkieException(ErrClientNotActivated, "client is not active"),
+            )
+
+            val documentKey = document.getKey()
+            val attachment = attachments[documentKey]
+                ?: throw YorkieException(
+                    ErrDocumentNotAttached,
+                    "document($documentKey) is not attached",
+                )
+
+            val request = getRevisionRequest {
+                clientId = requireClientId()
+                documentId = attachment.resourceId
+                this.revisionId = revisionId
+            }
+            val response = service.getRevision(
+                request,
+                documentKey.attachmentBasedRequestHeader,
+            ).getOrThrow()
+
+            if (!response.hasRevision()) {
+                throw YorkieException(
+                    YorkieException.Code.ErrInvalidArgument,
+                    "revision is not returned",
+                )
+            }
+
+            logDebug(
+                "GR",
+                "c:\"${options.key}\" gets revision d:\"$documentKey\" r:\"$revisionId\"",
+            )
+            response.revision.toRevisionSummary()
         }
     }
 

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -501,6 +501,40 @@ class ClientTest {
     }
 
     @Test
+    fun `getRevision fails when client is not active`() = runTest {
+        val document = Document(NORMAL_DOCUMENT_KEY)
+
+        val exception = assertFailsWith<YorkieException> {
+            target.getRevision(document, "revision-id").await()
+        }
+        assertEquals(YorkieException.Code.ErrClientNotActivated, exception.code)
+    }
+
+    @Test
+    fun `getRevision fails when document is not attached`() = runTest {
+        target.activateAsync().await()
+        val document = Document(NORMAL_DOCUMENT_KEY)
+
+        val exception = assertFailsWith<YorkieException> {
+            target.getRevision(document, "revision-id").await()
+        }
+        assertEquals(ErrDocumentNotAttached, exception.code)
+    }
+
+    @Test
+    fun `getRevision returns revision summary matching requested id`() = runTest {
+        target.activateAsync().await()
+        val document = Document(NORMAL_DOCUMENT_KEY)
+        target.attachDocument(document, syncMode = Manual).await()
+
+        val revision = target.getRevision(document, "test-revision-id").await()
+
+        assertEquals("test-revision-id", revision.id)
+        assertEquals("test-label", revision.label)
+        assertEquals("test-description", revision.description)
+    }
+
+    @Test
     fun `restoreRevision fails when client is not active`() = runTest {
         val document = Document(NORMAL_DOCUMENT_KEY)
 

--- a/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
@@ -27,6 +27,8 @@ import dev.yorkie.api.v1.DetachChannelResponse
 import dev.yorkie.api.v1.DetachDocumentRequest
 import dev.yorkie.api.v1.DetachDocumentResponse
 import dev.yorkie.api.v1.DocEventType
+import dev.yorkie.api.v1.GetRevisionRequest
+import dev.yorkie.api.v1.GetRevisionResponse
 import dev.yorkie.api.v1.ListRevisionsRequest
 import dev.yorkie.api.v1.ListRevisionsResponse
 import dev.yorkie.api.v1.OperationKt.remove
@@ -60,6 +62,7 @@ import dev.yorkie.api.v1.detachDocumentResponse
 import dev.yorkie.api.v1.docEvent
 import dev.yorkie.api.v1.docWatchEvent
 import dev.yorkie.api.v1.documentInit
+import dev.yorkie.api.v1.getRevisionResponse
 import dev.yorkie.api.v1.jSONElementSimple
 import dev.yorkie.api.v1.listRevisionsResponse
 import dev.yorkie.api.v1.operation
@@ -479,6 +482,24 @@ class MockYorkieService(
                     id = "test-revision-id"
                     label = request.label
                     description = request.description
+                    snapshot = "{}"
+                }
+            },
+            emptyMap(),
+            emptyMap(),
+        )
+    }
+
+    override suspend fun getRevision(
+        request: GetRevisionRequest,
+        headers: Headers,
+    ): ResponseMessage<GetRevisionResponse> {
+        return ResponseMessage.Success(
+            getRevisionResponse {
+                revision = revisionSummary {
+                    id = request.revisionId
+                    label = "test-label"
+                    description = "test-description"
                     snapshot = "{}"
                 }
             },


### PR DESCRIPTION
> **RTCOLLABPLATFORM-654**: [Add GetRevision for retrieving specific revisions](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-654)
> **JS reference:** [yorkie-js-sdk#1133](https://github.com/yorkie-team/yorkie-js-sdk/pull/1133)

## Summary
- Add `Client.getRevision(document, revisionId)` to retrieve a specific revision (including its full snapshot) by ID.
- Mirrors yorkie-js-sdk PR #1133 and follows the `createRevision` / `listRevisions` / `restoreRevision` pattern established in PR #320.

## Changes
- `yorkie/proto/yorkie/v1/yorkie.proto` — add `GetRevision` RPC plus `GetRevisionRequest` (`client_id`, `document_id`, `revision_id`) and `GetRevisionResponse` (`RevisionSummary`).
- `yorkie/src/main/kotlin/dev/yorkie/core/Client.kt` — add `getRevision(document, revisionId)` returning `Deferred<RevisionSummary>`, placed adjacent to `restoreRevision`. Validates the client is activated and the document is attached, then delegates to the service stub and reuses `toRevisionSummary()`.
- `yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt` — implement the new `getRevision` stub returning a `RevisionSummary` echoing the requested id.
- `yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt` — add unit tests covering not-activated, not-attached, and the happy path.
- `yorkie/src/androidTest/kotlin/dev/yorkie/core/RevisionTest.kt` — add `can_retrieve_a_specific_revision_by_id` instrumented test verifying that the returned snapshots reflect each revision's state.

## Test plan
- [x] Unit tests pass: `./gradlew yorkie:testDebugUnitTest` (`ClientTest` 25/25 pass, includes 3 new `getRevision` cases)
- [x] Lint passes: `./gradlew lintKotlin`
- [x] Instrumented test passes: `RevisionTest#can_retrieve_a_specific_revision_by_id` against `yorkieteam/yorkie:0.6.48`

> Items run automatically by CI (lint, unit tests, coverage) are excluded.