### PR TITLE
Enhance YSON parsing with generic type support

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/document/yson/YsonParser.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/yson/YsonParser.kt
@@ -36,6 +36,34 @@ public fun parse(yson: String): YsonValue {
 }
 
 /**
+ * [parseAs] parses a YSON formatted string and narrows the result to [T].
+ *
+ * Mirrors the generic type parameter of `parse<T extends YSONValue>(...)` in
+ * yorkie-js-sdk. The reified type [T] is checked at runtime against the parsed
+ * root value; a mismatch surfaces as a [YorkieException] rather than a
+ * [ClassCastException].
+ *
+ * ```kotlin
+ * val obj = parseAs<YsonValue.YsonObject>("""{"content":Text([{"val":"Hi"}])}""")
+ * val text = obj.entries["content"] as YsonValue.YsonText
+ * ```
+ *
+ * @param yson YSON formatted string.
+ * @throws YorkieException with [YorkieException.Code.ErrInvalidArgument] when parsing fails
+ * or the parsed root is not an instance of [T].
+ */
+public inline fun <reified T : YsonValue> parseAs(yson: String): T {
+    val value = parse(yson)
+    if (value !is T) {
+        throw YorkieException(
+            YorkieException.Code.ErrInvalidArgument,
+            "Expected ${T::class.simpleName}, got ${value::class.simpleName}",
+        )
+    }
+    return value
+}
+
+/**
  * [textToString] returns the concatenated character values of a [YsonValue.YsonText].
  */
 public fun textToString(text: YsonValue.YsonText): String =

--- a/yorkie/src/test/kotlin/dev/yorkie/document/yson/YsonParserTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/yson/YsonParserTest.kt
@@ -451,4 +451,149 @@ class YsonParserTest {
         val result = parse("Text([{\"val\":\"x\"}])") as YsonValue.YsonText
         assertNull(result.nodes[0].attrs)
     }
