### PR TITLE
RTCOLLABPLATFORM-712: Sync-up Yorkie JS SDK v0.7.6 - Part 1

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -142,7 +142,8 @@ public class Client(
     // suppresses errors from in-flight RPCs. Volatile because the keepalive deactivate
     // path runs on a different thread (GlobalScope + Dispatchers.IO).
     @Volatile
-    private var deactivating = false
+    @VisibleForTesting
+    internal var deactivating = false
 
     private val _status = MutableStateFlow<Status>(Status.Deactivated)
     public val status = _status.asStateFlow()

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -138,6 +138,12 @@ public class Client(
 
     private val attachments = ConcurrentHashMap<String, Attachment<out Attachable>>()
 
+    // Set immediately when deactivate is requested so the sync loop exits early and
+    // suppresses errors from in-flight RPCs. Volatile because the keepalive deactivate
+    // path runs on a different thread (GlobalScope + Dispatchers.IO).
+    @Volatile
+    private var deactivating = false
+
     private val _status = MutableStateFlow<Status>(Status.Deactivated)
     public val status = _status.asStateFlow()
 
@@ -227,6 +233,7 @@ public class Client(
                 return@async Result.failure(it)
             }
             _status.emit(Status.Activated(activateResponse.clientId))
+            deactivating = false
             runSyncLoop()
             SUCCESS
         }
@@ -240,11 +247,16 @@ public class Client(
         conditions[ClientCondition.SYNC_LOOP] = true
         scope.launch(activationJob) {
             while (true) {
-                if (!isActive) {
+                if (!isActive || deactivating) {
                     conditions[ClientCondition.SYNC_LOOP] = false
                     return@launch
                 }
                 for ((_, attachment) in attachments) {
+                    // Stop syncing if the client is being deactivated.
+                    if (deactivating) {
+                        break
+                    }
+
                     val heartbeatInterval = options.channelHeartbeatInterval.inWholeMilliseconds
                     if (!attachment.needSync(heartbeatInterval)) {
                         continue
@@ -256,6 +268,11 @@ public class Client(
                     }
 
                     val (attachment, result) = syncInternal(attachment, attachment.syncMode)
+                    // Suppress sync errors from in-flight RPCs once deactivation started.
+                    if (deactivating) {
+                        conditions[ClientCondition.SYNC_LOOP] = false
+                        return@launch
+                    }
                     val isRetryAble = handleConnectException(
                         result.exceptionOrNull() as? ConnectException,
                     ) { connectException ->
@@ -1151,6 +1168,11 @@ public class Client(
             return CompletableDeferred(SUCCESS)
         }
 
+        // Mark as deactivating synchronously, before the task is dispatched, so an
+        // already-queued sync-loop iteration on the same dispatcher observes it and
+        // stops before sending another RPC.
+        deactivating = true
+
         val task = suspend {
             activationJob.cancelChildren()
             try {
@@ -1167,6 +1189,7 @@ public class Client(
                 deactivateInternal()
                 SUCCESS
             } catch (e: ConnectException) {
+                deactivating = false
                 handleConnectException(e) { exception ->
                     if (errorCodeOf(exception) == ErrUnauthenticated.codeString) {
                         shouldRefreshToken = true

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -686,11 +686,25 @@ internal data class CrdtTree(
         )
 
         val (from, diffFrom) = findNodesAndSplitText(range.first, executedAt)
-        val (fromParent, fromLeft) = from
+        val (fromParent, fromLeftRaw) = from
         val (to, diffTo) = findNodesAndSplitText(range.second, executedAt)
-        val (toParent, toLeft) = to
+        val (toParent, toLeftRaw) = to
 
         diff = addDataSizes(diff, diffTo, diffFrom)
+
+        // Advance past split siblings the editor did not know about so range
+        // boundaries land after every unseen split product, matching style().
+        // Skip when leftRaw equals the parent (leftmost-child sentinel).
+        val fromLeft = if (fromLeftRaw === fromParent) {
+            fromLeftRaw
+        } else {
+            advancePastUnknownSplitSiblings(fromLeftRaw, versionVector)
+        }
+        val toLeft = if (toLeftRaw === toParent) {
+            toLeftRaw
+        } else {
+            advancePastUnknownSplitSiblings(toLeftRaw, versionVector)
+        }
 
         val changes = mutableListOf<TreeChange>()
         val gcPairs = mutableListOf<GCPair<RhtNode>>()
@@ -1286,6 +1300,10 @@ internal data class CrdtTreeNode(
         return copy(
             id = CrdtTreeNodeID(createdAt, offset),
             _value = null,
+            // Deep-copy attributes so a split node keeps its own styling and a
+            // concurrent style operation whose range was computed before the
+            // split also covers the right part of the split.
+            _attributes = _attributes.deepCopy(),
             childNodes = IndexTreeNodeList(mutableListOf()),
         ).apply {
             removedAt = this@CrdtTreeNode.removedAt

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -181,6 +181,51 @@ internal data class CrdtTree(
                         diff = addDataSizes(diff, curr.dataSize)
                     }
                 }
+
+                // Propagate style to unknown split siblings so that a style
+                // operation whose range was determined before the split also
+                // covers the right part of the split. Mirrors JS SDK PR #1224.
+                if (tokenType == TokenType.Start && versionVector != null) {
+                    var current = node
+                    while (true) {
+                        val nextID = current.insNextID ?: break
+                        val next = findFloorNode(nextID) ?: break
+                        if (next.isText) break
+                        if (isSplitSiblingKnown(next, versionVector)) break
+
+                        val siblingPairs = next.setAttributes(attributes, executedAt)
+                        val siblingAffectedAttrs =
+                            siblingPairs.fold(emptyMap<String, String>()) { acc, pair ->
+                                val curr = pair.new
+                                acc + curr?.let {
+                                    mapOf(curr.key to attributes[curr.key].orEmpty())
+                                }.orEmpty()
+                            }
+                        if (siblingAffectedAttrs.isNotEmpty()) {
+                            val parentOfNext = requireNotNull(next.parent)
+                            val previousNext = next.prevSibling ?: parentOfNext
+                            TreeChange(
+                                type = TreeChangeType.Style,
+                                from = toIndex(parentOfNext, previousNext),
+                                to = toIndex(next, next),
+                                fromPath = toPath(parentOfNext, previousNext),
+                                toPath = toPath(next, next),
+                                actorID = executedAt.actorID,
+                                attributes = siblingAffectedAttrs,
+                            ).let(changes::add)
+                        }
+                        siblingPairs.forEach { (prev, _) ->
+                            prev?.let { gcPairs.add(GCPair(next, prev)) }
+                        }
+                        for ((key, _) in attributes) {
+                            val curr = next.getAttrs().getNodeMapByKey()[key]
+                            if (curr != null) {
+                                diff = addDataSizes(diff, curr.dataSize)
+                            }
+                        }
+                        current = next
+                    }
+                }
             }
         }
         return TreeOperationResult(
@@ -754,6 +799,41 @@ internal data class CrdtTree(
                     actorID = executedAt.actorID,
                     attributesToRemove = attributeToRemove,
                 ).let(changes::add)
+
+                // Propagate remove-style to unknown split siblings so a
+                // remove-style whose range was determined before the split
+                // also covers the right part. Mirrors JS SDK PR #1224.
+                if (tokenType == TokenType.Start && versionVector != null) {
+                    var current = node
+                    while (true) {
+                        val nextID = current.insNextID ?: break
+                        val next = findFloorNode(nextID) ?: break
+                        if (next.isText) break
+                        if (isSplitSiblingKnown(next, versionVector)) break
+
+                        var removedAny = false
+                        attributeToRemove.forEach { key ->
+                            val removed = next.removeAttribute(key, executedAt)
+                            if (removed.isNotEmpty()) removedAny = true
+                            removed.map { rhtNode -> GCPair(next, rhtNode) }
+                                .let(gcPairs::addAll)
+                        }
+                        if (removedAny) {
+                            val parentOfNext = requireNotNull(next.parent)
+                            val previousNext = next.prevSibling ?: parentOfNext
+                            TreeChange(
+                                type = TreeChangeType.RemoveStyle,
+                                from = toIndex(parentOfNext, previousNext),
+                                to = toIndex(next, next),
+                                fromPath = toPath(parentOfNext, previousNext),
+                                toPath = toPath(next, next),
+                                actorID = executedAt.actorID,
+                                attributesToRemove = attributeToRemove,
+                            ).let(changes::add)
+                        }
+                        current = next
+                    }
+                }
             }
         }
         return TreeOperationResult(changes, gcPairs, diff, prevAttributes = prevAttributes)
@@ -905,6 +985,17 @@ internal data class CrdtTree(
 
             current = next
         }
+    }
+
+    /**
+     * Returns true when the creation of the split sibling [node] is known to
+     * the given [versionVector]. Mirrors JS SDK `ticketKnown`. Used to stop
+     * propagating a style/remove-style along the [CrdtTreeNode.insNextID] chain
+     * once a sibling the editor already knew about is reached.
+     */
+    private fun isSplitSiblingKnown(node: CrdtTreeNode, versionVector: VersionVector): Boolean {
+        val knownLamport = versionVector.get(node.createdAt.actorID) ?: return false
+        return knownLamport >= node.createdAt.lamport
     }
 
     private fun hasUnknownSplitSibling(node: CrdtTreeNode, versionVector: VersionVector): Boolean {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -197,9 +197,7 @@ internal data class CrdtTree(
                         val siblingAffectedAttrs =
                             siblingPairs.fold(emptyMap<String, String>()) { acc, pair ->
                                 val curr = pair.new
-                                acc + curr?.let {
-                                    mapOf(curr.key to attributes[curr.key].orEmpty())
-                                }.orEmpty()
+                                acc + curr?.let { mapOf(curr.key to curr.value) }.orEmpty()
                             }
                         if (siblingAffectedAttrs.isNotEmpty()) {
                             val parentOfNext = requireNotNull(next.parent)
@@ -218,10 +216,10 @@ internal data class CrdtTree(
                             prev?.let { gcPairs.add(GCPair(next, prev)) }
                         }
                         for ((key, _) in attributes) {
-                            val curr = next.getAttrs().getNodeMapByKey()[key]
-                            if (curr != null) {
-                                diff = addDataSizes(diff, curr.dataSize)
-                            }
+                            // The RHT always retains an entry for a key that was just
+                            // set (the new node or the LWW-winning previous one).
+                            val curr = next.getAttrs().getNodeMapByKey().getValue(key)
+                            diff = addDataSizes(diff, curr.dataSize)
                         }
                         current = next
                     }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonStringifier.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonStringifier.kt
@@ -8,7 +8,10 @@ import dev.yorkie.document.crdt.CrdtObject
 import dev.yorkie.document.crdt.CrdtPrimitive
 import dev.yorkie.document.crdt.CrdtText
 import dev.yorkie.document.crdt.CrdtTree
+import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 
 internal object JsonStringifier {
 
@@ -24,8 +27,10 @@ internal object JsonStringifier {
                 buffer.append(
                     when (type) {
                         CrdtPrimitive.Type.String -> """"${escapeString(value as String)}""""
-                        CrdtPrimitive.Type.Bytes -> """"${(value as ByteString).toStringUtf8()}""""
-                        CrdtPrimitive.Type.Date -> (value as Date).time.toString()
+                        CrdtPrimitive.Type.Bytes ->
+                            """"${encodeBase64((value as ByteString).toByteArray())}""""
+                        CrdtPrimitive.Type.Date ->
+                            """"${isoDateFormat().format(value as Date)}""""
                         else -> "$value"
                     },
                 )
@@ -71,5 +76,41 @@ internal object JsonStringifier {
                 buffer.append(rootTreeNode)
             }
         }
+    }
+
+    /**
+     * Returns an ISO 8601 formatter (UTC, millisecond precision) matching the JS SDK's
+     * `Date.toISOString()`. A fresh instance is returned per call because [SimpleDateFormat]
+     * is not thread-safe.
+     */
+    private fun isoDateFormat(): SimpleDateFormat {
+        return SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+    }
+
+    /**
+     * Encodes the given bytes as a standard, padded Base64 string, matching the JS SDK's
+     * `btoa(...)`. Implemented in pure Kotlin so it works in JVM unit tests and on every
+     * supported Android API level ([android.util.Base64] is unavailable off-device and
+     * [java.util.Base64] requires API 26 while the SDK targets API 24).
+     */
+    private fun encodeBase64(bytes: ByteArray): String {
+        if (bytes.isEmpty()) return ""
+        val alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+        val builder = StringBuilder((bytes.size + 2) / 3 * 4)
+        var i = 0
+        while (i < bytes.size) {
+            val b0 = bytes[i].toInt() and 0xFF
+            val b1 = if (i + 1 < bytes.size) bytes[i + 1].toInt() and 0xFF else 0
+            val b2 = if (i + 2 < bytes.size) bytes[i + 2].toInt() and 0xFF else 0
+            val triple = (b0 shl 16) or (b1 shl 8) or b2
+            builder.append(alphabet[triple shr 18 and 0x3F])
+            builder.append(alphabet[triple shr 12 and 0x3F])
+            builder.append(if (i + 1 < bytes.size) alphabet[triple shr 6 and 0x3F] else '=')
+            builder.append(if (i + 2 < bytes.size) alphabet[triple and 0x3F] else '=')
+            i += 3
+        }
+        return builder.toString()
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
@@ -44,6 +44,12 @@ internal data class SetOperation(
             val removed = parentObject.set(key, copiedValue, executedAt)
             root.registerElement(copiedValue, parentObject)
             removed?.let(root::registerRemovedElement)
+            // When the new value already has a removedAt (i.e. it was the LWW-losing side
+            // of a concurrent set), register it as removed so GC can collect it once all
+            // peers have seen the winning value.
+            if (copiedValue.isRemoved) {
+                root.registerRemovedElement(copiedValue)
+            }
 
             val reverseOp = if (previousValue != null) {
                 SetOperation(key, previousValue.deepCopy(), parentCreatedAt, executedAt)

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -16,6 +16,7 @@ import dev.yorkie.api.v1.YorkieServiceClientInterface
 import dev.yorkie.api.v1.deactivateClientResponse
 import dev.yorkie.assertJsonContentEquals
 import dev.yorkie.core.Client.SyncMode.Manual
+import dev.yorkie.core.Client.SyncMode.RealtimePushOnly
 import dev.yorkie.core.MockYorkieService.Companion.ATTACH_ERROR_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.AUTH_ERROR_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.DETACH_ERROR_DOCUMENT_KEY
@@ -48,6 +49,7 @@ import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.unmockkStatic
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
@@ -57,6 +59,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -174,6 +177,108 @@ class ClientTest {
             target.detachDocument(document).await()
             target.deactivateAsync().await()
             document.close()
+        }
+    }
+
+    @Test
+    fun `should stop sync loop when client status is not activated`() = runTest {
+        runBlocking {
+            // given an active client with a running sync loop
+            target.activateAsync().await()
+            assertTrue(target.conditions[Client.ClientCondition.SYNC_LOOP]!!)
+            val activated = target.status.value
+
+            // when the status flips to deactivated while the loop is still alive
+            target.forceStatus(Client.Status.Deactivated)
+            delay(1_000)
+
+            // then the sync loop observes the status and stops
+            assertFalse(target.conditions[Client.ClientCondition.SYNC_LOOP]!!)
+
+            target.forceStatus(activated)
+            target.deactivateAsync().await()
+        }
+    }
+
+    @Test
+    fun `should suppress sync result when deactivation starts during sync`() = runTest {
+        runBlocking {
+            mockkStatic(Base64::class)
+            every { Base64.encodeToString(any(), any()) } returns "mockk"
+
+            // given an attached document whose sync RPC raises the deactivating flag
+            // mid-flight, as the keepalive deactivate path does from another thread
+            val armed = AtomicBoolean(false)
+            val document = Document(NORMAL_DOCUMENT_KEY)
+            target.activateAsync().await()
+            coEvery { service.pushPullChanges(any(), any()) } coAnswers {
+                if (armed.get()) {
+                    target.deactivating = true
+                }
+                callOriginal()
+            }
+            target.attachDocument(document).await()
+            assertTrue(target.conditions[Client.ClientCondition.SYNC_LOOP]!!)
+
+            // when a local change triggers a sync during which the flag is raised
+            armed.set(true)
+            document.updateAsync { root, _ ->
+                root.setNewText("text")
+            }.await()
+            delay(1_000)
+
+            // then the loop drops the in-flight result and stops
+            assertFalse(target.conditions[Client.ClientCondition.SYNC_LOOP]!!)
+
+            armed.set(false)
+            target.deactivating = false
+            target.detachDocument(document).await()
+            target.deactivateAsync().await()
+            document.close()
+
+            unmockkStatic(Base64::class)
+        }
+    }
+
+    @Test
+    fun `should stop iterating attachments when client is deactivating`() = runTest {
+        runBlocking {
+            // given two attached push-only documents that raise the deactivating flag
+            // from within the sync loop's own needSync check once armed, so the loop
+            // observes the flag between two attachments of a single iteration
+            val armed = AtomicBoolean(false)
+            val documents = listOf(
+                spyk(Document(NORMAL_DOCUMENT_KEY)),
+                spyk(Document(ATTACHMENT_LOOP_DOCUMENT_KEY)),
+            ).onEach { document ->
+                every { document.hasLocalChanges() } answers {
+                    if (armed.get()) {
+                        target.deactivating = true
+                    }
+                    false
+                }
+            }
+
+            target.activateAsync().await()
+            documents.forEach { document ->
+                target.attachDocument(document, syncMode = RealtimePushOnly).await()
+            }
+            assertTrue(target.conditions[Client.ClientCondition.SYNC_LOOP]!!)
+
+            // when the flag is raised mid-iteration
+            armed.set(true)
+            delay(1_000)
+
+            // then the loop breaks out of the attachment iteration and stops
+            assertFalse(target.conditions[Client.ClientCondition.SYNC_LOOP]!!)
+
+            armed.set(false)
+            target.deactivating = false
+            documents.forEach { document ->
+                target.detachDocument(document).await()
+            }
+            target.deactivateAsync().await()
+            documents.forEach(Document::close)
         }
     }
 
@@ -648,11 +753,24 @@ class ClientTest {
         assertEquals(TEST_ACTOR_ID, clientId)
     }
 
+    /**
+     * Forces the client's status without going through activation or deactivation,
+     * so tests can observe how running loops react to a status change alone.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun Client.forceStatus(status: Client.Status) {
+        val field = Client::class.java.getDeclaredField("_status")
+        field.isAccessible = true
+        (field.get(this) as MutableStateFlow<Client.Status>).value = status
+    }
+
     private fun assertIsInitialChangePack(initialChangePack: ChangePack, changePack: PBChangePack) {
         assertEquals(initialChangePack, changePack.toChangePack())
     }
 
     companion object {
+        private const val ATTACHMENT_LOOP_DOCUMENT_KEY = "ATTACHMENT_LOOP_DOCUMENT_KEY"
+
         private fun createInitialChangePack(
             changesVersionVector: VersionVector = INITIAL_VERSION_VECTOR,
             changePackVersionVector: VersionVector = INITIAL_VERSION_VECTOR,

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -3,6 +3,7 @@ package dev.yorkie.core
 import android.util.Base64
 import com.connectrpc.Code
 import com.connectrpc.ConnectException
+import com.connectrpc.ResponseMessage
 import dev.yorkie.api.PBChangePack
 import dev.yorkie.api.toChangePack
 import dev.yorkie.api.v1.ActivateClientRequest
@@ -12,6 +13,7 @@ import dev.yorkie.api.v1.DetachDocumentRequest
 import dev.yorkie.api.v1.PushPullChangesRequest
 import dev.yorkie.api.v1.RemoveDocumentRequest
 import dev.yorkie.api.v1.YorkieServiceClientInterface
+import dev.yorkie.api.v1.deactivateClientResponse
 import dev.yorkie.assertJsonContentEquals
 import dev.yorkie.core.Client.SyncMode.Manual
 import dev.yorkie.core.MockYorkieService.Companion.ATTACH_ERROR_DOCUMENT_KEY
@@ -39,6 +41,7 @@ import dev.yorkie.document.time.VersionVector.Companion.INITIAL_VERSION_VECTOR
 import dev.yorkie.util.YorkieException
 import dev.yorkie.util.YorkieException.Code.ErrDocumentNotAttached
 import dev.yorkie.util.handleConnectException
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockkStatic
@@ -122,6 +125,56 @@ class ClientTest {
         assertIsTestActorID(deactivateRequestCaptor.captured.clientId)
         assertFalse(target.isActive)
         assertIs<Client.Status.Deactivated>(target.status.value)
+    }
+
+    @Test
+    fun `should keep client active when deactivate fails with connect exception`() = runTest {
+        // given an active client whose deactivate RPC fails
+        target.activateAsync().await()
+        coEvery { service.deactivateClient(any(), any()) } returns ResponseMessage.Failure(
+            ConnectException(Code.FAILED_PRECONDITION),
+            emptyMap(),
+            emptyMap(),
+        )
+
+        // when
+        val result = target.deactivateAsync().await()
+
+        // then the failure is reported and the client stays active
+        assertTrue(result.isFailure)
+        assertTrue(target.isActive)
+
+        // and a later deactivate succeeds once the RPC recovers
+        coEvery { service.deactivateClient(any(), any()) } returns ResponseMessage.Success(
+            deactivateClientResponse { },
+            emptyMap(),
+            emptyMap(),
+        )
+        assertTrue(target.deactivateAsync().await().isSuccess)
+        assertFalse(target.isActive)
+    }
+
+    @Test
+    fun `should stop sync loop when client is deactivating`() = runTest {
+        runBlocking {
+            // given an active client with an attached document and a running sync loop
+            val document = Document(NORMAL_DOCUMENT_KEY)
+            target.activateAsync().await()
+            target.attachDocument(document).await()
+            assertTrue(target.conditions[Client.ClientCondition.SYNC_LOOP]!!)
+
+            // when marking the client as deactivating without cancelling the loop
+            target.deactivating = true
+            delay(1_000)
+
+            // then the sync loop observes the flag and stops
+            assertFalse(target.conditions[Client.ClientCondition.SYNC_LOOP]!!)
+
+            target.deactivating = false
+            target.detachDocument(document).await()
+            target.deactivateAsync().await()
+            document.close()
+        }
     }
 
     @Test

--- a/yorkie/src/test/kotlin/dev/yorkie/document/DocumentSizeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/DocumentSizeTest.kt
@@ -17,7 +17,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
-import org.junit.Ignore
 
 class DocumentSizeTest {
     private lateinit var document: Document
@@ -678,7 +677,6 @@ class DocumentSizeTest {
     }
 
     @Test
-    @Ignore("should be resolved after the JS SDK implementation")
     fun `test split tree node with attribute`() {
         val attributes = Rht().apply {
             set("bold", "true", TimeTicket.InitialTimeTicket)

--- a/yorkie/src/test/kotlin/dev/yorkie/document/DocumentTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/DocumentTest.kt
@@ -118,9 +118,9 @@ class DocumentTest {
                             "k4": 100,
                             "k5": 111.11,
                             "k6": "test string\n\n",
-                            "k7": "bytes",
-                            "k8": 1000,
-                            "k9": [true, 1, 100, 111.111, "test", "bytes", 10000, {"k1": 1}, [1, 2]],
+                            "k7": "Ynl0ZXM=",
+                            "k8": "1970-01-01T00:00:01.000Z",
+                            "k9": [true, 1, 100, 111.111, "test", "Ynl0ZXM=", "1970-01-01T00:00:10.000Z", {"k1": 1}, [1, 2]],
                             "int": 100,
                             "long": 100,
                             "text": [{"attrs":{"b":"1"},"val":"H"},{"val":"ello World"}]

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtRootTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtRootTest.kt
@@ -2,6 +2,8 @@ package dev.yorkie.document.crdt
 
 import dev.yorkie.document.change.ChangeContext
 import dev.yorkie.document.change.ChangeID
+import dev.yorkie.document.operation.OpSource
+import dev.yorkie.document.operation.SetOperation
 import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.VersionVector
 import org.junit.Assert.assertEquals
@@ -99,5 +101,40 @@ class CrdtRootTest {
         root.registerRemovedElement(obj["k1"])
         root.registerRemovedElement(obj["k2"])
         root.garbageCollect(VersionVector.INITIAL_VERSION_VECTOR)
+    }
+
+    @Test
+    fun `should register LWW-losing element in GC set on Set conflict`() {
+        // given
+        val root = CrdtRoot(CrdtObject(TimeTicket.InitialTimeTicket, memberNodes = ElementRht()))
+        val actorA = "000000000000000000000001"
+        val actorB = "000000000000000000000002"
+        // actorB > actorA, so actorB wins LWW when lamport is equal.
+        val ticketA = TimeTicket(lamport = 1, delimiter = 0u, actorID = actorA)
+        val ticketB = TimeTicket(lamport = 1, delimiter = 0u, actorID = actorB)
+
+        // when actorA sets "key" = 1
+        SetOperation("key", CrdtPrimitive(1, ticketA), TimeTicket.InitialTimeTicket, ticketA)
+            .execute(root, OpSource.Remote, null)
+
+        // then no garbage yet
+        assertEquals(0, root.garbageLength)
+
+        // when actorB sets "key" = 2 (actorB wins, actorA is displaced)
+        SetOperation("key", CrdtPrimitive(2, ticketB), TimeTicket.InitialTimeTicket, ticketB)
+            .execute(root, OpSource.Remote, null)
+
+        // then the displaced actorA element is registered as garbage
+        assertEquals(1, root.garbageLength)
+        assertEquals("""{"key":2}""", root.rootObject.toJson())
+
+        // when actorA sets "key" = 3 (loses LWW to actorB's value)
+        val ticketA2 = TimeTicket(lamport = 1, delimiter = 1u, actorID = actorA)
+        SetOperation("key", CrdtPrimitive(3, ticketA2), TimeTicket.InitialTimeTicket, ticketA2)
+            .execute(root, OpSource.Remote, null)
+
+        // then the LWW-losing new value is also registered as garbage
+        assertEquals(2, root.garbageLength)
+        assertEquals("""{"key":2}""", root.rootObject.toJson())
     }
 }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTreeTest.kt
@@ -336,6 +336,42 @@ class CrdtTreeTest {
     }
 
     @Test
+    fun `should split element nodes with attributes`() {
+        //       0   1 2 3 4 5 6 7 8 9 10 11    12
+        // <root> <p> h e l l o w o r l  d  </p>  </root>
+        initializeTarget()
+        val para = CrdtTreeElement(issuePos(), "p").apply {
+            setAttributes(mapOf("bold" to "true"), issueTime())
+        }
+        target.edit(0 to 0, para.toList())
+        target.edit(1 to 1, CrdtTreeText(issuePos(), "helloworld").toList())
+        assertEquals("""<root><p bold="true">helloworld</p></root>""", target.toXml())
+
+        // Split at position 6 (after "hello"), splitLevel 1.
+        target.edit(6 to 6, null, 1)
+        assertEquals(
+            """<root><p bold="true">hello</p><p bold="true">world</p></root>""",
+            target.toXml(),
+        )
+    }
+
+    @Test
+    fun `should not share attributes between an element node and its split clone`() {
+        // given a styled element node
+        val original = CrdtTreeElement(issuePos(), "p").apply {
+            setAttributes(mapOf("bold" to "true"), issueTime())
+        }
+
+        // when cloning it (as split does) and mutating the clone's attribute
+        val clone = original.cloneElement(::issueTime)
+        clone.setAttributes(mapOf("bold" to "false"), issueTime())
+
+        // then the original keeps its own attribute — the RHT is not shared
+        assertEquals("true", original.attributes["bold"])
+        assertEquals("false", clone.attributes["bold"])
+    }
+
+    @Test
     fun `should split and merge element nodes by edit`() {
         target.edit(0 to 0, CrdtTreeElement(issuePos(), "p").toList())
         target.edit(1 to 1, CrdtTreeText(issuePos(), "abcd").toList())

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTreeTest.kt
@@ -3,6 +3,7 @@ package dev.yorkie.document.crdt
 import dev.yorkie.document.crdt.CrdtTreeNode.Companion.CrdtTreeElement
 import dev.yorkie.document.crdt.CrdtTreeNode.Companion.CrdtTreeText
 import dev.yorkie.document.time.TimeTicket
+import dev.yorkie.document.time.VersionVector
 import dev.yorkie.issueTime
 import dev.yorkie.util.IndexTreeNode.Companion.DEFAULT_TEXT_TYPE
 import org.junit.Assert.assertEquals
@@ -372,6 +373,213 @@ class CrdtTreeTest {
     }
 
     @Test
+    fun `should propagate style to a split sibling unknown to the operation`() {
+        // given a <p> split into two siblings, the second unknown to the styler
+        val tree = createSplitTree()
+
+        // when styling the first <p> with a version vector unaware of the split
+        tree.style(
+            tree.indexRangeToPosRange(0 to 2),
+            mapOf("bold" to "true"),
+            tick(6),
+            VersionVector(mapOf(ACTOR_A to 4L)),
+        )
+
+        // then the split-out sibling is styled as well
+        assertEquals(
+            """<root><p bold="true">a</p><p bold="true">b</p></root>""",
+            tree.toXml(),
+        )
+    }
+
+    @Test
+    fun `should not propagate style to a split sibling known to the operation`() {
+        // given a <p> split into two siblings, the second known to the styler
+        val tree = createSplitTree()
+
+        // when styling the first <p> with a version vector aware of the split
+        tree.style(
+            tree.indexRangeToPosRange(0 to 2),
+            mapOf("bold" to "true"),
+            tick(6),
+            VersionVector(mapOf(ACTOR_A to SPLIT_LAMPORT)),
+        )
+
+        // then only the first <p> is styled
+        assertEquals(
+            """<root><p bold="true">a</p><p>b</p></root>""",
+            tree.toXml(),
+        )
+    }
+
+    @Test
+    fun `should propagate style when the split sibling actor is missing from the version vector`() {
+        // given a <p> split by an actor absent from the styler's version vector
+        val tree = createSplitTree(splitActor = ACTOR_B)
+
+        // when styling the first <p>
+        tree.style(
+            tree.indexRangeToPosRange(0 to 2),
+            mapOf("bold" to "true"),
+            tick(6),
+            VersionVector(mapOf(ACTOR_A to 4L)),
+        )
+
+        // then the split-out sibling is styled as well
+        assertEquals(
+            """<root><p bold="true">a</p><p bold="true">b</p></root>""",
+            tree.toXml(),
+        )
+    }
+
+    @Test
+    fun `should skip propagation change when the split sibling attribute wins lww`() {
+        // given a split tree whose second sibling was styled with a newer ticket
+        val tree = createSplitTree()
+        tree.root.children[1].setAttributes(mapOf("bold" to "high"), tick(10))
+
+        // when styling the first <p> with an older ticket, unaware of the split
+        tree.style(
+            tree.indexRangeToPosRange(0 to 2),
+            mapOf("bold" to "low"),
+            tick(6),
+            VersionVector(mapOf(ACTOR_A to 4L)),
+        )
+
+        // then the sibling keeps its newer value
+        assertEquals(
+            """<root><p bold="low">a</p><p bold="high">b</p></root>""",
+            tree.toXml(),
+        )
+    }
+
+    @Test
+    fun `should re-style a split sibling whose attribute was removed`() {
+        // given a styled split tree whose attribute was removed on both siblings
+        val tree = createSplitTree(attributes = mapOf("bold" to "true"))
+        tree.removeStyle(
+            tree.indexRangeToPosRange(0 to 2),
+            listOf("bold"),
+            tick(6),
+            VersionVector(mapOf(ACTOR_A to 4L)),
+        )
+        assertEquals("<root><p>a</p><p>b</p></root>", tree.toXml())
+
+        // when styling the first <p> again, unaware of the split
+        val result = tree.style(
+            tree.indexRangeToPosRange(0 to 2),
+            mapOf("bold" to "false"),
+            tick(7),
+            VersionVector(mapOf(ACTOR_A to 4L)),
+        )
+
+        // then both siblings carry the new value and the tombstones are GC targets
+        assertEquals(
+            """<root><p bold="false">a</p><p bold="false">b</p></root>""",
+            tree.toXml(),
+        )
+        assertEquals(2, result.gcPairs.size)
+    }
+
+    @Test
+    fun `should propagate remove-style to a split sibling unknown to the operation`() {
+        // given a split tree whose siblings inherited the attribute from the split
+        val tree = createSplitTree(attributes = mapOf("bold" to "true"))
+        assertEquals(
+            """<root><p bold="true">a</p><p bold="true">b</p></root>""",
+            tree.toXml(),
+        )
+
+        // when removing the style from the first <p>, unaware of the split
+        val result = tree.removeStyle(
+            tree.indexRangeToPosRange(0 to 2),
+            listOf("bold"),
+            tick(6),
+            VersionVector(mapOf(ACTOR_A to 4L)),
+        )
+
+        // then the attribute is removed from the split-out sibling as well
+        assertEquals("<root><p>a</p><p>b</p></root>", tree.toXml())
+        assertEquals(2, result.gcPairs.size)
+    }
+
+    @Test
+    fun `should not propagate remove-style to a split sibling known to the operation`() {
+        // given a split tree whose siblings inherited the attribute from the split
+        val tree = createSplitTree(attributes = mapOf("bold" to "true"))
+
+        // when removing the style from the first <p> with a version vector aware of the split
+        tree.removeStyle(
+            tree.indexRangeToPosRange(0 to 2),
+            listOf("bold"),
+            tick(6),
+            VersionVector(mapOf(ACTOR_A to SPLIT_LAMPORT)),
+        )
+
+        // then the split-out sibling keeps the attribute
+        assertEquals("""<root><p>a</p><p bold="true">b</p></root>""", tree.toXml())
+    }
+
+    @Test
+    fun `should skip remove-style change when the split sibling attribute wins lww`() {
+        // given a split tree whose second sibling was styled with a newer ticket
+        val tree = createSplitTree()
+        tree.root.children[1].setAttributes(mapOf("bold" to "high"), tick(10))
+
+        // when removing the style from the first <p> with an older ticket, unaware of the split
+        tree.removeStyle(
+            tree.indexRangeToPosRange(0 to 2),
+            listOf("bold"),
+            tick(6),
+            VersionVector(mapOf(ACTOR_A to 4L)),
+        )
+
+        // then the sibling keeps its newer value
+        assertEquals("""<root><p>a</p><p bold="high">b</p></root>""", tree.toXml())
+    }
+
+    @Test
+    fun `should propagate style to a split sibling moved to another parent`() {
+        // given <root><p><b>ab</b></p></root> split at both levels
+        val tree = createMultiLevelSplitTree()
+
+        // when styling the first <b> with a version vector unaware of the split
+        tree.style(
+            tree.indexRangeToPosRange(1 to 3),
+            mapOf("bold" to "true"),
+            tick(7),
+            VersionVector(mapOf(ACTOR_A to 5L)),
+        )
+
+        // then the <b> moved into the split-out <p> is styled as well
+        assertEquals(
+            """<root><p><b bold="true">a</b></p><p><b bold="true">b</b></p></root>""",
+            tree.toXml(),
+        )
+    }
+
+    @Test
+    fun `should propagate remove-style to a split sibling moved to another parent`() {
+        // given a styled multi-level split tree
+        val tree = createMultiLevelSplitTree(attributes = mapOf("bold" to "true"))
+        assertEquals(
+            """<root><p><b bold="true">a</b></p><p><b bold="true">b</b></p></root>""",
+            tree.toXml(),
+        )
+
+        // when removing the style from the first <b>, unaware of the split
+        tree.removeStyle(
+            tree.indexRangeToPosRange(1 to 3),
+            listOf("bold"),
+            tick(7),
+            VersionVector(mapOf(ACTOR_A to 5L)),
+        )
+
+        // then the attribute is removed from the moved sibling as well
+        assertEquals("<root><p><b>a</b></p><p><b>b</b></p></root>", tree.toXml())
+    }
+
+    @Test
     fun `should split and merge element nodes by edit`() {
         target.edit(0 to 0, CrdtTreeElement(issuePos(), "p").toList())
         target.edit(1 to 1, CrdtTreeText(issuePos(), "abcd").toList())
@@ -509,7 +717,76 @@ class CrdtTreeTest {
         edit(fromPos to toPos, nodes, splitLevel, issueTime(), ::issueTime)
     }
 
+    /**
+     * Issues a [TimeTicket] with an explicit lamport so that a [VersionVector]
+     * can distinguish nodes created before and after a split ([issueTime] always
+     * issues the same lamport).
+     */
+    private fun tick(
+        lamport: Long,
+        delimiter: UInt = 0u,
+        actor: String = ACTOR_A,
+    ) = TimeTicket(lamport, delimiter, actor)
+
+    private fun CrdtTree.editAt(
+        index: Int,
+        nodes: List<CrdtTreeNode>?,
+        executedAt: TimeTicket,
+        splitLevel: Int = 0,
+        issueTimeTicket: (() -> TimeTicket)? = null,
+    ) {
+        edit(findPos(index) to findPos(index), nodes, splitLevel, executedAt, issueTimeTicket)
+    }
+
+    /**
+     * Builds `<root><p>a</p><p>b</p></root>` where the second `<p>` is a split
+     * sibling of the first, created at [SPLIT_LAMPORT] by [splitActor]. When
+     * [attributes] are given, the `<p>` is styled before the split (lamport 4)
+     * so both siblings inherit them.
+     */
+    private fun createSplitTree(
+        splitActor: String = ACTOR_A,
+        attributes: Map<String, String>? = null,
+    ): CrdtTree {
+        val tree = CrdtTree(CrdtTreeElement(CrdtTreeNodeID(tick(1), 0), "root"), tick(1))
+        tree.editAt(0, CrdtTreeElement(CrdtTreeNodeID(tick(2), 0), "p").toList(), tick(2, 1u))
+        tree.editAt(1, CrdtTreeText(CrdtTreeNodeID(tick(3), 0), "ab").toList(), tick(3, 1u))
+        if (attributes != null) {
+            tree.style(tree.indexRangeToPosRange(0 to 4), attributes, tick(4))
+        }
+        var delimiter = 0u
+        tree.editAt(2, null, tick(SPLIT_LAMPORT, 99u, splitActor), splitLevel = 1) {
+            tick(SPLIT_LAMPORT, delimiter++, splitActor)
+        }
+        return tree
+    }
+
+    /**
+     * Builds `<root><p><b>a</b></p><p><b>b</b></p></root>` by splitting
+     * `<root><p><b>ab</b></p></root>` at both levels ([SPLIT_LAMPORT] + 1), so the
+     * second `<b>` is a split sibling of the first moved to another parent. When
+     * [attributes] are given, the `<b>` is styled before the split (lamport 5)
+     * so both siblings inherit them.
+     */
+    private fun createMultiLevelSplitTree(attributes: Map<String, String>? = null): CrdtTree {
+        val tree = CrdtTree(CrdtTreeElement(CrdtTreeNodeID(tick(1), 0), "root"), tick(1))
+        tree.editAt(0, CrdtTreeElement(CrdtTreeNodeID(tick(2), 0), "p").toList(), tick(2, 1u))
+        tree.editAt(1, CrdtTreeElement(CrdtTreeNodeID(tick(3), 0), "b").toList(), tick(3, 1u))
+        tree.editAt(2, CrdtTreeText(CrdtTreeNodeID(tick(4), 0), "ab").toList(), tick(4, 1u))
+        if (attributes != null) {
+            tree.style(tree.indexRangeToPosRange(1 to 5), attributes, tick(5))
+        }
+        var delimiter = 0u
+        tree.editAt(3, null, tick(SPLIT_LAMPORT + 1, 99u), splitLevel = 2) {
+            tick(SPLIT_LAMPORT + 1, delimiter++)
+        }
+        return tree
+    }
+
     companion object {
         private val DIP = CrdtTreeNodeID(TimeTicket.InitialTimeTicket, 0)
+        private const val ACTOR_A = "000000000000000000000001"
+        private const val ACTOR_B = "000000000000000000000002"
+        private const val SPLIT_LAMPORT = 5L
     }
 }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTreeTest.kt
@@ -6,6 +6,7 @@ import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.VersionVector
 import dev.yorkie.issueTime
 import dev.yorkie.util.IndexTreeNode.Companion.DEFAULT_TEXT_TYPE
+import kotlin.test.assertFailsWith
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -577,6 +578,132 @@ class CrdtTreeTest {
 
         // then the attribute is removed from the moved sibling as well
         assertEquals("<root><p><b>a</b></p><p><b>b</b></p></root>", tree.toXml())
+    }
+
+    @Test
+    fun `should stop propagating style at a dangling split sibling link`() {
+        // given a split tree whose sibling link points to an unregistered node
+        val tree = createSplitTree()
+        tree.root.children[0].insNextID = CrdtTreeNodeID(tick(99), 0)
+
+        // when styling the first <p>, unaware of the split
+        tree.style(
+            tree.indexRangeToPosRange(0 to 2),
+            mapOf("bold" to "true"),
+            tick(6),
+            VersionVector(mapOf(ACTOR_A to 4L)),
+        )
+
+        // then propagation stops without styling the second sibling
+        assertEquals("""<root><p bold="true">a</p><p>b</p></root>""", tree.toXml())
+    }
+
+    @Test
+    fun `should stop propagating style at a text split sibling link`() {
+        // given a split tree whose sibling link points to a text node
+        val tree = createSplitTree()
+        tree.root.children[0].insNextID = tree.root.children[0].children[0].id
+
+        // when styling the first <p>, unaware of the split
+        tree.style(
+            tree.indexRangeToPosRange(0 to 2),
+            mapOf("bold" to "true"),
+            tick(6),
+            VersionVector(mapOf(ACTOR_A to 4L)),
+        )
+
+        // then propagation stops without styling the second sibling
+        assertEquals("""<root><p bold="true">a</p><p>b</p></root>""", tree.toXml())
+    }
+
+    @Test
+    fun `should stop propagating remove-style at a dangling split sibling link`() {
+        // given a styled split tree whose sibling link points to an unregistered node
+        val tree = createSplitTree(attributes = mapOf("bold" to "true"))
+        tree.root.children[0].insNextID = CrdtTreeNodeID(tick(99), 0)
+
+        // when removing the style from the first <p>, unaware of the split
+        tree.removeStyle(
+            tree.indexRangeToPosRange(0 to 2),
+            listOf("bold"),
+            tick(6),
+            VersionVector(mapOf(ACTOR_A to 4L)),
+        )
+
+        // then propagation stops and the second sibling keeps the attribute
+        assertEquals("""<root><p>a</p><p bold="true">b</p></root>""", tree.toXml())
+    }
+
+    @Test
+    fun `should stop propagating remove-style at a text split sibling link`() {
+        // given a styled split tree whose sibling link points to a text node
+        val tree = createSplitTree(attributes = mapOf("bold" to "true"))
+        tree.root.children[0].insNextID = tree.root.children[0].children[0].id
+
+        // when removing the style from the first <p>, unaware of the split
+        tree.removeStyle(
+            tree.indexRangeToPosRange(0 to 2),
+            listOf("bold"),
+            tick(6),
+            VersionVector(mapOf(ACTOR_A to 4L)),
+        )
+
+        // then propagation stops and the second sibling keeps the attribute
+        assertEquals("""<root><p>a</p><p bold="true">b</p></root>""", tree.toXml())
+    }
+
+    @Test
+    fun `should adjust remove-style range starting after a text node`() {
+        // given a styled split tree
+        val tree = createSplitTree(attributes = mapOf("bold" to "true"))
+
+        // when removing the style over a range that starts after the first text
+        // node, so the from-boundary has a real left sibling to advance from
+        tree.removeStyle(
+            tree.indexRangeToPosRange(2 to 6),
+            listOf("bold"),
+            tick(6),
+            VersionVector(mapOf(ACTOR_A to SPLIT_LAMPORT)),
+        )
+
+        // then the attribute is removed from both siblings covered by the range
+        assertEquals("<root><p>a</p><p>b</p></root>", tree.toXml())
+    }
+
+    @Test
+    fun `should require a parent when propagating style to a split sibling`() {
+        // given a split tree whose second sibling was physically removed from its parent
+        val tree = createSplitTree()
+        tree.root.removeChild(tree.root.children[1])
+
+        // when styling the first <p>, unaware of the split,
+        // then the parent invariant of the split sibling is enforced
+        assertFailsWith<IllegalArgumentException> {
+            tree.style(
+                tree.indexRangeToPosRange(0 to 2),
+                mapOf("bold" to "true"),
+                tick(6),
+                VersionVector(mapOf(ACTOR_A to 4L)),
+            )
+        }
+    }
+
+    @Test
+    fun `should require a parent when propagating remove-style to a split sibling`() {
+        // given a styled split tree whose second sibling was physically removed from its parent
+        val tree = createSplitTree(attributes = mapOf("bold" to "true"))
+        tree.root.removeChild(tree.root.children[1])
+
+        // when removing the style from the first <p>, unaware of the split,
+        // then the parent invariant of the split sibling is enforced
+        assertFailsWith<IllegalArgumentException> {
+            tree.removeStyle(
+                tree.indexRangeToPosRange(0 to 2),
+                listOf("bold"),
+                tick(6),
+                VersionVector(mapOf(ACTOR_A to 4L)),
+            )
+        }
     }
 
     @Test

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonArrayTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonArrayTest.kt
@@ -49,7 +49,8 @@ class JsonArrayTest {
         }
         assertTrue(jsonPrimitive in target)
         assertEquals(
-            """[false,0,1,2.0,"string","Ynl0ZSBhcnJheQ==","1970-01-01T00:00:01.000Z","json",[1],{"array":[]}]""",
+            """[false,0,1,2.0,"string","Ynl0ZSBhcnJheQ==","1970-01-01T00:00:01.000Z"""" +
+                ""","json",[1],{"array":[]}]""".trimMargin(),
             target.toJson(),
         )
     }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonArrayTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonArrayTest.kt
@@ -49,7 +49,7 @@ class JsonArrayTest {
         }
         assertTrue(jsonPrimitive in target)
         assertEquals(
-            """[false,0,1,2.0,"string","byte array",1000,"json",[1],{"array":[]}]""",
+            """[false,0,1,2.0,"string","Ynl0ZSBhcnJheQ==","1970-01-01T00:00:01.000Z","json",[1],{"array":[]}]""",
             target.toJson(),
         )
     }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonStringifierTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonStringifierTest.kt
@@ -21,6 +21,18 @@ class JsonStringifierTest {
     }
 
     @Test
+    fun `should serialize empty bytes primitive as empty string`() {
+        // given
+        val primitive = CrdtPrimitive(byteArrayOf(), TimeTicket.InitialTimeTicket)
+
+        // when
+        val json = primitive.toJson()
+
+        // then
+        assertEquals("\"\"", json)
+    }
+
+    @Test
     fun `should serialize date primitive as iso 8601 string`() {
         // given
         val primitive = CrdtPrimitive(Date(1_000L), TimeTicket.InitialTimeTicket)

--- a/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonStringifierTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/json/JsonStringifierTest.kt
@@ -1,0 +1,34 @@
+package dev.yorkie.document.json
+
+import dev.yorkie.document.crdt.CrdtPrimitive
+import dev.yorkie.document.time.TimeTicket
+import java.util.Date
+import kotlin.test.assertEquals
+import org.junit.Test
+
+class JsonStringifierTest {
+
+    @Test
+    fun `should serialize bytes primitive as base64 string`() {
+        // given
+        val primitive = CrdtPrimitive(byteArrayOf(65, 66), TimeTicket.InitialTimeTicket)
+
+        // when
+        val json = primitive.toJson()
+
+        // then
+        assertEquals(""""QUI="""", json)
+    }
+
+    @Test
+    fun `should serialize date primitive as iso 8601 string`() {
+        // given
+        val primitive = CrdtPrimitive(Date(1_000L), TimeTicket.InitialTimeTicket)
+
+        // when
+        val json = primitive.toJson()
+
+        // then
+        assertEquals(""""1970-01-01T00:00:01.000Z"""", json)
+    }
+}


### PR DESCRIPTION
> **RTCOLLABPLATFORM-712**: [[Android] Sync-up Yorkie JS SDK v0.7.6](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-712)

## Summary
Ports the tractable v0.7.6 changes from yorkie-js-sdk to Android (https://github.com/yorkie-team/yorkie-js-sdk/releases/tag/v0.7.6), using the merged iOS PR ([yorkie-ios-sdk#258](https://github.com/yorkie-team/yorkie-ios-sdk/pull/258)) as the reference. The larger **#1227** (LWW position register, proto change) ships in a **[separate PR #335](https://github.com/yorkie-team/yorkie-android-sdk/pull/335)**; **#1229** (presence reconcile) is deferred — the underlying JS bug does not reproduce on Android.

## Changes
- **#1225 — Bytes/Date `toJson()`**: Bytes serialize as base64 and Date as ISO-8601 (`JsonStringifier`). Pure-Kotlin base64 encoder so it works in JVM unit tests and on all supported API levels (minSdk 24). :warning: **Behavior change** to `toJson()`/`toString()` output for Bytes/Date values.
- **#1226 — LWW GC**: `SetOperation` registers the LWW-losing element for garbage collection on a Set conflict.
- **#1224 — Tree split attributes**: `CrdtTree.clone()` deep-copies attributes (no shared `Rht`), and `removeStyle()` propagates to unknown split siblings, mirroring `style()`.
- **#1228 — Deactivate race**: `Client` gains a `deactivating` flag (set synchronously in `deactivateAsync`) so the sync loop stops and suppresses in-flight RPC errors during deactivation. The detach race is already handled by the per-doc `Mutex`.

## Test plan
- [ ] Bytes/Date render as base64 / ISO-8601 in `toJson()` output in a running app
- [ ] Concurrent array/object Set conflict eventually GCs the LWW-losing element
- [ ] Deactivating a client mid-sync produces no "client not activated" errors

> Items run automatically by CI (lint, unit tests, coverage) are excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Byte values are now represented as standard Base64 strings in JSON.
  * Date values are now formatted as UTC ISO-8601 timestamps with millisecond precision.

* **Bug Fixes**
  * Improved shutdown behavior to prevent background synchronization after deactivation.
  * Corrected concurrent style removal and element splitting behavior.
  * Preserved independent attributes when document elements are split.
  * Improved cleanup of values replaced during concurrent updates.

* **Tests**
  * Expanded coverage for serialization, splitting, conflict handling, and document sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->