### PR TITLE
Implement YSON module (parser + types)

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/document/yson/YsonParser.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/yson/YsonParser.kt
@@ -1,0 +1,480 @@
+package dev.yorkie.document.yson
+
+import dev.yorkie.util.YorkieException
+
+/**
+ * [parse] parses a YSON formatted string into a typed [YsonValue].
+ *
+ * YSON extends JSON with the following type constructors:
+ * - `Text([...])` for the Text CRDT.
+ * - `Tree({...})` for the Tree CRDT.
+ * - `Int(42)` and `Long(64)` for typed integers.
+ * - `Date("2025-01-02T15:04:05.058Z")` for ISO 8601 timestamps.
+ * - `BinData("...")` for Base64-encoded binary data.
+ * - `Counter(Int(10))` or `Counter(Long(100))` for Counter CRDTs.
+ *
+ * @param yson YSON formatted string.
+ * @throws YorkieException with [YorkieException.Code.ErrInvalidArgument] when parsing fails.
+ */
+public fun parse(yson: String): YsonValue {
+    val parser = YsonParser(yson)
+    return try {
+        val value = parser.parseValue()
+        parser.skipWhitespace()
+        if (!parser.atEnd()) {
+            throw parser.error("Unexpected trailing characters")
+        }
+        value
+    } catch (e: YorkieException) {
+        throw e
+    } catch (e: Exception) {
+        throw YorkieException(
+            YorkieException.Code.ErrInvalidArgument,
+            "Failed to parse YSON: ${e.message}",
+        )
+    }
+}
+
+/**
+ * [textToString] returns the concatenated character values of a [YsonValue.YsonText].
+ */
+public fun textToString(text: YsonValue.YsonText): String =
+    text.nodes.joinToString(separator = "") { it.value }
+
+/**
+ * [treeToXML] returns an XML string representation of a [YsonValue.YsonTree].
+ */
+public fun treeToXML(tree: YsonValue.YsonTree): String = treeNodeToXml(tree.root)
+
+private fun treeNodeToXml(node: YsonTreeNode): String {
+    val attrs = node.attrs
+        ?.entries
+        ?.joinToString(separator = "") { (key, value) -> " $key=\"${escapeXml(value)}\"" }
+        ?: ""
+
+    if (node.type == "text" && node.value != null) {
+        return "<${node.type}$attrs>${escapeXml(node.value)}</${node.type}>"
+    }
+
+    val children = node.children
+    if (children.isNullOrEmpty()) {
+        return "<${node.type}$attrs />"
+    }
+
+    val childrenXml = children.joinToString(separator = "") { treeNodeToXml(it) }
+    return "<${node.type}$attrs>$childrenXml</${node.type}>"
+}
+
+private fun escapeXml(input: String): String = buildString(input.length) {
+    for (ch in input) {
+        when (ch) {
+            '&' -> append("&amp;")
+            '<' -> append("&lt;")
+            '>' -> append("&gt;")
+            '"' -> append("&quot;")
+            '\'' -> append("&apos;")
+            else -> append(ch)
+        }
+    }
+}
+
+/**
+ * [YsonParser] is a hand-rolled recursive-descent parser for YSON.
+ *
+ * The parser understands all JSON productions plus YSON type constructors
+ * (`Text`, `Tree`, `Int`, `Long`, `Date`, `BinData`, `Counter`). It produces a
+ * typed [YsonValue] without relying on any third-party JSON library.
+ */
+internal class YsonParser(private val input: String) {
+    private var pos: Int = 0
+
+    fun parseValue(): YsonValue {
+        skipWhitespace()
+        if (atEnd()) {
+            throw error("Unexpected end of input")
+        }
+        return when (val ch = input[pos]) {
+            '{' -> parseObject()
+            '[' -> parseArray()
+            '"' -> YsonValue.YsonString(parseString())
+            't', 'f' -> parseBoolean()
+            'n' -> parseNull()
+            'T' -> when {
+                matches("Text") -> parseTextConstructor()
+                matches("Tree") -> parseTreeConstructor()
+                else -> throw error("Unknown keyword starting with 'T'")
+            }
+            'I' -> parseIntConstructor()
+            'L' -> parseLongConstructor()
+            'D' -> parseDateConstructor()
+            'B' -> parseBinDataConstructor()
+            'C' -> parseCounterConstructor()
+            '-', in '0'..'9' -> parseNumber()
+            else -> throw error("Unexpected character '$ch'")
+        }
+    }
+
+    private fun parseObject(): YsonValue.YsonObject {
+        expect('{')
+        skipWhitespace()
+        val entries = linkedMapOf<String, YsonValue>()
+        if (peek() == '}') {
+            pos++
+            return YsonValue.YsonObject(entries)
+        }
+        while (true) {
+            skipWhitespace()
+            if (peek() != '"') {
+                throw error("Expected string key in object")
+            }
+            val key = parseString()
+            skipWhitespace()
+            expect(':')
+            val value = parseValue()
+            entries[key] = value
+            skipWhitespace()
+            when (val ch = peekOrNull()) {
+                ',' -> {
+                    pos++
+                    skipWhitespace()
+                    if (peek() == '}') {
+                        throw error("Trailing comma in object")
+                    }
+                }
+                '}' -> {
+                    pos++
+                    return YsonValue.YsonObject(entries)
+                }
+                null -> throw error("Unterminated object")
+                else -> throw error("Expected ',' or '}', got '$ch'")
+            }
+        }
+    }
+
+    private fun parseArray(): YsonValue.YsonArray {
+        expect('[')
+        skipWhitespace()
+        val elements = mutableListOf<YsonValue>()
+        if (peek() == ']') {
+            pos++
+            return YsonValue.YsonArray(elements)
+        }
+        while (true) {
+            val value = parseValue()
+            elements.add(value)
+            skipWhitespace()
+            when (val ch = peekOrNull()) {
+                ',' -> {
+                    pos++
+                    skipWhitespace()
+                    if (peek() == ']') {
+                        throw error("Trailing comma in array")
+                    }
+                }
+                ']' -> {
+                    pos++
+                    return YsonValue.YsonArray(elements)
+                }
+                null -> throw error("Unterminated array")
+                else -> throw error("Expected ',' or ']', got '$ch'")
+            }
+        }
+    }
+
+    private fun parseString(): String {
+        expect('"')
+        val builder = StringBuilder()
+        while (pos < input.length) {
+            when (val ch = input[pos]) {
+                '"' -> {
+                    pos++
+                    return builder.toString()
+                }
+                '\\' -> {
+                    pos++
+                    if (pos >= input.length) {
+                        throw error("Unterminated escape sequence")
+                    }
+                    when (val esc = input[pos]) {
+                        '"' -> builder.append('"')
+                        '\\' -> builder.append('\\')
+                        '/' -> builder.append('/')
+                        'b' -> builder.append('\b')
+                        'f' -> builder.append('')
+                        'n' -> builder.append('\n')
+                        'r' -> builder.append('\r')
+                        't' -> builder.append('\t')
+                        'u' -> {
+                            if (pos + 4 >= input.length) {
+                                throw error("Truncated unicode escape")
+                            }
+                            val hex = input.substring(pos + 1, pos + 5)
+                            val codePoint = hex.toIntOrNull(16)
+                                ?: throw error("Invalid unicode escape \\u$hex")
+                            builder.append(codePoint.toChar())
+                            pos += 4
+                        }
+                        else -> throw error("Invalid escape sequence \\$esc")
+                    }
+                    pos++
+                }
+                '\n', '\r' -> throw error("Unterminated string literal")
+                else -> {
+                    builder.append(ch)
+                    pos++
+                }
+            }
+        }
+        throw error("Unterminated string literal")
+    }
+
+    private fun parseBoolean(): YsonValue.YsonBoolean {
+        if (matches("true")) {
+            pos += 4
+            return YsonValue.YsonBoolean(true)
+        }
+        if (matches("false")) {
+            pos += 5
+            return YsonValue.YsonBoolean(false)
+        }
+        throw error("Invalid boolean literal")
+    }
+
+    private fun parseNull(): YsonValue {
+        if (matches("null")) {
+            pos += 4
+            return YsonValue.YsonNull
+        }
+        throw error("Invalid null literal")
+    }
+
+    private fun parseNumber(): YsonValue.YsonNumber {
+        val start = pos
+        if (peek() == '-') pos++
+        while (pos < input.length && input[pos].isDigit()) pos++
+        if (pos < input.length && input[pos] == '.') {
+            pos++
+            while (pos < input.length && input[pos].isDigit()) pos++
+        }
+        if (pos < input.length && (input[pos] == 'e' || input[pos] == 'E')) {
+            pos++
+            if (pos < input.length && (input[pos] == '+' || input[pos] == '-')) pos++
+            while (pos < input.length && input[pos].isDigit()) pos++
+        }
+        val literal = input.substring(start, pos)
+        val parsed = literal.toDoubleOrNull()
+            ?: throw error("Invalid number literal '$literal'")
+        return YsonValue.YsonNumber(parsed)
+    }
+
+    private fun parseIntConstructor(): YsonValue.YsonInt {
+        expectKeyword("Int")
+        expect('(')
+        val value = parseSignedInteger()
+        expect(')')
+        val parsed = value.toIntOrNull()
+            ?: throw error("Int value out of range: $value")
+        return YsonValue.YsonInt(parsed)
+    }
+
+    private fun parseLongConstructor(): YsonValue.YsonLong {
+        expectKeyword("Long")
+        expect('(')
+        val value = parseSignedInteger()
+        expect(')')
+        val parsed = value.toLongOrNull()
+            ?: throw error("Long value out of range: $value")
+        return YsonValue.YsonLong(parsed)
+    }
+
+    private fun parseDateConstructor(): YsonValue.YsonDate {
+        expectKeyword("Date")
+        expect('(')
+        skipWhitespace()
+        if (peek() != '"') {
+            throw error("Date expects a string literal")
+        }
+        val value = parseString()
+        skipWhitespace()
+        expect(')')
+        return YsonValue.YsonDate(value)
+    }
+
+    private fun parseBinDataConstructor(): YsonValue.YsonBinData {
+        expectKeyword("BinData")
+        expect('(')
+        skipWhitespace()
+        if (peek() != '"') {
+            throw error("BinData expects a string literal")
+        }
+        val value = parseString()
+        skipWhitespace()
+        expect(')')
+        return YsonValue.YsonBinData(value)
+    }
+
+    private fun parseCounterConstructor(): YsonValue.YsonCounter {
+        expectKeyword("Counter")
+        expect('(')
+        skipWhitespace()
+        val inner = parseValue()
+        if (inner !is YsonValue.YsonInt && inner !is YsonValue.YsonLong) {
+            throw YorkieException(
+                YorkieException.Code.ErrInvalidArgument,
+                "Counter must contain Int or Long",
+            )
+        }
+        skipWhitespace()
+        expect(')')
+        return YsonValue.YsonCounter(inner)
+    }
+
+    private fun parseTextConstructor(): YsonValue.YsonText {
+        expectKeyword("Text")
+        expect('(')
+        skipWhitespace()
+        if (peek() != '[') {
+            throw error("Text expects an array")
+        }
+        val nodes = parseArray().elements.map { element ->
+            parseTextNode(element)
+        }
+        skipWhitespace()
+        expect(')')
+        return YsonValue.YsonText(nodes)
+    }
+
+    private fun parseTreeConstructor(): YsonValue.YsonTree {
+        expectKeyword("Tree")
+        expect('(')
+        skipWhitespace()
+        val inner = parseValue()
+        skipWhitespace()
+        expect(')')
+        return YsonValue.YsonTree(parseTreeNode(inner))
+    }
+
+    private fun parseTextNode(value: YsonValue): YsonTextNode {
+        if (value !is YsonValue.YsonObject) {
+            throw YorkieException(
+                YorkieException.Code.ErrInvalidArgument,
+                "invalid text node format",
+            )
+        }
+        val rawVal = value.entries["val"]
+        if (rawVal !is YsonValue.YsonString) {
+            throw YorkieException(
+                YorkieException.Code.ErrInvalidArgument,
+                "invalid text node format",
+            )
+        }
+        val attrs = value.entries["attrs"]
+        val attrMap: Map<String, YsonValue>? = when (attrs) {
+            null -> null
+            is YsonValue.YsonObject -> attrs.entries
+            else -> throw YorkieException(
+                YorkieException.Code.ErrInvalidArgument,
+                "invalid text node format",
+            )
+        }
+        return YsonTextNode(rawVal.value, attrMap)
+    }
+
+    private fun parseTreeNode(value: YsonValue): YsonTreeNode {
+        if (value !is YsonValue.YsonObject) {
+            throw YorkieException(
+                YorkieException.Code.ErrInvalidArgument,
+                "invalid tree node format",
+            )
+        }
+        val typeRaw = value.entries["type"]
+        if (typeRaw !is YsonValue.YsonString) {
+            throw YorkieException(
+                YorkieException.Code.ErrInvalidArgument,
+                "invalid tree node format",
+            )
+        }
+        val type = typeRaw.value
+        val nodeValueRaw = value.entries["value"]
+        if (type == "text" && nodeValueRaw is YsonValue.YsonString) {
+            return YsonTreeNode(type = type, value = nodeValueRaw.value)
+        }
+
+        val attrs = value.entries["attrs"]
+        val attrMap: Map<String, String>? = when (attrs) {
+            null -> null
+            is YsonValue.YsonObject -> attrs.entries.mapValues { (_, attrVal) ->
+                when (attrVal) {
+                    is YsonValue.YsonString -> attrVal.value
+                    else -> attrVal.toString()
+                }
+            }
+            else -> null
+        }
+
+        val children = value.entries["children"]
+        val childList: List<YsonTreeNode>? = when (children) {
+            null -> null
+            is YsonValue.YsonArray -> children.elements.map { parseTreeNode(it) }
+            else -> null
+        }
+
+        return YsonTreeNode(type = type, attrs = attrMap, children = childList)
+    }
+
+    private fun parseSignedInteger(): String {
+        skipWhitespace()
+        val start = pos
+        if (peek() == '-') pos++
+        val digitStart = pos
+        while (pos < input.length && input[pos].isDigit()) pos++
+        if (pos == digitStart) {
+            throw error("Expected integer literal")
+        }
+        val literal = input.substring(start, pos)
+        skipWhitespace()
+        return literal
+    }
+
+    private fun expectKeyword(keyword: String) {
+        if (!matches(keyword)) {
+            throw error("Expected '$keyword'")
+        }
+        pos += keyword.length
+    }
+
+    private fun matches(keyword: String): Boolean {
+        if (pos + keyword.length > input.length) return false
+        for (i in keyword.indices) {
+            if (input[pos + i] != keyword[i]) return false
+        }
+        return true
+    }
+
+    private fun expect(ch: Char) {
+        skipWhitespace()
+        if (atEnd() || input[pos] != ch) {
+            val found = if (atEnd()) "end of input" else "'${input[pos]}'"
+            throw error("Expected '$ch', got $found")
+        }
+        pos++
+    }
+
+    private fun peek(): Char {
+        if (atEnd()) throw error("Unexpected end of input")
+        return input[pos]
+    }
+
+    private fun peekOrNull(): Char? = if (atEnd()) null else input[pos]
+
+    fun skipWhitespace() {
+        while (pos < input.length && input[pos].isWhitespace()) pos++
+    }
+
+    fun atEnd(): Boolean = pos >= input.length
+
+    fun error(message: String): YorkieException = YorkieException(
+        YorkieException.Code.ErrInvalidArgument,
+        "Failed to parse YSON at position $pos: $message",
+    )
+}

