### PR TITLE
Simplify Counter interface (Kotlin: keep Long)

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonCounter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonCounter.kt
@@ -7,11 +7,11 @@ import dev.yorkie.document.crdt.CrdtPrimitive
 import dev.yorkie.document.operation.IncreaseOperation
 
 /**
- * [JsonCounter] is a custom data type that is used to counter.
+ * [JsonCounter] is a numeric counter that supports [increase].
  *
- * When [isDedup] is true the counter is backed by a HyperLogLog sketch and only
- * supports [add], which records a unique actor. Otherwise it supports [increase]
- * with arbitrary integer or long deltas.
+ * For counting unique actors via HyperLogLog, use [JsonDedupCounter] instead.
+ * Splitting the two roles into separate classes makes invalid method calls
+ * (such as [add] on a numeric counter) compile-time errors.
  */
 public class JsonCounter internal constructor(
     internal val context: ChangeContext,
@@ -22,23 +22,20 @@ public class JsonCounter internal constructor(
         get() = target.value
 
     /**
-     * Returns true when this counter is in dedup mode.
+     * Increases this counter by [value] as an [Int] delta.
      */
-    public val isDedup: Boolean
-        get() = target.isDedup()
-
     public fun increase(value: Int): JsonCounter {
         return increaseInternal(value)
     }
 
+    /**
+     * Increases this counter by [value] as a [Long] delta.
+     */
     public fun increase(value: Long): JsonCounter {
         return increaseInternal(value)
     }
 
     private fun increaseInternal(value: CounterValue): JsonCounter {
-        check(!target.isDedup()) {
-            "dedup counter does not support increase(), use add(actor)"
-        }
         val ticket = context.issueTimeTicket()
         val counterValue = CrdtPrimitive(value, ticket)
         target.increase(counterValue)
@@ -47,34 +44,6 @@ public class JsonCounter internal constructor(
                 value = counterValue,
                 parentCreatedAt = target.createdAt,
                 executedAt = ticket,
-            ),
-        )
-        return this
-    }
-
-    /**
-     * Records a unique [actor] token in the dedup counter. Duplicate actors are
-     * ignored. Returns this [JsonCounter] for chaining.
-     *
-     * @throws IllegalStateException when the counter is not in dedup mode.
-     * @throws IllegalArgumentException when [actor] is empty.
-     */
-    public fun add(actor: String): JsonCounter {
-        check(target.isDedup()) {
-            "add() is only supported on dedup counters"
-        }
-        require(actor.isNotEmpty()) {
-            "actor is required"
-        }
-        val ticket = context.issueTimeTicket()
-        val counterValue = CrdtPrimitive(1, ticket)
-        target.increaseDedup(counterValue, actor)
-        context.push(
-            IncreaseOperation(
-                value = counterValue,
-                parentCreatedAt = target.createdAt,
-                executedAt = ticket,
-                actor = actor,
             ),
         )
         return this

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonDedupCounter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonDedupCounter.kt
@@ -1,0 +1,47 @@
+package dev.yorkie.document.json
+
+import dev.yorkie.document.change.ChangeContext
+import dev.yorkie.document.crdt.CrdtCounter
+import dev.yorkie.document.crdt.CrdtPrimitive
+import dev.yorkie.document.operation.IncreaseOperation
+
+/**
+ * [JsonDedupCounter] counts unique actors via an internal HyperLogLog sketch
+ * and exposes [add] to register one actor. Duplicate actors are ignored.
+ *
+ * For numeric increment counters, use [JsonCounter] instead. Keeping the two
+ * roles in separate classes makes invalid method calls (such as `increase`
+ * on a dedup counter) compile-time errors.
+ */
+public class JsonDedupCounter internal constructor(
+    internal val context: ChangeContext,
+    override val target: CrdtCounter,
+) : JsonElement() {
+
+    public val value: Int
+        get() = target.value.toInt()
+
+    /**
+     * Records a unique [actor] token in this dedup counter. Duplicate actors
+     * are ignored. Returns this [JsonDedupCounter] for chaining.
+     *
+     * @throws IllegalArgumentException when [actor] is empty.
+     */
+    public fun add(actor: String): JsonDedupCounter {
+        require(actor.isNotEmpty()) {
+            "actor is required"
+        }
+        val ticket = context.issueTimeTicket()
+        val counterValue = CrdtPrimitive(1, ticket)
+        target.increaseDedup(counterValue, actor)
+        context.push(
+            IncreaseOperation(
+                value = counterValue,
+                parentCreatedAt = target.createdAt,
+                executedAt = ticket,
+                actor = actor,
+            ),
+        )
+        return this
+    }
+}

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonElement.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonElement.kt
@@ -30,7 +30,6 @@ public abstract class JsonElement {
             CrdtArray::class.java to JsonArray::class.java,
             CrdtText::class.java to JsonText::class.java,
             CrdtPrimitive::class.java to JsonPrimitive::class.java,
-            CrdtCounter::class.java to JsonCounter::class.java,
             CrdtTree::class.java to JsonTree::class.java,
         )
 
@@ -38,9 +37,28 @@ public abstract class JsonElement {
             context: ChangeContext,
         ): T {
             val clazz = if (T::class.java == JsonElement::class.java) {
-                TypeMapper[this::class.java]
+                if (this is CrdtCounter) {
+                    if (isDedup()) JsonDedupCounter::class.java else JsonCounter::class.java
+                } else {
+                    TypeMapper[this::class.java]
+                }
             } else {
                 T::class.java
+            }
+            // Reject JsonCounter / JsonDedupCounter requests that do not match
+            // the underlying counter mode so that callers see a type error at
+            // access time rather than a runtime error on a later method call.
+            if (this is CrdtCounter) {
+                if (clazz == JsonCounter::class.java && isDedup()) {
+                    throw TypeCastException(
+                        "expected numeric counter but found dedup counter: $this",
+                    )
+                }
+                if (clazz == JsonDedupCounter::class.java && !isDedup()) {
+                    throw TypeCastException(
+                        "expected dedup counter but found numeric counter: $this",
+                    )
+                }
             }
             return try {
                 when (clazz) {
@@ -49,6 +67,8 @@ public abstract class JsonElement {
                     JsonText::class.java -> JsonText(context, this as CrdtText)
                     JsonPrimitive::class.java -> JsonPrimitive(this as CrdtPrimitive)
                     JsonCounter::class.java -> JsonCounter(context, this as CrdtCounter)
+                    JsonDedupCounter::class.java ->
+                        JsonDedupCounter(context, this as CrdtCounter)
                     JsonTree::class.java -> JsonTree(context, this as CrdtTree)
                     else -> throw TypeCastException("unknown CrdtElement type: $this")
                 } as T

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonObject.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonObject.kt
@@ -116,11 +116,11 @@ public class JsonObject internal constructor(
     }
 
     /**
-     * Creates a new dedup-mode [JsonCounter] at [key]. The counter is backed by a
-     * HyperLogLog sketch and counts unique actors via [JsonCounter.add]. Provides
-     * approximate counts with ~2% error.
+     * Creates a new dedup-mode [JsonDedupCounter] at [key]. The counter is
+     * backed by a HyperLogLog sketch and counts unique actors via
+     * [JsonDedupCounter.add]. Provides approximate counts with ~2% error.
      */
-    public fun setNewDedupCounter(key: String): JsonCounter {
+    public fun setNewDedupCounter(key: String): JsonDedupCounter {
         val createdAt = context.issueTimeTicket()
         val counter = CrdtCounter.createDedup(createdAt)
         setAndRegister(key, counter, createdAt)

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonCounterTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonCounterTest.kt
@@ -5,7 +5,6 @@ import dev.yorkie.document.Document
 import dev.yorkie.document.crdt.CrdtCounter.CounterType
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -61,7 +60,6 @@ class JsonCounterTest {
         // given - when
         document.updateAsync { root, _ ->
             val uv = root.setNewDedupCounter("uv")
-            assertTrue(uv.isDedup)
             uv.add("alice")
             uv.add("bob")
             uv.add("alice") // duplicate
@@ -69,29 +67,9 @@ class JsonCounterTest {
         }.await()
 
         // then
-        val uv = document.getRoot().getAs<JsonCounter>("uv")
+        val uv = document.getRoot().getAs<JsonDedupCounter>("uv")
         assertEquals(CounterType.IntDedup, uv.target.type)
         assertEquals(3, uv.value)
-    }
-
-    @Test
-    fun `dedup counter rejects increase()`() = runTest {
-        document.updateAsync { root, _ ->
-            val uv = root.setNewDedupCounter("uv")
-            assertFailsWith<IllegalStateException> {
-                uv.increase(1)
-            }
-        }.await()
-    }
-
-    @Test
-    fun `non-dedup counter rejects add(actor)`() = runTest {
-        document.updateAsync { root, _ ->
-            val pv = root.setNewCounter("pv", 0)
-            assertFailsWith<IllegalStateException> {
-                pv.add("alice")
-            }
-        }.await()
     }
 
     @Test
@@ -102,5 +80,31 @@ class JsonCounterTest {
                 uv.add("")
             }
         }.await()
+    }
+
+    @Test
+    fun `getAs JsonCounter on a dedup counter is rejected at runtime`() = runTest {
+        // given - a dedup counter is stored at the key
+        document.updateAsync { root, _ ->
+            root.setNewDedupCounter("uv")
+        }.await()
+
+        // when - then - accessing it as a numeric JsonCounter must fail
+        assertFailsWith<TypeCastException> {
+            document.getRoot().getAs<JsonCounter>("uv")
+        }
+    }
+
+    @Test
+    fun `getAs JsonDedupCounter on a numeric counter is rejected at runtime`() = runTest {
+        // given - a numeric counter is stored at the key
+        document.updateAsync { root, _ ->
+            root.setNewCounter("pv", 0)
+        }.await()
+
+        // when - then - accessing it as a dedup counter must fail
+        assertFailsWith<TypeCastException> {
+            document.getRoot().getAs<JsonDedupCounter>("pv")
+        }
     }
 }


### PR DESCRIPTION
> **RTCOLLABPLATFORM-661**: [Simplify Counter interface (Kotlin: keep Long)](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-661)
> **JS reference:** [yorkie-js-sdk#1216](https://github.com/yorkie-team/yorkie-js-sdk/pull/1216)

## Summary

JS PR #1216 splits `Counter` and `DedupCounter` into independent classes so that invalid method calls (`increase()` on a dedup counter, `add()` on a numeric counter) are caught at compile time. This PR mirrors that design on Android while honouring the JIRA directive **"Kotlin: keep Long"** — the underlying `CounterType` (Int, Long, IntDedup) is preserved for wire-format compatibility, and the simplification is confined to the user-facing JSON layer.

## Changes

- **`JsonCounter`** is now numeric-only — exposes only `value`, `increase(Int)`, `increase(Long)`. The previous `add(actor)` method and `isDedup` flag are gone.
- **`JsonDedupCounter`** is a new sibling class — exposes only `value` (as `Int`) and `add(actor)`. It is returned by `JsonObject.setNewDedupCounter` and by `getAs<JsonDedupCounter>`.
- **`JsonElement.toJsonElement`** dispatches between the two wrappers based on `CrdtCounter.isDedup()`. A mismatched `getAs<JsonCounter>` on a dedup CRDT (or `getAs<JsonDedupCounter>` on a numeric CRDT) now throws `TypeCastException` at access time instead of failing later inside `CrdtCounter`.
- **`JsonCounterTest`** updated — dedup tests use `JsonDedupCounter` directly, and two new tests cover the `getAs` mismatch behaviour. The previously runtime-only "dedup rejects `increase()`" and "numeric rejects `add()`" tests are no longer needed because the methods do not exist on the wrong class (compile-time guard).

## Wire-format compatibility

- **No change** to `CounterType` (`Int`, `Long`, `IntDedup`), to proto value types (`VALUE_TYPE_INTEGER_CNT`, `VALUE_TYPE_LONG_CNT`, `VALUE_TYPE_INTEGER_DEDUP_CNT`), or to converters in `ElementConverter.kt`. Documents stored before this change continue to read and write identically.
- The `long` library swap that JS did is JS-only (Kotlin already uses native `Long`).

## Breaking changes

- `JsonObject.setNewDedupCounter(key)` now returns `JsonDedupCounter` instead of `JsonCounter`. Callers that previously held the result as `JsonCounter` must use `JsonDedupCounter` instead. No deprecated aliases were kept — the whole point of the change is compile-time safety, and an alias would defeat that.
- `JsonCounter.add(actor)` and `JsonCounter.isDedup` are removed. The only call sites in this repo were in `JsonCounterTest`, which is updated. No production code or example apps were affected.
- `getAs<JsonCounter>("...")` on a key holding a dedup CRDT now throws `TypeCastException` instead of silently constructing a `JsonCounter` wrapper that would fail later inside `CrdtCounter.increase`.

## Test plan

- [x] Unit tests pass — `./gradlew yorkie:testDebugUnitTest` (439 tests, 0 failures)
- [x] Lint passes — `./gradlew lintKotlin`
- [x] Instrumented counter tests pass — `DocumentTest` (11), `ClientTest` (14), `UndoRedoTest` (9) on `Pixel_3_API_33`

> Items run automatically by CI (lint, unit tests, coverage) are excluded from the manual list.