### PR TITLE
Add tree-level schema validation

### DIFF
--- a/yorkie/proto/yorkie/v1/resources.proto
+++ b/yorkie/proto/yorkie/v1/resources.proto
@@ -467,9 +467,17 @@ message Schema {
   google.protobuf.Timestamp created_at = 6;
 }
 
+message TreeNodeRule {
+  string node_type = 1;
+  string content = 2;
+  string marks = 3;
+  string group = 4;
+}
+
 message Rule {
   string path = 1;
   string type = 2;
+  repeated TreeNodeRule tree_nodes = 3;
 }
 
 message RevisionSummary {

--- a/yorkie/src/main/kotlin/dev/yorkie/api/RuleConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/RuleConverter.kt
@@ -33,6 +33,18 @@ fun List<PBRule>.fromSchemaRules(): List<Rule> {
                 Rule.YorkieTypeRule(
                     path = it.path,
                     type = it.type,
+                    treeNodes = if (it.treeNodesList.isNotEmpty()) {
+                        it.treeNodesList.map { pbTreeNode ->
+                            Rule.TreeNodeRule(
+                                nodeType = pbTreeNode.nodeType,
+                                content = pbTreeNode.content,
+                                marks = pbTreeNode.marks,
+                                group = pbTreeNode.group,
+                            )
+                        }
+                    } else {
+                        null
+                    },
                 )
             }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/schema/ContentExpression.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/schema/ContentExpression.kt
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.yorkie.document.schema
+
+/**
+ * Represents a parsed ProseMirror-compatible content expression.
+ *
+ * Content expressions define what children a node can contain using the grammar:
+ * ```
+ *   expr       -> sequence ('|' sequence)*     // alternatives
+ *   sequence   -> element+                     // sequence
+ *   element    -> atom quantifier?             // element + quantifier
+ *   atom       -> name | '(' expr ')'          // node type or group
+ *   quantifier -> '+' | '*' | '?'              // 1+, 0+, 0-1
+ * ```
+ */
+internal sealed class ContentExpr {
+    data class Node(val nodeType: String) : ContentExpr()
+
+    data class Sequence(val children: List<ContentExpr>) : ContentExpr()
+
+    data class Alternative(val children: List<ContentExpr>) : ContentExpr()
+
+    data class Repeat(
+        val child: ContentExpr,
+        val min: Int,
+        val max: Int,
+    ) : ContentExpr()
+}
+
+private enum class TokenType {
+    Name,
+    Plus,
+    Star,
+    Question,
+    Pipe,
+    LParen,
+    RParen,
+}
+
+private data class Token(val type: TokenType, val value: String)
+
+/**
+ * Splits a content expression string into tokens.
+ */
+private fun tokenize(expr: String): List<Token> {
+    val tokens = ArrayList<Token>()
+    var i = 0
+    while (i < expr.length) {
+        val ch = expr[i]
+        if (ch.isWhitespace()) {
+            i++
+            continue
+        }
+        when (ch) {
+            '+' -> {
+                tokens.add(Token(TokenType.Plus, "+"))
+                i++
+            }
+            '*' -> {
+                tokens.add(Token(TokenType.Star, "*"))
+                i++
+            }
+            '?' -> {
+                tokens.add(Token(TokenType.Question, "?"))
+                i++
+            }
+            '|' -> {
+                tokens.add(Token(TokenType.Pipe, "|"))
+                i++
+            }
+            '(' -> {
+                tokens.add(Token(TokenType.LParen, "("))
+                i++
+            }
+            ')' -> {
+                tokens.add(Token(TokenType.RParen, ")"))
+                i++
+            }
+            else -> {
+                val sb = StringBuilder()
+                while (i < expr.length && (expr[i].isLetterOrDigit() || expr[i] == '_')) {
+                    sb.append(expr[i])
+                    i++
+                }
+                if (sb.isEmpty()) {
+                    throw IllegalArgumentException(
+                        "Unexpected character '$ch' at position $i in content expression",
+                    )
+                }
+                tokens.add(Token(TokenType.Name, sb.toString()))
+            }
+        }
+    }
+    return tokens
+}
+
+private data class ParseResult(val expr: ContentExpr, val pos: Int)
+
+/**
+ * Parses alternatives separated by `'|'`.
+ */
+private fun parseAlternatives(tokens: List<Token>, start: Int): ParseResult {
+    val seqs = ArrayList<ContentExpr>()
+    var result = parseSequence(tokens, start)
+    seqs.add(result.expr)
+    while (result.pos < tokens.size && tokens[result.pos].type == TokenType.Pipe) {
+        result = parseSequence(tokens, result.pos + 1)
+        seqs.add(result.expr)
+    }
+    return if (seqs.size == 1) {
+        ParseResult(seqs[0], result.pos)
+    } else {
+        ParseResult(ContentExpr.Alternative(seqs), result.pos)
+    }
+}
+
+/**
+ * Parses a sequence of elements.
+ */
+private fun parseSequence(tokens: List<Token>, start: Int): ParseResult {
+    val elements = ArrayList<ContentExpr>()
+    var pos = start
+    while (
+        pos < tokens.size &&
+        tokens[pos].type != TokenType.Pipe &&
+        tokens[pos].type != TokenType.RParen
+    ) {
+        val result = parseElement(tokens, pos)
+        elements.add(result.expr)
+        pos = result.pos
+    }
+    return if (elements.size == 1) {
+        ParseResult(elements[0], pos)
+    } else {
+        ParseResult(ContentExpr.Sequence(elements), pos)
+    }
+}
+
+/**
+ * Parses an atom optionally followed by a quantifier.
+ */
+private fun parseElement(tokens: List<Token>, start: Int): ParseResult {
+    val atom = parseAtom(tokens, start)
+    var expr = atom.expr
+    var pos = atom.pos
+    if (pos < tokens.size) {
+        when (tokens[pos].type) {
+            TokenType.Plus -> {
+                expr = ContentExpr.Repeat(expr, min = 1, max = Int.MAX_VALUE)
+                pos++
+            }
+            TokenType.Star -> {
+                expr = ContentExpr.Repeat(expr, min = 0, max = Int.MAX_VALUE)
+                pos++
+            }
+            TokenType.Question -> {
+                expr = ContentExpr.Repeat(expr, min = 0, max = 1)
+                pos++
+            }
+            else -> Unit
+        }
+    }
+    return ParseResult(expr, pos)
+}
+
+/**
+ * Parses a name or a parenthesized sub-expression.
+ */
+private fun parseAtom(tokens: List<Token>, start: Int): ParseResult {
+    if (start >= tokens.size) {
+        throw IllegalArgumentException("Unexpected end of content expression")
+    }
+    val token = tokens[start]
+    return when (token.type) {
+        TokenType.LParen -> {
+            val inner = parseAlternatives(tokens, start + 1)
+            if (inner.pos >= tokens.size || tokens[inner.pos].type != TokenType.RParen) {
+                throw IllegalArgumentException(
+                    "Unmatched parenthesis in content expression",
+                )
+            }
+            ParseResult(inner.expr, inner.pos + 1)
+        }
+        TokenType.Name -> {
+            ParseResult(ContentExpr.Node(token.value), start + 1)
+        }
+        else -> {
+            throw IllegalArgumentException(
+                "Expected node type name but got '${token.value}' in content expression",
+            )
+        }
+    }
+}
+
+/**
+ * Parses a ProseMirror-compatible content expression string into a
+ * [ContentExpr] AST.
+ *
+ * Examples:
+ * - `"paragraph+"` matches one or more paragraphs.
+ * - `"text*"` matches zero or more text nodes.
+ * - `"heading paragraph+"` matches one heading then one or more paragraphs.
+ * - `"paragraph | heading"` matches one paragraph or one heading.
+ * - `"(paragraph | heading)+"` matches one or more of paragraph or heading.
+ * - `"block+"` matches one or more nodes from the `block` group.
+ */
+internal fun parseContentExpression(expr: String): ContentExpr {
+    val trimmed = expr.trim()
+    if (trimmed.isEmpty()) {
+        return ContentExpr.Sequence(emptyList())
+    }
+    val tokens = tokenize(trimmed)
+    val result = parseAlternatives(tokens, 0)
+    if (result.pos < tokens.size) {
+        throw IllegalArgumentException(
+            "Unexpected token '${tokens[result.pos].value}' at position ${result.pos} " +
+                "in content expression",
+        )
+    }
+    return result.expr
+}
+
+/**
+ * Result of matching a parsed content expression against child node types.
+ */
+internal data class ContentMatchResult(
+    val valid: Boolean,
+    val error: String? = null,
+)
+
+/**
+ * Attempts to match child types starting at any of the given positions
+ * against the expression. Returns the set of all reachable positions
+ * after matching, enabling backtracking for ambiguous expressions like `a* a`.
+ */
+private fun matchExpr(
+    expr: ContentExpr,
+    types: List<String>,
+    positions: Set<Int>,
+    resolver: (String) -> List<String>,
+): Set<Int> {
+    return when (expr) {
+        is ContentExpr.Node -> {
+            val allowed = resolver(expr.nodeType)
+            val result = HashSet<Int>()
+            for (pos in positions) {
+                if (pos < types.size && types[pos] in allowed) {
+                    result.add(pos + 1)
+                }
+            }
+            result
+        }
+        is ContentExpr.Sequence -> {
+            var current = positions
+            for (child in expr.children) {
+                current = matchExpr(child, types, current, resolver)
+                if (current.isEmpty()) {
+                    return current
+                }
+            }
+            current
+        }
+        is ContentExpr.Alternative -> {
+            val result = HashSet<Int>()
+            for (child in expr.children) {
+                result.addAll(matchExpr(child, types, positions, resolver))
+            }
+            result
+        }
+        is ContentExpr.Repeat -> {
+            val min = expr.min
+            val max = expr.max
+            var current = positions
+            val reachable = HashSet<Int>()
+            if (min == 0) {
+                reachable.addAll(current)
+            }
+            var count = 1
+            while (count <= max) {
+                val next = matchExpr(expr.child, types, current, resolver)
+                val newPositions = HashSet<Int>()
+                for (p in next) {
+                    if (!reachable.contains(p) || count < min) {
+                        newPositions.add(p)
+                    }
+                }
+                if (newPositions.isEmpty()) break
+                current = newPositions
+                if (count >= min) {
+                    reachable.addAll(current)
+                }
+                count++
+            }
+            reachable
+        }
+    }
+}
+
+/**
+ * Matches a list of child type names against a parsed content expression.
+ * Uses [groupResolver] to resolve group names (like `"block"`) to a list of
+ * concrete node type names.
+ *
+ * Returns a result with `valid = true` if the children match, or
+ * `valid = false` with an error message otherwise.
+ */
+internal fun matchContentExpression(
+    expr: ContentExpr,
+    childTypes: List<String>,
+    groupResolver: (String) -> List<String>,
+): ContentMatchResult {
+    val positions = matchExpr(expr, childTypes, setOf(0), groupResolver)
+    if (positions.contains(childTypes.size)) {
+        return ContentMatchResult(valid = true)
+    }
+    if (positions.isEmpty()) {
+        return ContentMatchResult(
+            valid = false,
+            error = "Children do not match content expression",
+        )
+    }
+    return ContentMatchResult(
+        valid = false,
+        error = "Unexpected child at position ${positions.max()}",
+    )
+}

--- a/yorkie/src/main/kotlin/dev/yorkie/document/schema/Rule.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/schema/Rule.kt
@@ -49,6 +49,7 @@ sealed interface Rule {
     data class YorkieTypeRule(
         override val path: String,
         override val type: String,
+        val treeNodes: List<TreeNodeRule>? = null,
     ) : Rule {
         enum class Type(val value: String) {
             TEXT("yorkie.Text"),
@@ -58,6 +59,18 @@ sealed interface Rule {
             ARRAY("yorkie.Array"),
         }
     }
+
+    /**
+     * Represents a single tree node rule used to validate the structure of
+     * a [dev.yorkie.document.crdt.CrdtTree] against the schema. Mirrors the
+     * `TreeNodeRule` type from the yorkie-js-sdk schema package.
+     */
+    data class TreeNodeRule(
+        val nodeType: String,
+        val content: String? = null,
+        val marks: String? = null,
+        val group: String? = null,
+    )
 
     data class EnumRule(
         override val path: String,

--- a/yorkie/src/main/kotlin/dev/yorkie/document/schema/RulesetValidator.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/schema/RulesetValidator.kt
@@ -162,6 +162,21 @@ internal fun validateValue(value: Any?, rule: Rule): ValidationResult {
                     ),
                 )
             }
+            val treeNodes = (rule as? Rule.YorkieTypeRule)?.treeNodes
+            if (!treeNodes.isNullOrEmpty()) {
+                val treeResult = validateTreeAgainstSchema(value, treeNodes)
+                if (!treeResult.valid) {
+                    return ValidationResult(
+                        valid = false,
+                        errors = listOf(
+                            ValidationError(
+                                path = rule.path,
+                                message = treeResult.error.orEmpty(),
+                            ),
+                        ),
+                    )
+                }
+            }
         }
         Rule.YorkieTypeRule.Type.COUNTER.value -> {
             if (value !is CrdtCounter) {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/schema/TreeValidator.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/schema/TreeValidator.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.yorkie.document.schema
+
+import dev.yorkie.document.crdt.CrdtTree
+import dev.yorkie.document.crdt.CrdtTreeNode
+
+/**
+ * Result of validating a [CrdtTree] against a list of [Rule.TreeNodeRule].
+ */
+data class TreeValidationResult(
+    val valid: Boolean,
+    val error: String? = null,
+)
+
+private val WhitespaceRegex = Regex("\\s+")
+
+/**
+ * Builds a group resolver function from the given tree node rules.
+ * The resolver maps a name to the list of node types that belong to that
+ * group. If the name is not a group, returns the name itself, treating it
+ * as a concrete node type.
+ */
+internal fun buildGroupResolver(treeNodes: List<Rule.TreeNodeRule>): (String) -> List<String> {
+    val groupMap = HashMap<String, MutableList<String>>()
+    for (node in treeNodes) {
+        val group = node.group ?: continue
+        if (group.isEmpty()) continue
+        for (g in group.split(WhitespaceRegex).filter { it.isNotEmpty() }) {
+            groupMap.getOrPut(g) { ArrayList() }.add(node.nodeType)
+        }
+    }
+    return { name ->
+        groupMap[name] ?: listOf(name)
+    }
+}
+
+/**
+ * Validates a [CrdtTree]'s structure against the given tree node rules.
+ *
+ * The check covers:
+ * 1. Each node's type exists in the rules.
+ * 2. Children match the content expression for non-text nodes.
+ * 3. Text node marks are allowed by the parent's marks rule.
+ */
+internal fun validateTreeAgainstSchema(
+    tree: CrdtTree,
+    treeNodes: List<Rule.TreeNodeRule>,
+): TreeValidationResult {
+    val ruleMap = HashMap<String, Rule.TreeNodeRule>()
+    for (node in treeNodes) {
+        ruleMap[node.nodeType] = node
+    }
+
+    val resolver = buildGroupResolver(treeNodes)
+    return validateNode(tree.root, ruleMap, resolver)
+}
+
+/**
+ * Recursively validates a [CrdtTreeNode] against the rules.
+ */
+private fun validateNode(
+    node: CrdtTreeNode,
+    ruleMap: Map<String, Rule.TreeNodeRule>,
+    resolver: (String) -> List<String>,
+): TreeValidationResult {
+    val rule = ruleMap[node.type] ?: return TreeValidationResult(
+        valid = false,
+        error = "Unknown node type: \"${node.type}\"",
+    )
+
+    // Skip further validation for text nodes — they are leaf nodes and are
+    // validated by their parent's marks rule.
+    if (node.isText) {
+        return TreeValidationResult(valid = true)
+    }
+
+    val children = node.children
+
+    for (child in children) {
+        if (!child.isText && !ruleMap.containsKey(child.type)) {
+            return TreeValidationResult(
+                valid = false,
+                error = "Unknown node type: \"${child.type}\"",
+            )
+        }
+    }
+
+    if (rule.content != null) {
+        val childTypes = children.map { it.type }
+        val expr = parseContentExpression(rule.content)
+        val result = matchContentExpression(expr, childTypes, resolver)
+        if (!result.valid) {
+            return TreeValidationResult(
+                valid = false,
+                error = "Node \"${node.type}\": ${result.error}",
+            )
+        }
+    }
+
+    if (!rule.marks.isNullOrEmpty()) {
+        val allowedMarks = rule.marks.split(WhitespaceRegex).filter { it.isNotEmpty() }
+        val markResult = validateChildMarks(node, children, allowedMarks)
+        if (!markResult.valid) {
+            return markResult
+        }
+    }
+
+    for (child in children) {
+        if (!child.isText) {
+            val result = validateNode(child, ruleMap, resolver)
+            if (!result.valid) {
+                return result
+            }
+        }
+    }
+
+    return TreeValidationResult(valid = true)
+}
+
+/**
+ * Checks that text children of [parent] only have marks that are listed in
+ * the allowed marks.
+ */
+private fun validateChildMarks(
+    parent: CrdtTreeNode,
+    children: List<CrdtTreeNode>,
+    allowedMarks: List<String>,
+): TreeValidationResult {
+    for (child in children) {
+        if (!child.isText) continue
+        for (rhtNode in child.rhtNodes) {
+            if (rhtNode.isRemoved) continue
+            val markName = rhtNode.key
+            if (markName !in allowedMarks) {
+                return TreeValidationResult(
+                    valid = false,
+                    error = "Node \"${parent.type}\": text child has disallowed mark " +
+                        "\"$markName\". Allowed marks: ${allowedMarks.joinToString(", ")}",
+                )
+            }
+        }
+    }
+    return TreeValidationResult(valid = true)
+}

--- a/yorkie/src/test/kotlin/dev/yorkie/document/schema/ContentExpressionTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/schema/ContentExpressionTest.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.yorkie.document.schema
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ContentExpressionTest {
+
+    private val identityResolver: (String) -> List<String> = { listOf(it) }
+
+    @Test
+    fun `parses a single node type`() {
+        // given
+        val expr = parseContentExpression("paragraph")
+
+        // then
+        assertEquals(ContentExpr.Node("paragraph"), expr)
+    }
+
+    @Test
+    fun `parses one-or-more quantifier`() {
+        // given
+        val expr = parseContentExpression("paragraph+")
+
+        // then
+        assertEquals(
+            ContentExpr.Repeat(
+                child = ContentExpr.Node("paragraph"),
+                min = 1,
+                max = Int.MAX_VALUE,
+            ),
+            expr,
+        )
+    }
+
+    @Test
+    fun `parses zero-or-more quantifier`() {
+        // given
+        val expr = parseContentExpression("text*")
+
+        // then
+        assertEquals(
+            ContentExpr.Repeat(
+                child = ContentExpr.Node("text"),
+                min = 0,
+                max = Int.MAX_VALUE,
+            ),
+            expr,
+        )
+    }
+
+    @Test
+    fun `parses alternatives`() {
+        // given
+        val expr = parseContentExpression("paragraph | heading")
+
+        // then
+        assertTrue(expr is ContentExpr.Alternative)
+        assertEquals(2, (expr as ContentExpr.Alternative).children.size)
+    }
+
+    @Test
+    fun `parses parenthesized alternatives with quantifier`() {
+        // given
+        val expr = parseContentExpression("(paragraph | heading)+")
+
+        // then
+        assertTrue(expr is ContentExpr.Repeat)
+        assertEquals(1, (expr as ContentExpr.Repeat).min)
+    }
+
+    @Test
+    fun `matches single required node`() {
+        // given
+        val expr = parseContentExpression("paragraph")
+
+        // when
+        val result = matchContentExpression(expr, listOf("paragraph"), identityResolver)
+
+        // then
+        assertTrue(result.valid)
+    }
+
+    @Test
+    fun `rejects when required node is missing`() {
+        // given
+        val expr = parseContentExpression("paragraph+")
+
+        // when
+        val result = matchContentExpression(expr, emptyList(), identityResolver)
+
+        // then
+        assertFalse(result.valid)
+        assertNotNull(result.error)
+    }
+
+    @Test
+    fun `matches one or more paragraphs`() {
+        // given
+        val expr = parseContentExpression("paragraph+")
+
+        // when
+        val result = matchContentExpression(
+            expr,
+            listOf("paragraph", "paragraph"),
+            identityResolver,
+        )
+
+        // then
+        assertTrue(result.valid)
+    }
+
+    @Test
+    fun `matches empty children with zero-or-more`() {
+        // given
+        val expr = parseContentExpression("text*")
+
+        // when
+        val result = matchContentExpression(expr, emptyList(), identityResolver)
+
+        // then
+        assertTrue(result.valid)
+    }
+
+    @Test
+    fun `matches alternatives`() {
+        // given
+        val expr = parseContentExpression("(paragraph | heading)+")
+
+        // when
+        val result = matchContentExpression(
+            expr,
+            listOf("paragraph", "heading", "paragraph"),
+            identityResolver,
+        )
+
+        // then
+        assertTrue(result.valid)
+    }
+
+    @Test
+    fun `resolves group names via resolver`() {
+        // given
+        val expr = parseContentExpression("block+")
+        val resolver: (String) -> List<String> = { name ->
+            when (name) {
+                "block" -> listOf("paragraph", "heading")
+                else -> listOf(name)
+            }
+        }
+
+        // when
+        val result = matchContentExpression(
+            expr,
+            listOf("paragraph", "heading"),
+            resolver,
+        )
+
+        // then
+        assertTrue(result.valid)
+    }
+
+    @Test
+    fun `rejects unexpected child after greedy match`() {
+        // given
+        val expr = parseContentExpression("paragraph+")
+
+        // when
+        val result = matchContentExpression(
+            expr,
+            listOf("paragraph", "heading"),
+            identityResolver,
+        )
+
+        // then
+        assertFalse(result.valid)
+    }
+
+    @Test
+    fun `empty expression matches no children`() {
+        // given
+        val expr = parseContentExpression("")
+
+        // when
+        val result = matchContentExpression(expr, emptyList(), identityResolver)
+
+        // then
+        assertTrue(result.valid)
+    }
+}

--- a/yorkie/src/test/kotlin/dev/yorkie/document/schema/RulesetValidatorTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/schema/RulesetValidatorTest.kt
@@ -2,13 +2,18 @@ package dev.yorkie.document.schema
 
 import dev.yorkie.document.Document
 import dev.yorkie.document.json.JsonObject
+import dev.yorkie.document.json.JsonTree
 import dev.yorkie.document.json.TreeBuilder.element
+import dev.yorkie.document.json.TreeBuilder.text
 import dev.yorkie.toDocKey
+import dev.yorkie.util.YorkieException
 import java.util.Date
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -308,5 +313,141 @@ class RulesetValidatorTest {
             ),
             actual = result.errors,
         )
+    }
+
+    @Test
+    fun `should validate yorkie Tree structure against tree node rules`() = runTest {
+        // given
+        val ruleset = listOf(
+            Rule.YorkieTypeRule(
+                path = "\$.content",
+                type = "yorkie.Tree",
+                treeNodes = listOf(
+                    Rule.TreeNodeRule(
+                        nodeType = "doc",
+                        content = "block+",
+                        marks = "",
+                        group = "",
+                    ),
+                    Rule.TreeNodeRule(
+                        nodeType = "paragraph",
+                        content = "text*",
+                        marks = "",
+                        group = "block",
+                    ),
+                    Rule.TreeNodeRule(
+                        nodeType = "text",
+                        content = "",
+                        marks = "",
+                        group = "",
+                    ),
+                ),
+            ),
+        )
+        val document = Document(UUID.randomUUID().toString().toDocKey())
+
+        // when
+        document.updateAsync { root, _ ->
+            root.setNewTree(
+                "content",
+                element("doc") {
+                    element("paragraph") { text { "hello" } }
+                },
+            )
+        }.await()
+
+        // then
+        val validResult = validateYorkieRuleset(document.getRootObject(), ruleset)
+        assertTrue(validResult.valid)
+        assertNull(validResult.errors.firstOrNull())
+
+        // when an unknown node type is added
+        document.updateAsync { root, _ ->
+            root.setNewTree(
+                "content",
+                element("doc") {
+                    element("div") { text { "x" } }
+                },
+            )
+        }.await()
+
+        // then
+        val invalidResult = validateYorkieRuleset(document.getRootObject(), ruleset)
+        assertFalse(invalidResult.valid)
+        assertNotNull(invalidResult.errors.firstOrNull())
+        assertTrue(invalidResult.errors.first().message.contains("Unknown node type"))
+        assertTrue(invalidResult.errors.first().message.contains("div"))
+    }
+
+    @Test
+    fun `tree schema rejects local update via Document updateAsync`() = runTest {
+        // given
+        val document = Document(UUID.randomUUID().toString().toDocKey())
+        document.updateAsync { root, _ ->
+            root.setNewTree(
+                "content",
+                element("doc") {
+                    element("paragraph") { text { "hello" } }
+                },
+            )
+        }.await()
+
+        document.setSchemaRules(
+            listOf(
+                Rule.ObjectRule(
+                    path = "\$",
+                    type = "object",
+                    properties = listOf("content"),
+                    optional = emptyList(),
+                ),
+                Rule.YorkieTypeRule(
+                    path = "\$.content",
+                    type = "yorkie.Tree",
+                    treeNodes = listOf(
+                        Rule.TreeNodeRule(
+                            nodeType = "doc",
+                            content = "paragraph+",
+                            marks = "",
+                            group = "",
+                        ),
+                        Rule.TreeNodeRule(
+                            nodeType = "paragraph",
+                            content = "text*",
+                            marks = "",
+                            group = "",
+                        ),
+                        Rule.TreeNodeRule(
+                            nodeType = "text",
+                            content = "",
+                            marks = "",
+                            group = "",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        // when invalid edit attempted, then exception is thrown
+        var thrown: YorkieException? = null
+        try {
+            document.updateAsync { root, _ ->
+                val tree = root.getAs<JsonTree>("content")
+                tree.edit(
+                    0,
+                    0,
+                    element("div") {
+                        text { "invalid" }
+                    },
+                )
+            }.await()
+        } catch (e: YorkieException) {
+            thrown = e
+        }
+        assertNotNull(thrown)
+        assertEquals(
+            YorkieException.Code.ErrDocumentSchemaValidationFailed,
+            thrown!!.code,
+        )
+        assertTrue(thrown.message.orEmpty().contains("Unknown node type"))
     }
 }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/schema/TreeValidatorTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/schema/TreeValidatorTest.kt
@@ -1,0 +1,394 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.yorkie.document.schema
+
+import dev.yorkie.document.Document
+import dev.yorkie.document.crdt.CrdtTree
+import dev.yorkie.document.json.JsonTree
+import dev.yorkie.document.json.TreeBuilder.element
+import dev.yorkie.document.json.TreeBuilder.text
+import dev.yorkie.toDocKey
+import java.util.UUID
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TreeValidatorTest {
+
+    @Test
+    fun `group resolver maps group name to node types`() {
+        // given
+        val rules = listOf(
+            Rule.TreeNodeRule(
+                nodeType = "paragraph",
+                content = "text*",
+                marks = "",
+                group = "block",
+            ),
+            Rule.TreeNodeRule(
+                nodeType = "heading",
+                content = "text*",
+                marks = "",
+                group = "block",
+            ),
+            Rule.TreeNodeRule(
+                nodeType = "blockquote",
+                content = "block+",
+                marks = "",
+                group = "block",
+            ),
+        )
+
+        // when
+        val resolver = buildGroupResolver(rules)
+
+        // then
+        assertEquals(listOf("paragraph", "heading", "blockquote"), resolver("block"))
+    }
+
+    @Test
+    fun `group resolver returns the name itself when not a group`() {
+        // given
+        val rules = listOf(
+            Rule.TreeNodeRule(
+                nodeType = "paragraph",
+                content = "text*",
+                marks = "",
+                group = "block",
+            ),
+        )
+
+        // when
+        val resolver = buildGroupResolver(rules)
+
+        // then
+        assertEquals(listOf("paragraph"), resolver("paragraph"))
+        assertEquals(listOf("unknown"), resolver("unknown"))
+    }
+
+    @Test
+    fun `group resolver supports multiple groups per node`() {
+        // given
+        val rules = listOf(
+            Rule.TreeNodeRule(
+                nodeType = "paragraph",
+                content = "text*",
+                marks = "",
+                group = "block flow",
+            ),
+        )
+
+        // when
+        val resolver = buildGroupResolver(rules)
+
+        // then
+        assertEquals(listOf("paragraph"), resolver("block"))
+        assertEquals(listOf("paragraph"), resolver("flow"))
+    }
+
+    @Test
+    fun `validates a valid tree (doc gt paragraph gt text)`() = runTest {
+        // given
+        val rules = docParagraphRules()
+        val tree = treeFor(
+            element("doc") {
+                element("paragraph") {
+                    text { "hello" }
+                }
+            },
+        )
+
+        // when
+        val result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        assertTrue(result.valid)
+        assertNull(result.error)
+    }
+
+    @Test
+    fun `rejects unknown node type`() = runTest {
+        // given
+        val rules = docParagraphRules()
+        val tree = treeFor(
+            element("doc") {
+                element("div") {
+                    text { "hello" }
+                }
+            },
+        )
+
+        // when
+        val result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        assertFalse(result.valid)
+        assertNotNull(result.error)
+        val error = result.error.orEmpty()
+        assertTrue(error.contains("Unknown node type"))
+        assertTrue(error.contains("div"))
+    }
+
+    @Test
+    fun `rejects content expression violation when required child missing`() = runTest {
+        // given
+        val rules = docParagraphRules()
+        val tree = treeFor(element("doc"))
+
+        // when
+        val result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        assertFalse(result.valid)
+        assertTrue(result.error.orEmpty().contains("doc"))
+    }
+
+    @Test
+    fun `validates with group resolver`() = runTest {
+        // given
+        val rules = listOf(
+            Rule.TreeNodeRule(
+                nodeType = "doc",
+                content = "block+",
+                marks = "",
+                group = "",
+            ),
+            Rule.TreeNodeRule(
+                nodeType = "paragraph",
+                content = "text*",
+                marks = "",
+                group = "block",
+            ),
+            Rule.TreeNodeRule(
+                nodeType = "heading",
+                content = "text*",
+                marks = "",
+                group = "block",
+            ),
+        )
+        val tree = treeFor(
+            element("doc") {
+                element("paragraph") { text { "hello" } }
+                element("heading") { text { "world" } }
+            },
+        )
+
+        // when
+        val result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        assertTrue(result.valid)
+    }
+
+    @Test
+    fun `rejects when wrong child type for content expression`() = runTest {
+        // given
+        val rules = listOf(
+            Rule.TreeNodeRule(
+                nodeType = "doc",
+                content = "paragraph+",
+                marks = "",
+                group = "",
+            ),
+            Rule.TreeNodeRule(
+                nodeType = "paragraph",
+                content = "text*",
+                marks = "",
+                group = "",
+            ),
+            Rule.TreeNodeRule(
+                nodeType = "heading",
+                content = "text*",
+                marks = "",
+                group = "",
+            ),
+        )
+        val tree = treeFor(
+            element("doc") {
+                element("heading") { text { "hello" } }
+            },
+        )
+
+        // when
+        val result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        assertFalse(result.valid)
+        assertTrue(result.error.orEmpty().contains("doc"))
+    }
+
+    @Test
+    fun `validates deeply nested trees`() = runTest {
+        // given
+        val rules = listOf(
+            Rule.TreeNodeRule(
+                nodeType = "doc",
+                content = "section+",
+                marks = "",
+                group = "",
+            ),
+            Rule.TreeNodeRule(
+                nodeType = "section",
+                content = "paragraph+",
+                marks = "",
+                group = "",
+            ),
+            Rule.TreeNodeRule(
+                nodeType = "paragraph",
+                content = "text*",
+                marks = "",
+                group = "",
+            ),
+        )
+        val tree = treeFor(
+            element("doc") {
+                element("section") {
+                    element("paragraph") { text { "hello" } }
+                }
+            },
+        )
+
+        // when
+        val result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        assertTrue(result.valid)
+    }
+
+    @Test
+    fun `detects errors in nested children`() = runTest {
+        // given
+        val rules = listOf(
+            Rule.TreeNodeRule(
+                nodeType = "doc",
+                content = "section+",
+                marks = "",
+                group = "",
+            ),
+            Rule.TreeNodeRule(
+                nodeType = "section",
+                content = "paragraph+",
+                marks = "",
+                group = "",
+            ),
+            Rule.TreeNodeRule(
+                nodeType = "paragraph",
+                content = "text*",
+                marks = "",
+                group = "",
+            ),
+        )
+        val tree = treeFor(
+            element("doc") {
+                element("section")
+            },
+        )
+
+        // when
+        val result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        assertFalse(result.valid)
+        assertTrue(result.error.orEmpty().contains("section"))
+    }
+
+    @Test
+    fun `handles alternative content expressions`() = runTest {
+        // given
+        val rules = listOf(
+            Rule.TreeNodeRule(
+                nodeType = "doc",
+                content = "(paragraph | heading)+",
+                marks = "",
+                group = "",
+            ),
+            Rule.TreeNodeRule(
+                nodeType = "paragraph",
+                content = "text*",
+                marks = "",
+                group = "",
+            ),
+            Rule.TreeNodeRule(
+                nodeType = "heading",
+                content = "text*",
+                marks = "",
+                group = "",
+            ),
+        )
+        val tree = treeFor(
+            element("doc") {
+                element("paragraph") { text { "hello" } }
+                element("heading") { text { "title" } }
+            },
+        )
+
+        // when
+        val result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        assertTrue(result.valid)
+    }
+
+    @Test
+    fun `skips mark validation when marks rule is empty`() = runTest {
+        // given
+        val rules = docParagraphRules()
+        val tree = treeFor(
+            element("doc") {
+                element("paragraph") { text { "hello" } }
+            },
+        )
+
+        // when
+        val result = validateTreeAgainstSchema(tree, rules)
+
+        // then
+        assertTrue(result.valid)
+    }
+
+    private fun docParagraphRules() = listOf(
+        Rule.TreeNodeRule(
+            nodeType = "doc",
+            content = "paragraph+",
+            marks = "",
+            group = "",
+        ),
+        Rule.TreeNodeRule(
+            nodeType = "paragraph",
+            content = "text*",
+            marks = "",
+            group = "",
+        ),
+    )
+
+    /**
+     * Creates an in-memory [CrdtTree] by setting [rootElement] on a fresh
+     * [Document] and returning the underlying CRDT element.
+     */
+    private suspend fun treeFor(rootElement: JsonTree.ElementNode): CrdtTree {
+        val document = Document(UUID.randomUUID().toString().toDocKey())
+        document.updateAsync { root, _ ->
+            root.setNewTree("t", rootElement)
+        }.await()
+        val crdtObject = document.getRootObject()
+        return crdtObject["t"] as CrdtTree
+    }
+}


### PR DESCRIPTION
> **RTCOLLABPLATFORM-657**: [Add tree-level schema validation](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-657)
> **JS reference:** [yorkie-js-sdk#1181](https://github.com/yorkie-team/yorkie-js-sdk/pull/1181)

## Summary
- Extend schema-rule validation to cover `JsonTree` structure (allowed node types, content expressions, marks).
- Mirrors yorkie-js-sdk PR #1181.

## Changes
- `yorkie/proto/yorkie/v1/resources.proto`: add `TreeNodeRule` message and `tree_nodes` field on `Rule`.
- `Rule.TreeNodeRule` data class and `treeNodes` field on `Rule.YorkieTypeRule`.
- `ContentExpression.kt`: ProseMirror-compatible content-expression parser and matcher (`paragraph+`, `text*`, `(a | b)+`, group resolution).
- `TreeValidator.kt`: walks a `CrdtTree` against the tree node rules, checking unknown node types, content expressions and allowed marks.
- `RulesetValidator.kt`: invokes the tree validator when a `yorkie.Tree` rule carries `treeNodes`. Surfaces violations through the existing `ErrDocumentSchemaValidationFailed` exception (matches the JS error surface).
- `RuleConverter.kt`: wires `tree_nodes` from the protobuf rule to `Rule.YorkieTypeRule`.

## Test plan
- [x] Unit tests pass: `./gradlew yorkie:testDebugUnitTest` (271 tests, 0 failures)
- [x] Lint passes: `./gradlew yorkie:lintKotlin`
- [x] Existing instrumented `DocumentSchemaTest` spot-checked against running server.

## Notes
- An end-to-end instrumented test for tree-node rules was deferred: the bundled Docker server image (yorkie 0.6.35) predates the server-side `tree_nodes` proto field (added in upstream commit 52a45a41, shipping in v0.7.x). The validation hook is fully exercised by unit tests, including a Document-level test (`tree schema rejects local update via Document updateAsync`) that injects rules with `setSchemaRules` and triggers the exception via the real edit path.

> Items run automatically by CI (lint, unit tests, coverage) are excluded.