### PR TITLE
fix(example): crash when navigating back from rich-text-editor Editor screen

### DIFF
--- a/examples/rich-text-editor/src/main/java/dev/yorkie/example/richtexteditor/ui/richtexteditor/EditorViewModel.kt
+++ b/examples/rich-text-editor/src/main/java/dev/yorkie/example/richtexteditor/ui/richtexteditor/EditorViewModel.kt
@@ -278,15 +278,18 @@ class EditorViewModel(
         val content = document.getRoot().getAsOrNull<JsonText>(CONTENT)
         val newStyleOperations = ArrayList<OperationInfo.StyleOpInfo>()
         var idx = 0
-        content?.values?.forEach { textWithAttributes ->
-            newStyleOperations.add(
-                OperationInfo.StyleOpInfo(
-                    from = idx,
-                    to = idx + textWithAttributes.text.length,
-                    attributes = textWithAttributes.attributes,
-                ),
-            )
-            idx += textWithAttributes.text.length
+        try {
+            content?.values?.forEach { textWithAttributes ->
+                newStyleOperations.add(
+                    OperationInfo.StyleOpInfo(
+                        from = idx,
+                        to = idx + textWithAttributes.text.length,
+                        attributes = textWithAttributes.attributes,
+                    ),
+                )
+                idx += textWithAttributes.text.length
+            }
+        } catch (_: Exception) {
         }
 
         // Adjust local text selection based on remote edits
@@ -617,8 +620,13 @@ class EditorViewModel(
 
     override fun onCleared() {
         TerminationScope.launch {
-            client.detachDocument(document).await()
-            client.deactivateAsync().await()
+            try {
+                client.detachDocument(document).await()
+                client.deactivateAsync().await()
+            } catch (_: Exception) {
+            } finally {
+                client.close()
+            }
         }
         super.onCleared()
     }


### PR DESCRIPTION
## What

Re-applies the fix for a crash that occurs when navigating back from the rich-text-editor example's Editor screen.

`EditorViewModel` is hardened in two places:
- The remote-style reconciliation loop (`content?.values?.forEach { ... }`) is wrapped in `try/catch`, so a teardown race on the document content can't crash the screen.
- `onCleared()` wraps `detachDocument()` / `deactivateAsync()` in `try/catch/finally` and always calls `client.close()` in `finally`, so the client is released cleanly even if detach/deactivate throws during teardown.

## Why

This fix previously landed on `develop` (commit `a4e000f0`, "Fix crash when back from Editor screen") but is no longer present after `develop` was rebuilt — the current `EditorViewModel.kt` had regressed to the pre-fix version. This PR cherry-picks the original commit verbatim (1 file, +19/-11).

## Test plan

- Open the rich-text-editor example → enter the Editor screen → press back. Previously this could crash during `onCleared()` teardown; with this change the client closes cleanly.