--- a/yorkie/src/main/kotlin/dev/yorkie/document/yson/YsonValue.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/yson/YsonValue.kt
@@ -1,0 +1,158 @@
+package dev.yorkie.document.yson
+
+/**
+ * [YsonValue] represents any valid YSON value.
+ *
+ * Variants cover the standard JSON value set plus Yorkie CRDT and special
+ * scalar types: [YsonText], [YsonTree], [YsonInt], [YsonLong], [YsonDate],
+ * [YsonBinData], and [YsonCounter].
+ */
+public sealed interface YsonValue {
+
+    /**
+     * [YsonString] wraps a string primitive.
+     */
+    public data class YsonString(public val value: String) : YsonValue
+
+    /**
+     * [YsonNumber] wraps a JSON number primitive.
+     *
+     * Kotlin uses [Double] to mirror the JS reference implementation, where
+     * untyped numbers are always parsed as 64-bit floats. Typed integers use
+     * [YsonInt] or [YsonLong].
+     */
+    public data class YsonNumber(public val value: Double) : YsonValue
+
+    /**
+     * [YsonBoolean] wraps a boolean primitive.
+     */
+    public data class YsonBoolean(public val value: Boolean) : YsonValue
+
+    /**
+     * [YsonNull] represents the JSON null literal.
+     */
+    public object YsonNull : YsonValue
+
+    /**
+     * [YsonObject] represents a plain key-value map.
+     *
+     * Entries preserve insertion order to keep round-tripping deterministic.
+     */
+    public data class YsonObject(public val entries: Map<String, YsonValue>) : YsonValue
+
+    /**
+     * [YsonArray] represents an ordered list of values.
+     */
+    public data class YsonArray(public val elements: List<YsonValue>) : YsonValue
+
+    /**
+     * [YsonInt] represents a 32-bit integer literal, serialized as `Int(value)`.
+     */
+    public data class YsonInt(public val value: Int) : YsonValue
+
+    /**
+     * [YsonLong] represents a 64-bit integer literal, serialized as `Long(value)`.
+     */
+    public data class YsonLong(public val value: Long) : YsonValue
+
+    /**
+     * [YsonDate] represents an ISO 8601 timestamp literal, serialized as `Date("...")`.
+     */
+    public data class YsonDate(public val value: String) : YsonValue
+
+    /**
+     * [YsonBinData] represents a Base64-encoded binary literal, serialized as `BinData("...")`.
+     */
+    public data class YsonBinData(public val value: String) : YsonValue
+
+    /**
+     * [YsonCounter] represents a Counter CRDT, serialized as `Counter(Int(...))` or `Counter(Long(...))`.
+     *
+     * [value] is constrained at construction to be either [YsonInt] or [YsonLong].
+     */
+    public data class YsonCounter(public val value: YsonValue) : YsonValue {
+        init {
+            require(value is YsonInt || value is YsonLong) {
+                "Counter must contain Int or Long"
+            }
+        }
+    }
+
+    /**
+     * [YsonText] represents a Text CRDT, serialized as `Text([...])`.
+     */
+    public data class YsonText(public val nodes: List<YsonTextNode>) : YsonValue
+
+    /**
+     * [YsonTree] represents a Tree CRDT, serialized as `Tree({...})`.
+     */
+    public data class YsonTree(public val root: YsonTreeNode) : YsonValue
+}
+
+/**
+ * [YsonTextNode] represents a single character in a Text CRDT, optionally carrying inline attributes.
+ *
+ * @param value Character value held by this node.
+ * @param attrs Optional attribute map (for example formatting flags).
+ */
+public data class YsonTextNode(
+    public val value: String,
+    public val attrs: Map<String, YsonValue>? = null,
+)
+
+/**
+ * [YsonTreeNode] represents a node in a Tree CRDT.
+ *
+ * A text node carries [value]. An element node carries [attrs] and/or [children].
+ *
+ * @param type Node type (for example `text`, `p`, `div`).
+ * @param value Text content for text nodes.
+ * @param attrs Element attributes.
+ * @param children Child element list.
+ */
+public data class YsonTreeNode(
+    public val type: String,
+    public val value: String? = null,
+    public val attrs: Map<String, String>? = null,
+    public val children: List<YsonTreeNode>? = null,
+)
+
+/**
+ * [isText] returns true when [value] is a [YsonValue.YsonText].
+ */
+public fun isText(value: Any?): Boolean = value is YsonValue.YsonText
+
+/**
+ * [isTree] returns true when [value] is a [YsonValue.YsonTree].
+ */
+public fun isTree(value: Any?): Boolean = value is YsonValue.YsonTree
+
+/**
+ * [isInt] returns true when [value] is a [YsonValue.YsonInt].
+ */
+public fun isInt(value: Any?): Boolean = value is YsonValue.YsonInt
+
+/**
+ * [isLong] returns true when [value] is a [YsonValue.YsonLong].
+ */
+public fun isLong(value: Any?): Boolean = value is YsonValue.YsonLong
+
+/**
+ * [isDate] returns true when [value] is a [YsonValue.YsonDate].
+ */
+public fun isDate(value: Any?): Boolean = value is YsonValue.YsonDate
+
+/**
+ * [isBinData] returns true when [value] is a [YsonValue.YsonBinData].
+ */
+public fun isBinData(value: Any?): Boolean = value is YsonValue.YsonBinData
+
+/**
+ * [isCounter] returns true when [value] is a [YsonValue.YsonCounter].
+ */
+public fun isCounter(value: Any?): Boolean = value is YsonValue.YsonCounter
+
+/**
+ * [isObject] returns true when [value] is a plain [YsonValue.YsonObject], not a CRDT or special type.
+ */
+public fun isObject(value: Any?): Boolean = value is YsonValue.YsonObject

