### PR TITLE
Add epoch-mismatch event for compaction recovery

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -41,6 +41,7 @@ import dev.yorkie.api.v1.watchRequest
 import dev.yorkie.document.Document
 import dev.yorkie.document.Document.Event.AuthError
 import dev.yorkie.document.Document.Event.AuthError.AuthErrorMethod.PushPull
+import dev.yorkie.document.Document.Event.EpochMismatch
 import dev.yorkie.document.Document.Event.PresenceChanged.MyPresence.Initialized
 import dev.yorkie.document.Document.Event.PresenceChanged.Others
 import dev.yorkie.document.Document.Event.StreamConnectionChanged
@@ -60,6 +61,7 @@ import dev.yorkie.util.YorkieException
 import dev.yorkie.util.YorkieException.Code.ErrClientNotActivated
 import dev.yorkie.util.YorkieException.Code.ErrDocumentNotAttached
 import dev.yorkie.util.YorkieException.Code.ErrDocumentNotDetached
+import dev.yorkie.util.YorkieException.Code.ErrEpochMismatch
 import dev.yorkie.util.YorkieException.Code.ErrUnauthenticated
 import dev.yorkie.util.checkYorkieError
 import dev.yorkie.util.createSingleThreadDispatcher
@@ -387,6 +389,18 @@ public class Client(
                             cause = it,
                         ),
                     )