+
+    // --- typed parse with reified generics ---
+
+    @Test
+    fun `parseAs should narrow result to YsonObject`() {
+        val yson = "{\"content\":Text([{\"val\":\"H\"},{\"val\":\"i\"}]),\"title\":\"Hello\"}"
+        val result = parseAs<YsonValue.YsonObject>(yson)
+
+        assertEquals(YsonValue.YsonString("Hello"), result.entries["title"])
+        val content = result.entries["content"] as YsonValue.YsonText
+        assertEquals(2, content.nodes.size)
+    }
+
+    @Test
+    fun `parseAs should narrow result to YsonArray`() {
+        val yson = "[{\"id\":1,\"text\":Text([{\"val\":\"A\"}])}," +
+            "{\"id\":2,\"text\":Text([{\"val\":\"B\"}])}]"
+        val result = parseAs<YsonValue.YsonArray>(yson)
+
+        assertEquals(2, result.elements.size)
+        val first = result.elements[0] as YsonValue.YsonObject
+        assertEquals(YsonValue.YsonNumber(1.0), first.entries["id"])
+        val firstText = first.entries["text"] as YsonValue.YsonText
+        assertEquals("A", firstText.nodes[0].value)
+    }
+
+    @Test
+    fun `parseAs should narrow result to YsonString`() {
+        val result = parseAs<YsonValue.YsonString>("\"hello\"")
+        assertEquals("hello", result.value)
+    }
+
+    @Test
+    fun `parseAs should narrow result to YsonNumber`() {
+        val result = parseAs<YsonValue.YsonNumber>("42")
+        assertEquals(42.0, result.value, 0.0)
+    }
+
+    @Test
+    fun `parseAs should narrow result to YsonBoolean`() {
+        val result = parseAs<YsonValue.YsonBoolean>("true")
+        assertTrue(result.value)
+    }
+
+    @Test
+    fun `parseAs should narrow result to YsonInt`() {
+        val result = parseAs<YsonValue.YsonInt>("Int(42)")
+        assertEquals(42, result.value)
+    }
+
+    @Test
+    fun `parseAs should narrow result to YsonLong`() {
+        val result = parseAs<YsonValue.YsonLong>("Long(64)")
+        assertEquals(64L, result.value)
+    }
+
+    @Test
+    fun `parseAs should narrow result to YsonDate`() {
+        val dateStr = "2025-01-02T15:04:05.058Z"
+        val result = parseAs<YsonValue.YsonDate>("Date(\"$dateStr\")")
+        assertEquals(dateStr, result.value)
+    }
+
+    @Test
+    fun `parseAs should narrow result to YsonBinData`() {
+        val result = parseAs<YsonValue.YsonBinData>("BinData(\"AQID\")")
+        assertEquals("AQID", result.value)
+    }
+
+    @Test
+    fun `parseAs should narrow result to YsonCounter`() {
+        val result = parseAs<YsonValue.YsonCounter>("Counter(Int(10))")
+        val inner = result.value as YsonValue.YsonInt
+        assertEquals(10, inner.value)
+    }
+
+    @Test
+    fun `parseAs should narrow result to YsonText`() {
+        val result = parseAs<YsonValue.YsonText>("Text([{\"val\":\"H\"},{\"val\":\"i\"}])")
+        assertEquals(2, result.nodes.size)
+        assertEquals("H", result.nodes[0].value)
+    }
+
+    @Test
+    fun `parseAs should narrow result to YsonTree`() {
+        val yson = "Tree({\"type\":\"doc\",\"children\":" +
+            "[{\"type\":\"p\",\"children\":[{\"type\":\"text\",\"value\":\"Hello\"}]}]})"
+        val result = parseAs<YsonValue.YsonTree>(yson)
+        assertEquals("doc", result.root.type)
+    }
+
+    @Test
+    fun `parseAs should narrow result to YsonValue for nested mixed types`() {
+        val yson = """
+            {
+              "text": Text([{"val":"H"}]),
+              "tree": Tree({"type":"p","children":[]}),
+              "counter": Counter(Int(10)),
+              "timestamp": Date("2025-01-02T15:04:05.058Z")
+            }
+        """.trimIndent()
+        val result = parseAs<YsonValue.YsonObject>(yson)
+
+        assertTrue(isText(result.entries["text"]))
+        assertTrue(isTree(result.entries["tree"]))
+        assertTrue(isCounter(result.entries["counter"]))
+        assertTrue(isDate(result.entries["timestamp"]))
+    }
+
+    @Test
+    fun `parseAs should throw when parsing number as YsonObject`() {
+        val error = assertThrows(YorkieException::class.java) {
+            parseAs<YsonValue.YsonObject>("123")
+        }
+        assertEquals(YorkieException.Code.ErrInvalidArgument, error.code)
+        assertTrue(error.errorMessage.contains("YsonObject"))
+        assertTrue(error.errorMessage.contains("YsonNumber"))
+    }
+
+    @Test
+    fun `parseAs should throw when parsing object as YsonArray`() {
+        val error = assertThrows(YorkieException::class.java) {
+            parseAs<YsonValue.YsonArray>("{}")
+        }
+        assertEquals(YorkieException.Code.ErrInvalidArgument, error.code)
+        assertTrue(error.errorMessage.contains("YsonArray"))
+        assertTrue(error.errorMessage.contains("YsonObject"))
+    }
+
+    @Test
+    fun `parseAs should throw when parsing Text as YsonTree`() {
+        val error = assertThrows(YorkieException::class.java) {
+            parseAs<YsonValue.YsonTree>("Text([{\"val\":\"H\"}])")
+        }
+        assertEquals(YorkieException.Code.ErrInvalidArgument, error.code)
+        assertTrue(error.errorMessage.contains("YsonTree"))
+        assertTrue(error.errorMessage.contains("YsonText"))
+    }
+
+    @Test
+    fun `parseAs should propagate parse errors`() {
+        assertThrows(YorkieException::class.java) {
+            parseAs<YsonValue.YsonObject>("invalid yson")
+        }
+    }
 }


### PR DESCRIPTION
> **RTCOLLABPLATFORM-656**: [Enhance YSON parsing with generic type support](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-656)
> **JS reference:** [yorkie-js-sdk#1137](https://github.com/yorkie-team/yorkie-js-sdk/pull/1137)
> **Builds on:** [#323](https://github.com/yorkie-team/yorkie-android-sdk/pull/323) (RTCOLLABPLATFORM-655)

## Summary
- Add typed YSON parsing — callers can specify the expected `YsonValue` subtype via a reified generic.
- Mirrors yorkie-js-sdk PR #1137, with the Kotlin idiom of an inline reified function and a runtime type check.

## Changes
- Add `parseAs<reified T : YsonValue>(yson: String): T` in `YsonParser.kt`, alongside the untyped `parse`. The function parses normally and then narrows the root to `T`, throwing `YorkieException(ErrInvalidArgument, "Expected <T>, got <actual>")` on mismatch.
- Add 17 new unit tests in `YsonParserTest.kt` covering successful narrowing for every `YsonValue` variant (object, array, string, number, boolean, int, long, date, binData, counter, text, tree), a nested mixed-type case, and three type-mismatch cases plus a parse-error propagation case.

## Test plan
- [x] Unit tests pass: `./gradlew yorkie:testDebugUnitTest` (402 tests, 0 failures)
- [x] Lint passes: `./gradlew lintKotlin`

> Items run automatically by CI (lint, unit tests, coverage) are excluded.