--- a/yorkie/src/test/kotlin/dev/yorkie/document/yson/YsonParserTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/yson/YsonParserTest.kt
@@ -1,0 +1,454 @@
+package dev.yorkie.document.yson
+
+import dev.yorkie.util.YorkieException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class YsonParserTest {
+
+    // --- primitives ---
+
+    @Test
+    fun `parse should decode string primitive`() {
+        val result = parse("\"hello\"")
+        assertEquals(YsonValue.YsonString("hello"), result)
+    }
+
+    @Test
+    fun `parse should decode number primitive`() {
+        val result = parse("42")
+        assertEquals(YsonValue.YsonNumber(42.0), result)
+    }
+
+    @Test
+    fun `parse should decode boolean primitive`() {
+        assertEquals(YsonValue.YsonBoolean(true), parse("true"))
+        assertEquals(YsonValue.YsonBoolean(false), parse("false"))
+    }
+
+    @Test
+    fun `parse should decode null primitive`() {
+        assertEquals(YsonValue.YsonNull, parse("null"))
+    }
+
+    // --- collections ---
+
+    @Test
+    fun `parse should decode array of numbers`() {
+        val result = parse("[1, 2, 3]")
+        assertEquals(
+            YsonValue.YsonArray(
+                listOf(
+                    YsonValue.YsonNumber(1.0),
+                    YsonValue.YsonNumber(2.0),
+                    YsonValue.YsonNumber(3.0),
+                ),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `parse should decode plain object`() {
+        val result = parse("{\"name\":\"Alice\",\"age\":30}")
+        val expected = YsonValue.YsonObject(
+            linkedMapOf(
+                "name" to YsonValue.YsonString("Alice"),
+                "age" to YsonValue.YsonNumber(30.0),
+            ),
+        )
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `parse should decode empty object`() {
+        assertEquals(YsonValue.YsonObject(emptyMap()), parse("{}"))
+    }
+
+    @Test
+    fun `parse should decode empty array`() {
+        assertEquals(YsonValue.YsonArray(emptyList()), parse("[]"))
+    }
+
+    // --- Text CRDT ---
+
+    @Test
+    fun `parse should decode Text CRDT`() {
+        val yson = "{\"content\":Text([{\"val\":\"H\"},{\"val\":\"i\"}])}"
+        val result = parse(yson)
+
+        assertTrue(isObject(result))
+        val obj = result as YsonValue.YsonObject
+        val content = obj.entries["content"]
+        assertTrue(isText(content))
+
+        val text = content as YsonValue.YsonText
+        assertEquals(2, text.nodes.size)
+        assertEquals("H", text.nodes[0].value)
+        assertEquals("i", text.nodes[1].value)
+    }
+
+    @Test
+    fun `parse should decode Text CRDT with attributes`() {
+        val yson = "{\"content\":Text([{\"val\":\"H\",\"attrs\":{\"bold\":true}}])}"
+        val result = parse(yson) as YsonValue.YsonObject
+        val content = result.entries["content"] as YsonValue.YsonText
+
+        assertEquals(1, content.nodes.size)
+        val attrs = content.nodes[0].attrs
+        assertNotNull(attrs)
+        assertEquals(YsonValue.YsonBoolean(true), attrs!!["bold"])
+    }
+
+    // --- Tree CRDT ---
+
+    @Test
+    fun `parse should decode Tree CRDT`() {
+        val yson =
+            "{\"content\":Tree({\"type\":\"doc\",\"children\":" +
+                "[{\"type\":\"p\",\"children\":[{\"type\":\"text\",\"value\":\"Hello\"}]}]})}"
+        val result = parse(yson) as YsonValue.YsonObject
+        val content = result.entries["content"]
+        assertTrue(isTree(content))
+
+        val tree = content as YsonValue.YsonTree
+        assertEquals("doc", tree.root.type)
+        val children = tree.root.children
+        assertNotNull(children)
+        assertEquals(1, children!!.size)
+        assertEquals("p", children[0].type)
+    }
+
+    // --- nested ---
+
+    @Test
+    fun `parse should decode nested structures with Text inside array`() {
+        val yson = "{\"users\":[{\"name\":\"Alice\",\"content\":Text([{\"val\":\"A\"}])}]}"
+        val result = parse(yson) as YsonValue.YsonObject
+        val users = result.entries["users"] as YsonValue.YsonArray
+        val first = users.elements[0] as YsonValue.YsonObject
+        assertTrue(isText(first.entries["content"]))
+    }
+
+    // --- type guards ---
+
+    @Test
+    fun `isText should identify Text objects`() {
+        val text = YsonValue.YsonText(listOf(YsonTextNode("H")))
+        assertTrue(isText(text))
+        assertFalse(isText(YsonValue.YsonObject(emptyMap())))
+        assertFalse(isText("string"))
+    }
+
+    @Test
+    fun `isTree should identify Tree objects`() {
+        val tree = YsonValue.YsonTree(YsonTreeNode(type = "doc", children = emptyList()))
+        assertTrue(isTree(tree))
+        assertFalse(isTree(YsonValue.YsonObject(emptyMap())))
+    }
+
+    @Test
+    fun `isObject should identify plain objects only`() {
+        assertTrue(isObject(YsonValue.YsonObject(mapOf("name" to YsonValue.YsonString("Alice")))))
+        assertFalse(isObject(YsonValue.YsonText(emptyList())))
+        assertFalse(isObject(YsonValue.YsonArray(emptyList())))
+    }
+
+    // --- utility ---
+
+    @Test
+    fun `textToString should concatenate node values`() {
+        val text = YsonValue.YsonText(
+            listOf(
+                YsonTextNode("H"),
+                YsonTextNode("e"),
+                YsonTextNode("l"),
+                YsonTextNode("l"),
+                YsonTextNode("o"),
+            ),
+        )
+        assertEquals("Hello", textToString(text))
+    }
+
+    @Test
+    fun `textToString should return empty for empty text`() {
+        assertEquals("", textToString(YsonValue.YsonText(emptyList())))
+    }
+
+    @Test
+    fun `treeToXML should convert tree to XML`() {
+        val tree = YsonValue.YsonTree(
+            YsonTreeNode(
+                type = "doc",
+                children = listOf(
+                    YsonTreeNode(
+                        type = "p",
+                        attrs = mapOf("class" to "paragraph"),
+                        children = listOf(YsonTreeNode(type = "text", value = "Hello")),
+                    ),
+                ),
+            ),
+        )
+        val xml = treeToXML(tree)
+        assertTrue(xml.contains("<doc>"))
+        assertTrue(xml.contains("<p class=\"paragraph\">"))
+        assertTrue(xml.contains("<text>Hello</text>"))
+    }
+
+    @Test
+    fun `treeToXML should emit self-closing tag for empty element`() {
+        val tree = YsonValue.YsonTree(YsonTreeNode(type = "br"))
+        assertEquals("<br />", treeToXML(tree))
+    }
+
+    @Test
+    fun `treeToXML should escape special XML characters in text and attributes`() {
+        val tree = YsonValue.YsonTree(
+            YsonTreeNode(
+                type = "p",
+                attrs = mapOf("title" to "a & b < c"),
+                children = listOf(YsonTreeNode(type = "text", value = "<hi>")),
+            ),
+        )
+        val xml = treeToXML(tree)
+        assertTrue(xml.contains("title=\"a &amp; b &lt; c\""))
+        assertTrue(xml.contains("&lt;hi&gt;"))
+    }
+
+    // --- Int type ---
+
+    @Test
+    fun `parse should decode Int type`() {
+        val result = parse("{\"value\":Int(42)}") as YsonValue.YsonObject
+        val value = result.entries["value"]
+        assertTrue(isInt(value))
+        assertEquals(42, (value as YsonValue.YsonInt).value)
+    }
+
+    @Test
+    fun `parse should decode negative Int`() {
+        val result = parse("{\"value\":Int(-42)}") as YsonValue.YsonObject
+        assertEquals(-42, (result.entries["value"] as YsonValue.YsonInt).value)
+    }
+
+    // --- Long type ---
+
+    @Test
+    fun `parse should decode Long type`() {
+        val result = parse("{\"value\":Long(64)}") as YsonValue.YsonObject
+        val value = result.entries["value"]
+        assertTrue(isLong(value))
+        assertEquals(64L, (value as YsonValue.YsonLong).value)
+    }
+
+    @Test
+    fun `parse should decode Long at maximum boundary`() {
+        val result = parse("{\"value\":Long(${Long.MAX_VALUE})}") as YsonValue.YsonObject
+        assertEquals(Long.MAX_VALUE, (result.entries["value"] as YsonValue.YsonLong).value)
+    }
+
+    @Test
+    fun `parse should throw when Int value overflows`() {
+        val overflow = (Int.MAX_VALUE.toLong() + 1).toString()
+        assertThrows(YorkieException::class.java) { parse("{\"value\":Int($overflow)}") }
+    }
+
+    // --- Date type ---
+
+    @Test
+    fun `parse should decode Date type`() {
+        val dateStr = "2025-01-02T15:04:05.058Z"
+        val result = parse("{\"value\":Date(\"$dateStr\")}") as YsonValue.YsonObject
+        val value = result.entries["value"]
+        assertTrue(isDate(value))
+        assertEquals(dateStr, (value as YsonValue.YsonDate).value)
+    }
+
+    // --- BinData type ---
+
+    @Test
+    fun `parse should decode BinData type`() {
+        val result = parse("{\"value\":BinData(\"AQID\")}") as YsonValue.YsonObject
+        val value = result.entries["value"]
+        assertTrue(isBinData(value))
+        assertEquals("AQID", (value as YsonValue.YsonBinData).value)
+    }
+
+    // --- Counter ---
+
+    @Test
+    fun `parse should decode Counter with Int`() {
+        val result = parse("{\"value\":Counter(Int(10))}") as YsonValue.YsonObject
+        val value = result.entries["value"]
+        assertTrue(isCounter(value))
+        val inner = (value as YsonValue.YsonCounter).value
+        assertTrue(isInt(inner))
+        assertEquals(10, (inner as YsonValue.YsonInt).value)
+    }
+
+    @Test
+    fun `parse should decode Counter with Long`() {
+        val result = parse("{\"value\":Counter(Long(100))}") as YsonValue.YsonObject
+        val counter = result.entries["value"] as YsonValue.YsonCounter
+        assertTrue(isLong(counter.value))
+        assertEquals(100L, (counter.value as YsonValue.YsonLong).value)
+    }
+
+    // --- complex document ---
+
+    @Test
+    fun `parse should decode complex document with every supported type`() {
+        val yson = """
+            {
+              "str": "value1",
+              "num": 42,
+              "int": Int(42),
+              "long": Long(64),
+              "null": null,
+              "bool": true,
+              "bytes": BinData("AQID"),
+              "date": Date("2025-01-02T15:04:05.058Z"),
+              "counter": Counter(Int(10)),
+              "text": Text([{"val":"Hello"}]),
+              "tree": Tree({"type":"p","children":[{"type":"text","value":"Hello World"}]})
+            }
+        """.trimIndent()
+        val result = parse(yson) as YsonValue.YsonObject
+
+        assertEquals(YsonValue.YsonString("value1"), result.entries["str"])
+        assertEquals(YsonValue.YsonNumber(42.0), result.entries["num"])
+        assertTrue(isInt(result.entries["int"]))
+        assertTrue(isLong(result.entries["long"]))
+        assertEquals(YsonValue.YsonNull, result.entries["null"])
+        assertEquals(YsonValue.YsonBoolean(true), result.entries["bool"])
+        assertTrue(isBinData(result.entries["bytes"]))
+        assertTrue(isDate(result.entries["date"]))
+        assertTrue(isCounter(result.entries["counter"]))
+        assertTrue(isText(result.entries["text"]))
+        assertTrue(isTree(result.entries["tree"]))
+    }
+
+    // --- error handling ---
+
+    @Test
+    fun `parse should throw on invalid input`() {
+        assertThrows(YorkieException::class.java) { parse("invalid yson") }
+    }
+
+    @Test
+    fun `parse should throw on invalid Text node format`() {
+        assertThrows(YorkieException::class.java) {
+            parse("{\"content\":Text([{\"invalid\":\"node\"}])}")
+        }
+    }
+
+    @Test
+    fun `parse should throw on invalid Tree node format`() {
+        assertThrows(YorkieException::class.java) {
+            parse("{\"content\":Tree({\"invalid\":\"tree\"})}")
+        }
+    }
+
+    @Test
+    fun `parse should throw on unterminated string`() {
+        assertThrows(YorkieException::class.java) { parse("\"unterminated") }
+    }
+
+    @Test
+    fun `parse should throw on trailing comma in object`() {
+        assertThrows(YorkieException::class.java) { parse("{\"a\":1,}") }
+    }
+
+    @Test
+    fun `parse should throw on trailing comma in array`() {
+        assertThrows(YorkieException::class.java) { parse("[1,2,]") }
+    }
+
+    @Test
+    fun `parse should throw on missing colon in object`() {
+        assertThrows(YorkieException::class.java) { parse("{\"key\" \"value\"}") }
+    }
+
+    @Test
+    fun `parse should throw on Counter with non integer payload`() {
+        assertThrows(YorkieException::class.java) {
+            parse("{\"value\":Counter(Date(\"2025-01-02T15:04:05Z\"))}")
+        }
+    }
+
+    @Test
+    fun `YsonCounter constructor should reject non integer value`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            YsonValue.YsonCounter(YsonValue.YsonString("nope"))
+        }
+    }
+
+    // --- escapes and edge cases ---
+
+    @Test
+    fun `parse should decode string escapes`() {
+        val result = parse("\"a\\n\\t\\\"\\\\b\"") as YsonValue.YsonString
+        assertEquals("a\n\t\"\\b", result.value)
+    }
+
+    @Test
+    fun `parse should decode unicode escape`() {
+        val result = parse("\"\\u00e9\"") as YsonValue.YsonString
+        assertEquals("é", result.value)
+    }
+
+    @Test
+    fun `parse should decode negative zero`() {
+        val result = parse("-0") as YsonValue.YsonNumber
+        assertEquals(-0.0, result.value, 0.0)
+    }
+
+    @Test
+    fun `parse should decode scientific notation`() {
+        val result = parse("1.5e2") as YsonValue.YsonNumber
+        assertEquals(150.0, result.value, 0.0)
+    }
+
+    @Test
+    fun `parse should preserve object key order`() {
+        val result = parse("{\"z\":1,\"a\":2,\"m\":3}") as YsonValue.YsonObject
+        assertEquals(listOf("z", "a", "m"), result.entries.keys.toList())
+    }
+
+    @Test
+    fun `parse should reject trailing characters`() {
+        assertThrows(YorkieException::class.java) { parse("42 trailing") }
+    }
+
+    @Test
+    fun `parse should reject empty input`() {
+        assertThrows(YorkieException::class.java) { parse("") }
+    }
+
+    @Test
+    fun `parse should ignore whitespace around tokens`() {
+        val result = parse("   {  \"a\" :  1  }  ") as YsonValue.YsonObject
+        assertEquals(YsonValue.YsonNumber(1.0), result.entries["a"])
+    }
+
+    @Test
+    fun `parse should reject object missing closing brace`() {
+        assertThrows(YorkieException::class.java) { parse("{\"a\":1") }
+    }
+
+    @Test
+    fun `parse should reject array missing closing bracket`() {
+        assertThrows(YorkieException::class.java) { parse("[1,2") }
+    }
+
+    @Test
+    fun `Text node without optional attrs should not carry attrs`() {
+        val result = parse("Text([{\"val\":\"x\"}])") as YsonValue.YsonText
+        assertNull(result.nodes[0].attrs)
+    }
+}


### PR DESCRIPTION
> **RTCOLLABPLATFORM-655**: [Implement YSON module (parser + types)](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-655)
> **JS reference:** [yorkie-js-sdk#1135](https://github.com/yorkie-team/yorkie-js-sdk/pull/1135)

## Summary
- Add YSON module: typed value hierarchy, hand-rolled recursive-descent parser, and `textToString` / `treeToXML` utilities.
- Mirrors yorkie-js-sdk PR #1135 type definitions and public API surface (`parse`, `isText`, `isTree`, `isInt`, `isLong`, `isDate`, `isBinData`, `isCounter`, `isObject`, `textToString`, `treeToXML`).
- Foundation for C4 (RTCOLLABPLATFORM-656, YSON generics).

## Changes
- `YsonValue.kt`: sealed `YsonValue` hierarchy (`YsonString`, `YsonNumber`, `YsonBoolean`, `YsonNull`, `YsonObject`, `YsonArray`, `YsonInt`, `YsonLong`, `YsonDate`, `YsonBinData`, `YsonCounter`, `YsonText`, `YsonTree`) plus `YsonTextNode` / `YsonTreeNode` data classes and top-level type-guard predicates.
- `YsonParser.kt`: dependency-free recursive-descent parser that handles standard JSON plus YSON constructors (`Text([...])`, `Tree({...})`, `Int(n)`, `Long(n)`, `Date("...")`, `BinData("...")`, `Counter(Int(...))` / `Counter(Long(...))`); exposes top-level `parse`, `textToString`, `treeToXML`.
- `YsonParserTest.kt`: 50 unit tests including the 1:1 port of the JS test suite, escape/unicode/boundary-number cases, and parser-error cases.

This PR is library-only — no integration with `Document.toString()` or existing JSON wrappers yet. C4 will wire YSON into the broader API.

## Test plan
- [x] Unit tests pass: `./gradlew yorkie:testDebugUnitTest` (385 tests, 50 new in `YsonParserTest`, 0 failures)
- [x] Lint passes: `./gradlew lintKotlin`

> Items run automatically by CI (lint, unit tests, coverage) are excluded.