+
+                    // NOTE: If the server returns ErrEpochMismatch, the document was
+                    // compacted and this client must detach and reattach to recover.
+                    if (it is ConnectException &&
+                        errorCodeOf(it) == ErrEpochMismatch.codeString
+                    ) {
+                        resource.publish(
+                            event = EpochMismatch(
+                                method = EpochMismatch.EpochMismatchMethod.PushPull,
+                            ),
+                        )
+                    }
                 }
 
                 (it as? ConnectException)?.let { exception ->

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -1022,6 +1022,18 @@ public class Document(
         }
 
         /**
+         * `EpochMismatch` indicates the document was compacted on the server
+         * and this client must detach and reattach to recover.
+         */
+        public data class EpochMismatch(
+            val method: EpochMismatchMethod,
+        ) : Event {
+            enum class EpochMismatchMethod(val value: String) {
+                PushPull("PushPull"),
+            }
+        }
+
+        /**
          * Represents the modification made during a document update and the message passed.
          */
         public data class ChangeInfo(

--- a/yorkie/src/main/kotlin/dev/yorkie/util/ConnectRpcErrorUtil.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/ConnectRpcErrorUtil.kt
@@ -5,6 +5,7 @@ import com.connectrpc.ConnectException
 import com.google.rpc.ErrorInfo
 import dev.yorkie.util.YorkieException.Code.ErrClientNotActivated
 import dev.yorkie.util.YorkieException.Code.ErrClientNotFound
+import dev.yorkie.util.YorkieException.Code.ErrEpochMismatch
 import dev.yorkie.util.YorkieException.Code.ErrTooManyAttachments
 import dev.yorkie.util.YorkieException.Code.ErrTooManySubscribers
 import dev.yorkie.util.YorkieException.Code.ErrUnauthenticated
@@ -36,6 +37,13 @@ internal suspend fun handleConnectException(
     }
 
     if (yorkieErrorCode == ErrTooManyAttachments.codeString) {
+        return false
+    }
+
+    // NOTE: ErrEpochMismatch means the document has been compacted on the server.
+    // The client's checkpoint is stale, retrying yields the same result, so the
+    // sync loop must stop. The user recovers by detaching and reattaching.
+    if (yorkieErrorCode == ErrEpochMismatch.codeString) {
         return false
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/util/YorkieException.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/YorkieException.kt
@@ -58,6 +58,10 @@ public data class YorkieException(
 
         // ErrTooManyAttachments is returned when the number of attachments exceeds the limit.
         ErrTooManyAttachments("ErrTooManyAttachments"),
+
+        // ErrEpochMismatch is returned when the document has been compacted
+        // and the client's epoch no longer matches the server's epoch.
+        ErrEpochMismatch("ErrEpochMismatch"),
     }
 }
 

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -17,6 +17,7 @@ import dev.yorkie.core.Client.SyncMode.Manual
 import dev.yorkie.core.MockYorkieService.Companion.ATTACH_ERROR_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.AUTH_ERROR_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.DETACH_ERROR_DOCUMENT_KEY
+import dev.yorkie.core.MockYorkieService.Companion.EPOCH_MISMATCH_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.NORMAL_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.REMOVE_ERROR_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.TEST_ACTOR_ID
@@ -24,6 +25,7 @@ import dev.yorkie.core.MockYorkieService.Companion.TEST_KEY
 import dev.yorkie.core.MockYorkieService.Companion.TEST_USER_ID
 import dev.yorkie.core.MockYorkieService.Companion.WATCH_SYNC_ERROR_DOCUMENT_KEY
 import dev.yorkie.document.Document
+import dev.yorkie.document.Document.Event.EpochMismatch
 import dev.yorkie.document.Document.Event.StreamConnectionChanged
 import dev.yorkie.document.Document.Event.SyncStatusChanged
 import dev.yorkie.document.change.Change
@@ -312,6 +314,29 @@ class ClientTest {
 
         target.deactivateAsync().await()
     }
+
+    @Test
+    fun `should publish epoch mismatch event when server rejects sync with ErrEpochMismatch`() =
+        runTest {
+            // given
+            val document = Document(EPOCH_MISMATCH_DOCUMENT_KEY)
+            target.activateAsync().await()
+            target.attachDocument(document, syncMode = Manual).await()
+
+            val epochMismatchDeferred = async(start = CoroutineStart.UNDISPATCHED) {
+                document.events.filterIsInstance<EpochMismatch>().first()
+            }
+
+            // when
+            val syncResult = target.syncAsync(document).await()
+
+            // then
+            assertTrue(syncResult.isFailure)
+            val event = epochMismatchDeferred.await()
+            assertEquals(EpochMismatch.EpochMismatchMethod.PushPull, event.method)
+
+            target.deactivateAsync().await()
+        }
 
     @Test
     fun `should retry on network failure if error code was retryable`() = runTest {

--- a/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
@@ -81,6 +81,7 @@ import dev.yorkie.document.crdt.CrdtPrimitive
 import dev.yorkie.document.operation.SetOperation
 import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
 import dev.yorkie.document.time.VersionVector
+import dev.yorkie.util.YorkieException
 import dev.yorkie.util.YorkieException.Code.ErrUnauthenticated
 import io.mockk.every
 import io.mockk.mockk
@@ -199,6 +200,23 @@ class MockYorkieService(
                 ),
                 emptyMap(),
                 emptyMap(),
+            )
+        }
+        if (request.changePack.documentKey == EPOCH_MISMATCH_DOCUMENT_KEY) {
+            val errorInfo = ErrorInfo.newBuilder()
+                .putMetadata("code", YorkieException.Code.ErrEpochMismatch.codeString)
+                .build()
+
+            val connectException = mockk<ConnectException>(relaxed = true) {
+                every { code } returns customError[EPOCH_MISMATCH_DOCUMENT_KEY]!!
+                every {
+                    unpackedDetails(ErrorInfo::class)
+                } returns listOf(errorInfo)
+            }
+            return ResponseMessage.Failure(
+                cause = connectException,
+                headers = emptyMap(),
+                trailers = emptyMap(),
             )
         }
         return ResponseMessage.Success(
@@ -538,6 +556,7 @@ class MockYorkieService(
         internal const val DETACH_ERROR_DOCUMENT_KEY = "DETACH_ERROR_DOCUMENT_KEY"
         internal const val REMOVE_ERROR_DOCUMENT_KEY = "REMOVE_ERROR_DOCUMENT_KEY"
         internal const val AUTH_ERROR_DOCUMENT_KEY = "AUTH_ERROR_DOCUMENT_KEY"
+        internal const val EPOCH_MISMATCH_DOCUMENT_KEY = "EPOCH_MISMATCH_DOCUMENT_KEY"
         internal val TEST_ACTOR_ID = "0000000000ffff0000000000"
         internal const val TEST_USER_ID = "TEST_USER_ID"
 
@@ -547,6 +566,7 @@ class MockYorkieService(
             REMOVE_ERROR_DOCUMENT_KEY to Code.UNAVAILABLE,
             WATCH_SYNC_ERROR_DOCUMENT_KEY to Code.UNKNOWN,
             AUTH_ERROR_DOCUMENT_KEY to Code.UNAUTHENTICATED,
+            EPOCH_MISMATCH_DOCUMENT_KEY to Code.FAILED_PRECONDITION,
         )
     }
 }

--- a/yorkie/src/test/kotlin/dev/yorkie/util/ConnectRpcErrorUtilTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/util/ConnectRpcErrorUtilTest.kt
@@ -153,6 +153,19 @@ class ConnectRpcErrorUtilTest {
             )
         }
 
