### PR TITLE
Range-based styleByPath / removeStyleByPath for Tree

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
@@ -2104,6 +2104,90 @@ class JsonTreeTest {
     }
 
     @Test
+    fun test_sync_style_range_by_path() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        element("doc") {
+                            element("p") {
+                                attr { "weight" to "bold" }
+                                text { "a" }
+                            }
+                            element("p") {
+                                text { "b" }
+                            }
+                        },
+                    )
+                },
+                Updater(c2, d2),
+            )
+            assertTreesXmlEquals(
+                """<doc><p weight="bold">a</p><p>b</p></doc>""",
+                d1,
+                d2,
+            )
+
+            updateAndSync(
+                Updater(c1, d1) { root, _ ->
+                    root.rootTree().styleByPath(listOf(0), listOf(2), mapOf("color" to "red"))
+                },
+                Updater(c2, d2),
+            )
+            assertTreesXmlEquals(
+                """<doc><p color="red" weight="bold">a</p><p color="red">b</p></doc>""",
+                d1,
+                d2,
+            )
+        }
+    }
+
+    @Test
+    fun test_sync_remove_style_range_by_path() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            updateAndSync(
+                Updater(c1, d1) { root, _ ->
+                    root.setNewTree(
+                        "t",
+                        element("doc") {
+                            element("p") {
+                                attr { "bold" to "true" }
+                                attr { "italic" to "true" }
+                                text { "a" }
+                            }
+                            element("p") {
+                                attr { "bold" to "true" }
+                                attr { "italic" to "true" }
+                                text { "b" }
+                            }
+                        },
+                    )
+                },
+                Updater(c2, d2),
+            )
+            assertTreesXmlEquals(
+                """<doc><p bold="true" italic="true">a</p>""" +
+                    """<p bold="true" italic="true">b</p></doc>""",
+                d1,
+                d2,
+            )
+
+            updateAndSync(
+                Updater(c1, d1) { root, _ ->
+                    root.rootTree().removeStyleByPath(listOf(0), listOf(2), listOf("italic"))
+                },
+                Updater(c2, d2),
+            )
+            assertTreesXmlEquals(
+                """<doc><p bold="true">a</p><p bold="true">b</p></doc>""",
+                d1,
+                d2,
+            )
+        }
+    }
+
+    @Test
     fun test_tree_style_events_concurrency() {
         withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
             updateAndSync(

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonTree.kt
@@ -271,7 +271,7 @@ public class JsonTree internal constructor(
     }
 
     /**
-     * Sets the [attributes] to the elements of the given [path].
+     * Sets the [attributes] to the element at the given [path].
      */
     public fun styleByPath(path: List<Int>, attributes: Map<String, String>) {
         require(path.isNotEmpty()) {
@@ -280,6 +280,27 @@ public class JsonTree internal constructor(
 
         val treeRange = target.pathToPosRange(path)
         styleByRange(treeRange, attributes)
+    }
+
+    /**
+     * Sets the [attributes] to the elements in the path range
+     * between [fromPath] and [toPath].
+     */
+    public fun styleByPath(
+        fromPath: List<Int>,
+        toPath: List<Int>,
+        attributes: Map<String, String>,
+    ) {
+        require(fromPath.size == toPath.size) {
+            "path length should be equal"
+        }
+        require(fromPath.isNotEmpty() && toPath.isNotEmpty()) {
+            "path should not be empty"
+        }
+
+        val fromPos = target.pathToPos(fromPath)
+        val toPos = target.pathToPos(toPath)
+        styleByRange(fromPos to toPos, attributes)
     }
 
     /**
@@ -318,6 +339,10 @@ public class JsonTree internal constructor(
         gcPairs.forEach(context::registerGCPair)
     }
 
+    /**
+     * Removes the attributes in [attributesToRemove] from the elements
+     * in the given index range.
+     */
     public fun removeStyle(
         fromIndex: Int,
         toIndex: Int,
@@ -329,9 +354,34 @@ public class JsonTree internal constructor(
 
         val fromPos = target.findPos(fromIndex)
         val toPos = target.findPos(toIndex)
+        removeStyleByRange(fromPos to toPos, attributesToRemove)
+    }
+
+    /**
+     * Removes the attributes in [attributesToRemove] from the elements
+     * in the path range between [fromPath] and [toPath].
+     */
+    public fun removeStyleByPath(
+        fromPath: List<Int>,
+        toPath: List<Int>,
+        attributesToRemove: List<String>,
+    ) {
+        require(fromPath.size == toPath.size) {
+            "path length should be equal"
+        }
+        require(fromPath.isNotEmpty() && toPath.isNotEmpty()) {
+            "path should not be empty"
+        }
+
+        val fromPos = target.pathToPos(fromPath)
+        val toPos = target.pathToPos(toPath)
+        removeStyleByRange(fromPos to toPos, attributesToRemove)
+    }
+
+    private fun removeStyleByRange(range: TreePosRange, attributesToRemove: List<String>) {
         val executedAt = context.issueTimeTicket()
         val (_, gcPairs, diff) = target.removeStyle(
-            fromPos to toPos,
+            range,
             attributesToRemove,
             executedAt,
         )
@@ -343,8 +393,8 @@ public class JsonTree internal constructor(
         context.push(
             TreeStyleOperation(
                 target.createdAt,
-                fromPos,
-                toPos,
+                range.first,
+                range.second,
                 executedAt,
                 attributesToRemove = attributesToRemove,
             ),

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonTreeTest.kt
@@ -276,6 +276,133 @@ class JsonTreeTest {
     }
 
     @Test
+    fun `should style a range of elements by path`() {
+        // given
+        val target = createTreeWithMultipleParagraphs()
+        assertEquals(
+            """<doc><p weight="bold">a</p><p>b</p></doc>""",
+            target.toXml(),
+        )
+
+        // when
+        target.styleByPath(listOf(0), listOf(2), mapOf("color" to "red"))
+
+        // then
+        assertEquals(
+            """<doc><p color="red" weight="bold">a</p><p color="red">b</p></doc>""",
+            target.toXml(),
+        )
+    }
+
+    @Test
+    fun `should style multiple elements across a range by path`() {
+        // given
+        val target = createTreeWithTwoParagraphs()
+        assertEquals(
+            "<doc><p>ab</p><p>cd</p></doc>",
+            target.toXml(),
+        )
+
+        // when
+        target.styleByPath(listOf(0), listOf(2), mapOf("bold" to "true"))
+
+        // then
+        assertEquals(
+            """<doc><p bold="true">ab</p><p bold="true">cd</p></doc>""",
+            target.toXml(),
+        )
+    }
+
+    @Test
+    fun `should style a single element by path for backward compatibility`() {
+        // given
+        val target = createTreeWithSingleParagraph()
+        assertEquals(
+            "<doc><p>hello</p></doc>",
+            target.toXml(),
+        )
+
+        // when
+        target.styleByPath(listOf(0), mapOf("bold" to "true"))
+
+        // then
+        assertEquals(
+            """<doc><p bold="true">hello</p></doc>""",
+            target.toXml(),
+        )
+    }
+
+    @Test
+    fun `should remove style from a range of elements by path`() {
+        // given
+        val target = createTreeWithStyledParagraphs()
+        assertEquals(
+            """<doc><p bold="true" italic="true">a</p><p bold="true" italic="true">b</p></doc>""",
+            target.toXml(),
+        )
+
+        // when
+        target.removeStyleByPath(listOf(0), listOf(2), listOf("italic"))
+
+        // then
+        assertEquals(
+            """<doc><p bold="true">a</p><p bold="true">b</p></doc>""",
+            target.toXml(),
+        )
+    }
+
+    @Test
+    fun `should remove style from multiple elements across a range by path`() {
+        // given
+        val target = createTreeWithBoldParagraphs()
+        assertEquals(
+            """<doc><p bold="true">ab</p><p bold="true">cd</p></doc>""",
+            target.toXml(),
+        )
+
+        // when
+        target.removeStyleByPath(listOf(0), listOf(2), listOf("bold"))
+
+        // then
+        assertEquals(
+            "<doc><p>ab</p><p>cd</p></doc>",
+            target.toXml(),
+        )
+    }
+
+    @Test
+    fun `should throw on mismatched path lengths for range styleByPath`() {
+        val target = createTreeWithSingleParagraph()
+        assertThrows(IllegalArgumentException::class.java) {
+            target.styleByPath(listOf(0), listOf(0, 0), mapOf("bold" to "true"))
+        }
+    }
+
+    @Test
+    fun `should throw on empty paths for range styleByPath`() {
+        val target = createTreeWithSingleParagraph()
+        assertThrows(IllegalArgumentException::class.java) {
+            target.styleByPath(emptyList(), emptyList(), mapOf("bold" to "true"))
+        }
+    }
+
+    @Test
+    fun `should throw on mismatched path lengths for removeStyleByPath`() {
+        val target = createTreeWithSingleParagraph()
+        assertThrows(IllegalArgumentException::class.java) {
+            target.removeStyleByPath(listOf(0), listOf(0, 0), listOf("bold"))
+        }
+    }
+
+    @Test
+    fun `should throw on empty paths for removeStyleByPath`() {
+        val target = createTreeWithSingleParagraph()
+        assertThrows(IllegalArgumentException::class.java) {
+            target.removeStyleByPath(emptyList(), emptyList(), listOf("bold"))
+        }
+    }
+
+    @Test
     fun `should emit Tree edit operations accordingly when edited with index`() = runTest {
         val document = Document("")
         fun JsonObject.tree() = getAs<JsonTree>("t")
@@ -1022,6 +1149,85 @@ class JsonTreeTest {
                         }
                         attr { "a" to "b" }
                     }
+                }
+            }
+            return JsonTree(
+                DummyContext,
+                CrdtTree(JsonTree.buildRoot(root, DummyContext), InitialTimeTicket),
+            )
+        }
+
+        private fun createTreeWithSingleParagraph(): JsonTree {
+            val root = element("doc") {
+                element("p") {
+                    text { "hello" }
+                }
+            }
+            return JsonTree(
+                DummyContext,
+                CrdtTree(JsonTree.buildRoot(root, DummyContext), InitialTimeTicket),
+            )
+        }
+
+        private fun createTreeWithMultipleParagraphs(): JsonTree {
+            val root = element("doc") {
+                element("p") {
+                    text { "a" }
+                    attr { "weight" to "bold" }
+                }
+                element("p") {
+                    text { "b" }
+                }
+            }
+            return JsonTree(
+                DummyContext,
+                CrdtTree(JsonTree.buildRoot(root, DummyContext), InitialTimeTicket),
+            )
+        }
+
+        private fun createTreeWithTwoParagraphs(): JsonTree {
+            val root = element("doc") {
+                element("p") {
+                    text { "ab" }
+                }
+                element("p") {
+                    text { "cd" }
+                }
+            }
+            return JsonTree(
+                DummyContext,
+                CrdtTree(JsonTree.buildRoot(root, DummyContext), InitialTimeTicket),
+            )
+        }
+
+        private fun createTreeWithStyledParagraphs(): JsonTree {
+            val root = element("doc") {
+                element("p") {
+                    text { "a" }
+                    attr { "bold" to "true" }
+                    attr { "italic" to "true" }
+                }
+                element("p") {
+                    text { "b" }
+                    attr { "bold" to "true" }
+                    attr { "italic" to "true" }
+                }
+            }
+            return JsonTree(
+                DummyContext,
+                CrdtTree(JsonTree.buildRoot(root, DummyContext), InitialTimeTicket),
+            )
+        }
+
+        private fun createTreeWithBoldParagraphs(): JsonTree {
+            val root = element("doc") {
+                element("p") {
+                    text { "ab" }
+                    attr { "bold" to "true" }
+                }
+                element("p") {
+                    text { "cd" }
+                    attr { "bold" to "true" }
                 }
             }
             return JsonTree(


### PR DESCRIPTION
> **RTCOLLABPLATFORM-659**: [Range-based styleByPath / removeStyleByPath for Tree](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-659)
> **JS reference:** [yorkie-js-sdk#1198](https://github.com/yorkie-team/yorkie-js-sdk/pull/1198)

## Summary
- Extend `JsonTree.styleByPath` to accept a path range `(fromPath, toPath, attributes)` as an overload alongside the existing single-path form.
- Add `JsonTree.removeStyleByPath(fromPath, toPath, attributesToRemove)` to remove attributes across a path range.
- Mirrors yorkie-js-sdk PR #1198. The CRDT layer, operation type, and wire format are unchanged - this is purely a JSON-API layer addition.

## Changes
- `JsonTree.styleByPath(fromPath, toPath, attributes)` - new range overload. Validates that `fromPath.size == toPath.size` and that neither is empty, then converts each path with `pathToPos` and delegates to the existing index-based `style` pipeline.
- `JsonTree.removeStyleByPath(fromPath, toPath, attributesToRemove)` - new range API. Same validation/path-to-pos pattern, delegates to the existing `removeStyle` pipeline.
- Single-path `styleByPath(path, attributes)` is preserved as an overload (backward-compatible), matching the JS PR's overload approach.
- Refactored an internal `removeStyleByRange` helper, mirroring the existing `styleByRange` helper.

## Test plan
- [x] Unit tests pass: `./gradlew yorkie:testDebugUnitTest` (`JsonTreeTest`: 34 tests, all green; 10 new tests covering range style/removeStyle, multi-element range, single-path backward compatibility, and the four error cases from JS)
- [x] Lint passes: `./gradlew lintKotlin`
- [x] Instrumented `JsonTreeTest` passes for new range-by-path sync tests (`test_sync_style_range_by_path`, `test_sync_remove_style_range_by_path`)

> Items run automatically by CI (lint, unit tests, coverage) are excluded.