+    @Test
+    fun `should return not retryable if error code in metadata is ErrEpochMismatch`() = runTest {
+        val connectException =
+            produceConnectException(YorkieException.Code.ErrEpochMismatch.codeString)
+        assertEquals(
+            expected = false,
+            actual = handleConnectException(
+                exception = connectException,
+                handleError = null,
+            ),
+        )
+    }
+
     private fun produceConnectException(yorkieErrorCode: String): ConnectException {
         // Create ErrorInfo with unauthenticated error code
         val errorInfo = ErrorInfo.newBuilder()


### PR DESCRIPTION
> **RTCOLLABPLATFORM-658**: [Add epoch-mismatch event for compaction recovery](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-658)
> **JS reference:** [yorkie-js-sdk#1193](https://github.com/yorkie-team/yorkie-js-sdk/pull/1193)

## Summary
- Detect server `ErrEpochMismatch` errors during sync and surface them as a client event so applications can recover by detaching and reattaching the document.
- Mirrors yorkie-js-sdk PR #1193 in scope: no automatic recovery, just the event.

## Changes
- Add `YorkieException.Code.ErrEpochMismatch` with codeString `"ErrEpochMismatch"` to mirror the server error metadata.
- Mark `ErrEpochMismatch` as non-retryable in `handleConnectException` so the sync loop stops instead of looping on the same error.
- Add `Document.Event.EpochMismatch(method: EpochMismatchMethod)` sealed-class entry with a `PushPull` method enum, following the `AuthError` event shape.
- Publish `EpochMismatch` from the `syncInternal` `.onFailure` hook in `Client`, which covers `runSyncLoop`, `syncAsync`, and `changeSyncMode`-triggered sync paths.
- Tests:
  - Unit: `ConnectRpcErrorUtilTest` asserts the new code is non-retryable.
  - Unit: `ClientTest.should publish epoch mismatch event when server rejects sync with ErrEpochMismatch` uses an enhanced `MockYorkieService` (new `EPOCH_MISMATCH_DOCUMENT_KEY`) to drive a real pushPull failure and verifies the event surfaces with method `PushPull`.

## Test plan
- [x] Unit tests pass: `./gradlew yorkie:testDebugUnitTest` (387 tests, 0 failures)
- [x] Lint passes: `./gradlew lintKotlin`
- [ ] Instrumented test: **skipped** — the bundled server image is `yorkieteam/yorkie:0.6.48`, and epoch support shipped in yorkie-team/yorkie#1714 (merged 2026-03-27), which is not yet in any released server image (latest released is `v0.7.8`, but our `docker/docker-compose.yml` pins `0.6.48`). Same precedent as C5 (PR #322). Once the bundled image is bumped to a release containing #1714 we can add an integration test mirroring the JS one (`packages/sdk/test/integration/epoch_mismatch_test.ts`).

> Items run automatically by CI (lint, unit tests, coverage) are excluded.