### PR TITLE
RTCOLLABPLATFORM-712: Sync-up Yorkie JS SDK v0.7.6 - Part 2

### DIFF
--- a/yorkie/proto/yorkie/v1/resources.proto
+++ b/yorkie/proto/yorkie/v1/resources.proto
@@ -227,6 +227,9 @@ message RHTNode {
 message RGANode {
   RGANode next = 1;
   JSONElement element = 2;
+  TimeTicket position_created_at = 3;
+  TimeTicket position_moved_at = 4;
+  TimeTicket position_removed_at = 5;
 }
 
 message NodeAttr {

--- a/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/api/ElementConverter.kt
@@ -140,7 +140,29 @@ internal fun PBJsonObject.toCrdtObject(): CrdtObject {
 internal fun PBJsonArray.toCrdtArray(): CrdtArray {
     val rgaTreeList = RgaTreeList()
     nodesList.forEach { node ->
-        rgaTreeList.insert(node.element.toCrdtElement())
+        when {
+            !node.hasElement() -> {
+                // Dead position node — no element (JS/Go wire convention).
+                rgaTreeList.addDeadPosition(
+                    positionCreatedAt = node.positionCreatedAt.toTimeTicket(),
+                    positionRemovedAt = node.positionRemovedAt.toTimeTicket(),
+                )
+            }
+
+            node.hasPositionCreatedAt() && node.hasPositionMovedAt() -> {
+                // Moved node.
+                rgaTreeList.addMovedElement(
+                    value = node.element.toCrdtElement(),
+                    positionCreatedAt = node.positionCreatedAt.toTimeTicket(),
+                    positionMovedAt = node.positionMovedAt.toTimeTicket(),
+                )
+            }
+
+            else -> {
+                // Normal node.
+                rgaTreeList.insert(node.element.toCrdtElement())
+            }
+        }
     }
     return CrdtArray(
         createdAt = createdAt.toTimeTicket(),
@@ -350,14 +372,34 @@ internal fun CrdtArray.toPBJsonArray(): PBJsonElement {
             createdAt = crdtArray.createdAt.toPBTimeTicket()
             crdtArray.movedAt?.let { movedAt = it.toPBTimeTicket() }
             crdtArray.removedAt?.let { removedAt = it.toPBTimeTicket() }
-            nodes.addAll(elements.toPBRgaNodes())
+            nodes.addAll(crdtArray.toPBRgaNodes())
         }
     }
 }
 
-internal fun RgaTreeList.toPBRgaNodes(): List<PBRgaNode> {
-    return map {
-        rGANode { element = it.value.toPBJsonElement() }
+internal fun CrdtArray.toPBRgaNodes(): List<PBRgaNode> {
+    return getAllRGANodes().mapNotNull { node ->
+        val entry = node.elementEntry
+        if (entry != null) {
+            // Live or moved node — always encode the element.
+            rGANode {
+                element = entry.element.toPBJsonElement()
+                val posMovedAt = entry.posMovedAt
+                if (posMovedAt != null) {
+                    // Moved node — encode the position id and the move ticket.
+                    positionCreatedAt = node.positionCreatedAt.toPBTimeTicket()
+                    positionMovedAt = posMovedAt.toPBTimeTicket()
+                }
+                // Otherwise a normal node — no position fields.
+            }
+        } else {
+            // Dead position node — encode positionCreatedAt + positionRemovedAt, NO element.
+            val deadRemovedAt = node.positionRemovedAt ?: return@mapNotNull null
+            rGANode {
+                positionCreatedAt = node.positionCreatedAt.toPBTimeTicket()
+                positionRemovedAt = deadRemovedAt.toPBTimeTicket()
+            }
+        }
     }
 }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtArray.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtArray.kt
@@ -50,14 +50,34 @@ internal data class CrdtArray(
     }
 
     /**
-     * Moves the given [createdAt] element after the [prevCreatedAt] element.
+     * Moves the given [createdAt] element after the [prevCreatedAt] element using an LWW
+     * position register. Returns the displaced dead position node the caller must register
+     * for GC, or `null` when the move lost the LWW race / was already processed.
      */
     fun moveAfter(
         prevCreatedAt: TimeTicket,
         createdAt: TimeTicket,
         executedAt: TimeTicket,
-    ) {
-        elements.moveAfter(prevCreatedAt, createdAt, executedAt)
+    ): RgaTreeList.Node? {
+        return elements.moveAfter(prevCreatedAt, createdAt, executedAt)
+    }
+
+    /**
+     * Returns the underlying [RgaTreeList], used as the [GCParent] when registering dead
+     * position nodes.
+     */
+    fun getRGATreeList(): RgaTreeList = elements
+
+    /**
+     * Returns all nodes in linked-list order, including dead position nodes.
+     */
+    fun getAllRGANodes(): List<RgaTreeList.Node> = elements.allNodes()
+
+    /**
+     * Returns the current position node key for the element identified by [elemCreatedAt].
+     */
+    fun posCreatedAt(elemCreatedAt: TimeTicket): TimeTicket {
+        return elements.posCreatedAt(elemCreatedAt)
     }
 
     /**
@@ -124,10 +144,35 @@ internal data class CrdtArray(
     }
 
     override fun deepCopy(): CrdtElement {
+        // Iterate ALL position nodes (including moved and dead ones) and reconstruct each
+        // with its position timestamps. Copying only live nodes would lose moved positions
+        // and dead slots, so a later move on the clone could anchor after a wrong position.
         return copy(
             elements = RgaTreeList().apply {
-                elements.forEach { node ->
-                    insertAfter(lastCreatedAt, node.value.deepCopy())
+                this@CrdtArray.elements.allNodes().forEach { node ->
+                    val entry = node.elementEntry
+                    val positionRemovedAt = node.positionRemovedAt
+                    when {
+                        entry != null -> {
+                            val posMovedAt = entry.posMovedAt
+                            if (posMovedAt != null) {
+                                addMovedElement(
+                                    value = entry.element.deepCopy(),
+                                    positionCreatedAt = node.positionCreatedAt,
+                                    positionMovedAt = posMovedAt,
+                                )
+                            } else {
+                                insertAfter(lastCreatedAt, entry.element.deepCopy())
+                            }
+                        }
+
+                        positionRemovedAt != null -> {
+                            addDeadPosition(
+                                positionCreatedAt = node.positionCreatedAt,
+                                positionRemovedAt = positionRemovedAt,
+                            )
+                        }
+                    }
                 }
             },
         )

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtRoot.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtRoot.kt
@@ -66,6 +66,16 @@ internal class CrdtRoot(val rootObject: CrdtObject) {
             if (element is GCCrdtElement) {
                 element.gcPairs.forEach(::registerGCPair)
             }
+            // Register dead position nodes in a CrdtArray so they are collected once all
+            // peers have applied the winning move. Dead nodes have no element, so
+            // getDescendants never yields them — register them explicitly here.
+            if (element is CrdtArray) {
+                element.getAllRGANodes().forEach { node ->
+                    if (node.elementEntry == null && node.positionRemovedAt != null) {
+                        registerGCPair(GCPair(element.getRGATreeList(), node))
+                    }
+                }
+            }
             false
         }
     }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeList.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeList.kt
@@ -119,18 +119,9 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
     }
 
     /**
-     * Inserts a bare position node (no element) after the node identified by
-     * [prevPositionCreatedAt], marked dead at [executedAt].
+     * Inserts a bare position node (no element) after [prevNode], marked dead at [executedAt].
      */
-    private fun insertDeadPositionAfter(
-        prevPositionCreatedAt: TimeTicket,
-        executedAt: TimeTicket,
-    ): Node {
-        val prevNode = nodeMapByPositionCreatedAt[prevPositionCreatedAt]
-            ?: throw YorkieException(
-                code = YorkieException.Code.ErrInvalidArgument,
-                errorMessage = "can't find the given node createdAt: $prevPositionCreatedAt",
-            )
+    private fun insertDeadPositionAfter(prevNode: Node, executedAt: TimeTicket): Node {
         val anchor = findNextBeforeExecutedAt(prevNode, executedAt)
         val node = Node.create(CrdtPrimitive(null, executedAt), executedAt)
         insertNodeIntoStructures(node, anchor)
@@ -156,12 +147,11 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
                 code = YorkieException.Code.ErrInvalidArgument,
                 errorMessage = "can't find the given element createdAt: $createdAt",
             )
-        if (prevCreatedAt !in nodeMapByPositionCreatedAt) {
-            throw YorkieException(
+        val prevNode = nodeMapByPositionCreatedAt[prevCreatedAt]
+            ?: throw YorkieException(
                 code = YorkieException.Code.ErrInvalidArgument,
                 errorMessage = "can't find the previous node createdAt: $prevCreatedAt",
             )
-        }
 
         // Idempotency: a node with this executedAt already exists.
         if (executedAt in nodeMapByPositionCreatedAt) {
@@ -172,13 +162,12 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
         // dead position node so the GC pair set is complete.
         val posMovedAt = entry.posMovedAt
         if (posMovedAt != null && executedAt <= posMovedAt) {
-            return insertDeadPositionAfter(prevCreatedAt, executedAt)
+            return insertDeadPositionAfter(prevNode, executedAt)
         }
 
         // LWW winner: build the new position node carrying the element, wire the entry,
         // then kill the old position node.
         val oldPositionNode = entry.positionNode
-        val prevNode = requireNotNull(nodeMapByPositionCreatedAt[prevCreatedAt])
         val anchor = findNextBeforeExecutedAt(prevNode, executedAt)
         val newPositionNode = Node.create(entry.element, executedAt)
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeList.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeList.kt
@@ -2,33 +2,43 @@ package dev.yorkie.document.crdt
 
 import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
-import dev.yorkie.document.time.TimeTicket.Companion.compareTo
+import dev.yorkie.document.time.TimeTicket.Companion.TIME_TICKET_SIZE
+import dev.yorkie.util.DataSize
 import dev.yorkie.util.SplayTreeSet
 import dev.yorkie.util.YorkieException
 
 /**
- * [RgaTreeList] is a replicated growable array.
+ * [RgaTreeList] is a replicated growable array using an LWW position register so that
+ * concurrent array moves converge.
+ *
+ * Each element has a stable identity held in [ElementEntry], separate from its current
+ * position slot ([Node]). When two concurrent moves target the same element the one with
+ * the later `executedAt` wins; the old position becomes a *dead position node*
+ * (`elementEntry == null`, `positionRemovedAt` set, length 0) that is garbage-collected.
  */
-internal class RgaTreeList : Iterable<RgaTreeList.Node> {
-    private val dummyHead = Node(
-        CrdtPrimitive(
-            _value = 1,
-            createdAt = InitialTimeTicket,
-            removedAt = InitialTimeTicket,
-        ),
-    )
+internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.Node> {
+    private val dummyHead = Node.createDummy()
+
     var last: Node = dummyHead
         private set
 
     private val nodeMapByIndex = SplayTreeSet<Node> {
-        if (it.value.isRemoved) 0 else 1
+        if (it.elementEntry == null || it.value.isRemoved) 0 else 1
     }.apply {
         insert(dummyHead)
     }
 
-    private val nodeMapByCreatedAt = mutableMapOf<TimeTicket, Node>().apply {
-        set(dummyHead.createdAt, dummyHead)
+    /**
+     * Maps a position node's `positionCreatedAt` to the node itself.
+     */
+    private val nodeMapByPositionCreatedAt = mutableMapOf<TimeTicket, Node>().apply {
+        set(dummyHead.positionCreatedAt, dummyHead)
     }
+
+    /**
+     * Maps an element's `createdAt` to its [ElementEntry].
+     */
+    private val elementMapByCreatedAt = mutableMapOf<TimeTicket, ElementEntry>()
 
     val length
         get() = nodeMapByIndex.length
@@ -36,106 +46,225 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node> {
     val head
         get() = dummyHead.value
 
+    /**
+     * Returns the position identity of the last node.
+     */
     val lastCreatedAt
-        get() = last.createdAt
+        get() = last.positionCreatedAt
 
     /**
      * Adds a new node with [value] after the last node.
      */
     fun insert(value: CrdtElement) {
-        insertAfter(last.createdAt, value)
+        insertAfter(last.positionCreatedAt, value)
     }
 
     /**
-     * Adds a new node with [value] after the node created at [prevCreatedAt].
+     * Adds a new node with [value] after the node identified by [prevCreatedAt].
+     *
+     * [prevCreatedAt] is resolved as a position node key first, then an element key.
      */
     fun insertAfter(
         prevCreatedAt: TimeTicket,
         value: CrdtElement,
         executedAt: TimeTicket = value.createdAt,
     ): Node {
-        val prevNode = findNextBeforeExecutedAt(prevCreatedAt, executedAt)
-        val newNode = Node.createAfter(prevNode, value)
-        if (prevNode == last) {
-            last = newNode
-        }
-        nodeMapByIndex.insertAfter(prevNode, newNode)
-        nodeMapByCreatedAt[newNode.createdAt] = newNode
+        val anchorNode = nodeMapByPositionCreatedAt[prevCreatedAt]
+            ?: elementMapByCreatedAt[prevCreatedAt]?.positionNode
+            ?: throw YorkieException(
+                code = YorkieException.Code.ErrInvalidArgument,
+                errorMessage = "can't find the given node createdAt: $prevCreatedAt",
+            )
+        val anchor = findNextBeforeExecutedAt(anchorNode, executedAt)
+        val newNode = Node.create(value, value.createdAt)
+
+        // Wire the entry BEFORE splay-tree insertion so the length calculator sees 1.
+        val entry = ElementEntry(value, newNode)
+        newNode.elementEntry = entry
+        elementMapByCreatedAt[value.createdAt] = entry
+
+        insertNodeIntoStructures(newNode, anchor)
         return newNode
     }
 
     /**
-     * Returns the node by the given [createdAt] and [executedAt].
-     * It passes through nodes created after [executedAt] from the
-     * given node and returns the next node.
+     * Walks forward from [node] skipping nodes whose `positionedAt` is after [executedAt].
      */
-    private fun findNextBeforeExecutedAt(createdAt: TimeTicket, executedAt: TimeTicket): Node {
-        var node = nodeMapByCreatedAt[createdAt]
+    private fun findNextBeforeExecutedAt(node: Node, executedAt: TimeTicket): Node {
+        var current = node
+        while (true) {
+            val next = current.next ?: break
+            if (next.positionedAt <= executedAt) break
+            current = next
+        }
+        return current
+    }
+
+    /**
+     * Links [node] into the linked list and splay tree after [anchor].
+     */
+    private fun insertNodeIntoStructures(node: Node, anchor: Node) {
+        val anchorNext = anchor.next
+        anchor.next = node
+        node.prev = anchor
+        node.next = anchorNext
+        anchorNext?.prev = node
+
+        if (anchor == last) {
+            last = node
+        }
+
+        nodeMapByIndex.insertAfter(anchor, node)
+        nodeMapByPositionCreatedAt[node.positionCreatedAt] = node
+    }
+
+    /**
+     * Inserts a bare position node (no element) after the node identified by
+     * [prevPositionCreatedAt], marked dead at [executedAt].
+     */
+    private fun insertDeadPositionAfter(
+        prevPositionCreatedAt: TimeTicket,
+        executedAt: TimeTicket,
+    ): Node {
+        val prevNode = nodeMapByPositionCreatedAt[prevPositionCreatedAt]
             ?: throw YorkieException(
                 code = YorkieException.Code.ErrInvalidArgument,
-                errorMessage = "can't find the given node createdAt: $createdAt",
+                errorMessage = "can't find the given node createdAt: $prevPositionCreatedAt",
             )
-
-        while (node.value.movedAt != null && node.value.movedAt > executedAt) {
-            node = node.movedFrom ?: break
-        }
-
-        while (node.next != null && executedAt < node.next?.positionedAt) {
-            node = node.next ?: break
-        }
+        val anchor = findNextBeforeExecutedAt(prevNode, executedAt)
+        val node = Node.create(CrdtPrimitive(null, executedAt), executedAt)
+        insertNodeIntoStructures(node, anchor)
+        node.markDead(executedAt)
+        nodeMapByIndex.splay(node)
         return node
     }
 
     /**
-     * Moves the given [createdAt] element after the [prevCreatedAt] element.
+     * Moves the element identified by [createdAt] to after [prevCreatedAt].
+     *
+     * Uses an LWW position register: the winning position is the one with the latest
+     * [executedAt]. Returns the dead position node the caller must register for GC, or
+     * `null` when the move was already processed (idempotency).
      */
     fun moveAfter(
         prevCreatedAt: TimeTicket,
         createdAt: TimeTicket,
         executedAt: TimeTicket,
-    ) {
-        var prevNode = nodeMapByCreatedAt[prevCreatedAt]
+    ): Node? {
+        val entry = elementMapByCreatedAt[createdAt]
             ?: throw YorkieException(
                 code = YorkieException.Code.ErrInvalidArgument,
-                errorMessage = "can't find the given node createdAt: $prevCreatedAt",
+                errorMessage = "can't find the given element createdAt: $createdAt",
             )
-        var node = nodeMapByCreatedAt[createdAt]
-            ?: throw YorkieException(
+        if (prevCreatedAt !in nodeMapByPositionCreatedAt) {
+            throw YorkieException(
                 code = YorkieException.Code.ErrInvalidArgument,
-                errorMessage = "can't find the given node createdAt: $createdAt",
+                errorMessage = "can't find the previous node createdAt: $prevCreatedAt",
             )
-
-        if (prevNode != node && executedAt > node.positionedAt) {
-            val movedFrom = node.prev
-            var nextNode = node.next
-            release(node)
-
-            node = insertAfter(prevNode.createdAt, node.value, executedAt)
-            node.value.movedAt = executedAt
-            node.movedFrom = movedFrom
-
-            while (nextNode != null && nextNode.positionedAt > executedAt) {
-                prevNode = node
-                node = nextNode
-                nextNode = node.next
-
-                release(node)
-                node = insertAfter(prevNode.createdAt, node.value, executedAt)
-                node.value.movedAt = executedAt
-                node.movedFrom = movedFrom
-            }
         }
+
+        // Idempotency: a node with this executedAt already exists.
+        if (executedAt in nodeMapByPositionCreatedAt) {
+            return null
+        }
+
+        // LWW loser: superseded by a later move of the same element. Still create a bare
+        // dead position node so the GC pair set is complete.
+        val posMovedAt = entry.posMovedAt
+        if (posMovedAt != null && executedAt <= posMovedAt) {
+            return insertDeadPositionAfter(prevCreatedAt, executedAt)
+        }
+
+        // LWW winner: build the new position node carrying the element, wire the entry,
+        // then kill the old position node.
+        val oldPositionNode = entry.positionNode
+        val prevNode = requireNotNull(nodeMapByPositionCreatedAt[prevCreatedAt])
+        val anchor = findNextBeforeExecutedAt(prevNode, executedAt)
+        val newPositionNode = Node.create(entry.element, executedAt)
+
+        newPositionNode.elementEntry = entry
+        entry.positionNode = newPositionNode
+        entry.posMovedAt = executedAt
+        entry.element.movedAt = executedAt
+
+        insertNodeIntoStructures(newPositionNode, anchor)
+
+        // Kill the old position node but keep it splayed (length 0) until GC purges it:
+        // a later insert/append may still anchor after it (e.g. it was `last`).
+        oldPositionNode.markDead(executedAt)
+        nodeMapByIndex.splay(oldPositionNode)
+
+        return oldPositionNode
     }
 
     /**
-     * `delete` deletes the node of the given creation time.
+     * Restores a dead position node from a snapshot.
+     */
+    fun addDeadPosition(positionCreatedAt: TimeTicket, positionRemovedAt: TimeTicket) {
+        val node = Node.create(CrdtPrimitive(null, positionCreatedAt), positionCreatedAt)
+        node.markDead(positionRemovedAt)
+
+        val prevNode = last
+        prevNode.next = node
+        node.prev = prevNode
+        last = node
+        nodeMapByIndex.insertAfter(prevNode, node)
+        nodeMapByPositionCreatedAt[positionCreatedAt] = node
+    }
+
+    /**
+     * Restores a moved element's position from a snapshot.
+     */
+    fun addMovedElement(
+        value: CrdtElement,
+        positionCreatedAt: TimeTicket,
+        positionMovedAt: TimeTicket,
+    ) {
+        val anchor = findNextBeforeExecutedAt(last, positionCreatedAt)
+        val node = Node.create(value, positionCreatedAt)
+
+        val entry = ElementEntry(value, node).apply { posMovedAt = positionMovedAt }
+        node.elementEntry = entry
+        elementMapByCreatedAt[value.createdAt] = entry
+
+        insertNodeIntoStructures(node, anchor)
+    }
+
+    /**
+     * Returns the current position node key for the element identified by [elemCreatedAt].
+     */
+    fun posCreatedAt(elemCreatedAt: TimeTicket): TimeTicket {
+        val entry = elementMapByCreatedAt[elemCreatedAt]
+            ?: throw YorkieException(
+                code = YorkieException.Code.ErrInvalidArgument,
+                errorMessage = "can't find the given element createdAt: $elemCreatedAt",
+            )
+        return entry.positionNode.positionCreatedAt
+    }
+
+    /**
+     * Returns all nodes in linked-list order, including dead position nodes.
+     */
+    fun allNodes(): List<Node> {
+        val result = mutableListOf<Node>()
+        var current = dummyHead.next
+        while (current != null) {
+            result.add(current)
+            current = current.next
+        }
+        return result
+    }
+
+    /**
+     * `delete` deletes the element of the given [createdAt].
      */
     fun delete(createdAt: TimeTicket, editedAt: TimeTicket): CrdtElement {
-        val node = nodeMapByCreatedAt[createdAt]
+        val entry = elementMapByCreatedAt[createdAt]
             ?: throw YorkieException(
                 code = YorkieException.Code.ErrInvalidArgument,
                 errorMessage = "cant find the given node: $createdAt",
             )
+        val node = entry.positionNode
         val alreadyRemoved = node.isRemoved
         if (node.remove(editedAt) && !alreadyRemoved) {
             nodeMapByIndex.splay(node)
@@ -149,23 +278,23 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node> {
         }
         node.release()
         nodeMapByIndex.delete(node)
-        nodeMapByCreatedAt.remove(node.value.createdAt)
+        nodeMapByPositionCreatedAt.remove(node.positionCreatedAt)
     }
 
     /**
      * Returns the element of the given [createdAt].
      */
     fun get(createdAt: TimeTicket): CrdtElement? {
-        return nodeMapByCreatedAt[createdAt]?.value
+        return elementMapByCreatedAt[createdAt]?.element
     }
 
     /**
      * Returns the sub path of the given element.
      */
     fun subPathOf(createdAt: TimeTicket): String {
-        val node = nodeMapByCreatedAt[createdAt]
+        val entry = elementMapByCreatedAt[createdAt]
             ?: throw NoSuchElementException("can't find the given node createdAt: $createdAt")
-        return nodeMapByIndex.indexOf(node).toString()
+        return nodeMapByIndex.indexOf(entry.positionNode).toString()
     }
 
     /**
@@ -177,32 +306,46 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node> {
     }
 
     /**
-     * Returns a creation time of the previous node.
+     * Returns the position identity of the previous node, skipping dead position nodes
+     * and tombstoned elements.
      */
     fun getPrevCreatedAt(createdAt: TimeTicket): TimeTicket {
-        var node = nodeMapByCreatedAt[createdAt]
+        val entry = elementMapByCreatedAt[createdAt]
             ?: throw NoSuchElementException("can't find the given node createdAt: $createdAt")
+        var node: Node? = entry.positionNode
         do {
-            node = node.prev ?: break
-        } while (dummyHead != node && node.isRemoved)
-        return node.value.createdAt
+            node = node?.prev
+        } while (dummyHead != node && node != null && (node.elementEntry == null || node.isRemoved))
+        return (node ?: dummyHead).positionCreatedAt
     }
 
     /**
-     * Removes the node of the given [createdAt].
+     * Physically removes the element node from the list (final GC step).
      */
     fun purge(element: CrdtElement) {
-        val node = nodeMapByCreatedAt[element.createdAt]
+        val entry = elementMapByCreatedAt[element.createdAt]
             ?: throw YorkieException(
                 code = YorkieException.Code.ErrInvalidArgument,
                 errorMessage = "can't find the given node createdAt: ${element.createdAt}",
             )
-
-        release(node)
+        release(entry.positionNode)
+        elementMapByCreatedAt.remove(element.createdAt)
     }
 
     /**
-     * Removes the node at the given [index]
+     * Physically removes a dead position node from the list (final GC step for moves).
+     */
+    private fun purgeDeadPosition(positionCreatedAt: TimeTicket) {
+        val node = nodeMapByPositionCreatedAt[positionCreatedAt] ?: return
+        release(node)
+    }
+
+    override fun delete(node: Node) {
+        purgeDeadPosition(node.positionCreatedAt)
+    }
+
+    /**
+     * Removes the node at the given [index].
      */
     fun removeByIndex(index: Int, executedAt: TimeTicket): CrdtElement? {
         val node = getByIndex(index) ?: return null
@@ -220,24 +363,33 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node> {
         element: CrdtElement,
         executedAt: TimeTicket,
     ): CrdtElement {
-        val node = nodeMapByCreatedAt[createdAt]
+        val entry = elementMapByCreatedAt[createdAt]
             ?: throw YorkieException(
                 code = YorkieException.Code.ErrInvalidArgument,
                 errorMessage = "cant find the given node: $createdAt",
             )
-
-        insertAfter(node.createdAt, element, executedAt)
+        insertAfter(entry.positionNode.positionCreatedAt, element, executedAt)
         return delete(createdAt, executedAt)
     }
 
     override fun iterator(): Iterator<Node> {
         return object : Iterator<Node> {
-            var node = dummyHead
+            var node = nextLiveNode(dummyHead)
 
-            override fun hasNext() = node.next != null
+            override fun hasNext() = node != null
 
             override fun next(): Node {
-                return requireNotNull(node.next).also { node = it }
+                val current = requireNotNull(node)
+                node = nextLiveNode(current)
+                return current
+            }
+
+            private fun nextLiveNode(from: Node): Node? {
+                var current = from.next
+                while (current != null && current.elementEntry == null) {
+                    current = current.next
+                }
+                return current
             }
         }
     }
@@ -246,29 +398,64 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node> {
         if (other !is RgaTreeList) {
             return false
         }
-        return nodeMapByCreatedAt == other.nodeMapByCreatedAt
+        return elementMapByCreatedAt == other.elementMapByCreatedAt
     }
 
     override fun hashCode(): Int {
-        return nodeMapByCreatedAt.hashCode()
+        return elementMapByCreatedAt.hashCode()
     }
 
-    class Node(val value: CrdtElement) {
+    /**
+     * [ElementEntry] holds the stable identity of an element and its current position node.
+     */
+    class ElementEntry(val element: CrdtElement, var positionNode: Node) {
+        var posMovedAt: TimeTicket? = null
+    }
+
+    /**
+     * [Node] represents a position slot in the list, not necessarily a live element.
+     * A dead position node has `elementEntry == null` and its `positionRemovedAt` set.
+     */
+    class Node private constructor(
+        val value: CrdtElement,
+        val positionCreatedAt: TimeTicket,
+    ) : GCChild {
         var prev: Node? = null
         var next: Node? = null
-        var movedFrom: Node? = null
+
+        var positionRemovedAt: TimeTicket? = null
+            private set
+
+        var elementEntry: ElementEntry? = null
 
         val createdAt: TimeTicket
             get() = value.createdAt
 
+        /**
+         * The LWW register key used to arbitrate insertion order.
+         */
         val positionedAt: TimeTicket
-            get() = value.movedAt ?: createdAt
+            get() = positionCreatedAt
 
         val isRemoved
             get() = value.isRemoved
 
+        override val removedAt: TimeTicket?
+            get() = positionRemovedAt
+
+        override val dataSize: DataSize
+            get() = DataSize(
+                data = 0,
+                meta = TIME_TICKET_SIZE + if (positionRemovedAt != null) TIME_TICKET_SIZE else 0,
+            )
+
         fun remove(removedAt: TimeTicket): Boolean {
             return value.remove(removedAt)
+        }
+
+        fun markDead(at: TimeTicket) {
+            positionRemovedAt = at
+            elementEntry = null
         }
 
         fun release() {
@@ -280,19 +467,17 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node> {
         }
 
         companion object {
-            /**
-             * Creates a new node with [value] after the node [prev].
-             */
-            fun createAfter(prev: Node, value: CrdtElement): Node {
-                val newNode = Node(value)
-                val prevNext = prev.next
-                prev.next = newNode
-                newNode.prev = prev
-                newNode.next = prevNext
-                if (prevNext != null) {
-                    prevNext.prev = newNode
-                }
-                return newNode
+            fun create(value: CrdtElement, positionCreatedAt: TimeTicket): Node {
+                return Node(value, positionCreatedAt)
+            }
+
+            fun createDummy(): Node {
+                val dummyValue = CrdtPrimitive(
+                    _value = 1,
+                    createdAt = InitialTimeTicket,
+                    removedAt = InitialTimeTicket,
+                )
+                return Node(dummyValue, InitialTimeTicket)
             }
         }
     }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonArray.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/json/JsonArray.kt
@@ -205,15 +205,27 @@ public class JsonArray internal constructor(
 
     private fun moveInternal(prevCreatedAt: TimeTicket, createdAt: TimeTicket) {
         val executedAt = context.issueTimeTicket()
+        // Convert the anchor from element identity to its current position identity for the
+        // operation wire format. Falls back to the input when it is already a position key
+        // (e.g. dummy head, or a position key from getPrevCreatedAt/lastCreatedAt).
+        val prevPosCreatedAt = posCreatedAtOrSelf(prevCreatedAt)
         context.push(
             MoveOperation(
                 parentCreatedAt = target.createdAt,
-                prevCreatedAt = prevCreatedAt,
+                prevCreatedAt = prevPosCreatedAt,
                 createdAt = createdAt,
                 executedAt = executedAt,
             ),
         )
-        target.moveAfter(prevCreatedAt, createdAt, executedAt)
+        target.moveAfter(prevPosCreatedAt, createdAt, executedAt)
+    }
+
+    /**
+     * Returns the current position identity for [createdAt], or [createdAt] itself when it
+     * is not an element key (already a position identity).
+     */
+    private fun posCreatedAtOrSelf(createdAt: TimeTicket): TimeTicket {
+        return runCatching { target.posCreatedAt(createdAt) }.getOrDefault(createdAt)
     }
 
     /**
@@ -293,15 +305,16 @@ public class JsonArray internal constructor(
             )
 
         val ticket = context.issueTimeTicket()
+        val prevPosCreatedAt = posCreatedAtOrSelf(prevElem.createdAt)
         context.push(
             MoveOperation(
-                prevCreatedAt = prevElem.createdAt,
+                prevCreatedAt = prevPosCreatedAt,
                 createdAt = targetElem.createdAt,
                 parentCreatedAt = target.createdAt,
                 executedAt = ticket,
             ),
         )
-        target.moveAfter(prevElem.createdAt, targetElem.createdAt, ticket)
+        target.moveAfter(prevPosCreatedAt, targetElem.createdAt, ticket)
     }
 
     override fun contains(element: JsonElement): Boolean {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
@@ -2,6 +2,7 @@ package dev.yorkie.document.operation
 
 import dev.yorkie.document.crdt.CrdtArray
 import dev.yorkie.document.crdt.CrdtRoot
+import dev.yorkie.document.crdt.GCPair
 import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.VersionVector
 import dev.yorkie.util.Logger.Companion.logError
@@ -34,7 +35,10 @@ internal data class MoveOperation(
         return if (parentObject is CrdtArray) {
             val prevCreatedAtBefore = parentObject.getPrevCreatedAt(createdAt)
             val previousIndex = parentObject.subPathOf(createdAt).toInt()
-            parentObject.moveAfter(prevCreatedAt, createdAt, executedAt)
+            val deadNode = parentObject.moveAfter(prevCreatedAt, createdAt, executedAt)
+            if (deadNode != null) {
+                root.registerGCPair(GCPair(parentObject.getRGATreeList(), deadNode))
+            }
             val index = parentObject.subPathOf(createdAt).toInt()
 
             val reverseOp = MoveOperation(

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtArrayTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtArrayTest.kt
@@ -2,6 +2,7 @@ package dev.yorkie.document.crdt
 
 import dev.yorkie.api.toCrdtArray
 import dev.yorkie.api.toPBJsonArray
+import dev.yorkie.api.toPBTimeTicket
 import dev.yorkie.document.time.TimeTicket
 import org.junit.Assert
 import org.junit.Assert.assertEquals
@@ -217,6 +218,32 @@ class CrdtArrayTest {
         // the moved element keeps its new index (1) after the round-trip
         assertEquals(array.subPathOf(e2.createdAt), restored.subPathOf(e2.createdAt))
         assertEquals(2, (restored[1] as CrdtPrimitive).value)
+    }
+
+    // #1227: a node carrying position_created_at without position_moved_at (defensive wire
+    // shape) parses as a normal node.
+    @Test
+    fun `should parse a node with only position_created_at as a normal node`() {
+        val actor = "000000000000000000000001"
+        fun ticket(lamport: Long) = TimeTicket(lamport, TimeTicket.INITIAL_DELIMITER, actor)
+
+        val array = CrdtArray(ticket(0))
+        val e0 = CrdtPrimitive(0, ticket(1))
+        val e1 = CrdtPrimitive(1, ticket(2))
+        listOf(e0, e1).forEach { array.insertAfter(array.last.createdAt, it) }
+
+        val pb = array.toPBJsonArray().jsonArray
+        val mutated = pb.toBuilder().setNodes(
+            0,
+            pb.getNodes(0).toBuilder()
+                .setPositionCreatedAt(ticket(1).toPBTimeTicket())
+                .build(),
+        ).build()
+        val restored = mutated.toCrdtArray()
+
+        assertEquals(2, restored.length)
+        assertEquals(0, (restored[0] as CrdtPrimitive).value)
+        assertEquals(1, (restored[1] as CrdtPrimitive).value)
     }
 
     private fun createTimeTicket(): TimeTicket {

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtArrayTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtArrayTest.kt
@@ -1,5 +1,7 @@
 package dev.yorkie.document.crdt
 
+import dev.yorkie.api.toCrdtArray
+import dev.yorkie.api.toPBJsonArray
 import dev.yorkie.document.time.TimeTicket
 import org.junit.Assert
 import org.junit.Assert.assertEquals
@@ -174,6 +176,47 @@ class CrdtArrayTest {
         Assert.assertThrows(NoSuchElementException::class.java) {
             target.getPrevCreatedAt(createTimeTicket())
         }
+    }
+
+    // #1227: deepCopy must preserve moved positions and dead position nodes so a later
+    // move on the clone anchors correctly (copying only live nodes would lose them).
+    @Test
+    fun `should preserve moved and dead positions on deepCopy`() {
+        crdtElements.forEach { target.insertAfter(target.last.createdAt, it) }
+        // move E after F → [A, B, C, D, F, E, G]
+        target.moveAfter(timeTickets[5], timeTickets[4], createTimeTicket())
+        assertEquals("ABCDFEG", target.toTestString())
+
+        val copy = target.deepCopy() as CrdtArray
+
+        assertEquals("ABCDFEG", copy.toTestString())
+        assertEquals(target.length, copy.length)
+        // the moved element keeps its index in the clone
+        assertEquals(target.subPathOf(timeTickets[4]), copy.subPathOf(timeTickets[4]))
+    }
+
+    // #1227: a move must survive a protobuf round-trip, including the dead position node
+    // (serialized with position timestamps and no element). Uses hex actor IDs because the
+    // converter encodes the actor ID as a 12-byte hex string.
+    @Test
+    fun `should preserve moves across a protobuf round-trip`() {
+        val actor = "000000000000000000000001"
+        fun ticket(lamport: Long) = TimeTicket(lamport, TimeTicket.INITIAL_DELIMITER, actor)
+
+        val array = CrdtArray(ticket(0))
+        val e0 = CrdtPrimitive(0, ticket(1))
+        val e1 = CrdtPrimitive(1, ticket(2))
+        val e2 = CrdtPrimitive(2, ticket(3))
+        listOf(e0, e1, e2).forEach { array.insertAfter(array.last.createdAt, it) }
+        // move e2 after e0 → [0, 2, 1], leaving a dead position node for e2's old slot
+        array.moveAfter(e0.createdAt, e2.createdAt, ticket(5))
+
+        val restored = array.toPBJsonArray().jsonArray.toCrdtArray()
+
+        assertEquals(array.length, restored.length)
+        // the moved element keeps its new index (1) after the round-trip
+        assertEquals(array.subPathOf(e2.createdAt), restored.subPathOf(e2.createdAt))
+        assertEquals(2, (restored[1] as CrdtPrimitive).value)
     }
 
     private fun createTimeTicket(): TimeTicket {

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtRootTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtRootTest.kt
@@ -6,6 +6,7 @@ import dev.yorkie.document.operation.OpSource
 import dev.yorkie.document.operation.SetOperation
 import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.VersionVector
+import dev.yorkie.helper.maxVectorOf
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -101,6 +102,29 @@ class CrdtRootTest {
         root.registerRemovedElement(obj["k1"])
         root.registerRemovedElement(obj["k2"])
         root.garbageCollect(VersionVector.INITIAL_VERSION_VECTOR)
+    }
+
+    // #1227: dead position nodes inside an array (e.g. restored from a snapshot) are
+    // registered for GC when the root is constructed.
+    @Test
+    fun `should register dead position nodes of an array for gc on construction`() {
+        val actor = "A"
+        fun tick(lamport: Long) = TimeTicket(lamport, TimeTicket.INITIAL_DELIMITER, actor)
+
+        val array = CrdtArray(tick(1))
+        val a = CrdtPrimitive("a", tick(2))
+        val b = CrdtPrimitive("b", tick(3))
+        listOf(a, b).forEach { array.insertAfter(array.lastCreatedAt, it) }
+        // move a after b — a's old position becomes a dead node
+        array.moveAfter(b.createdAt, a.createdAt, tick(4))
+
+        val rootObject = CrdtObject(TimeTicket.InitialTimeTicket, memberNodes = ElementRht())
+        rootObject.set("arr", array, tick(5))
+        val root = CrdtRoot(rootObject)
+
+        assertEquals(1, root.garbageLength)
+        assertEquals(1, root.garbageCollect(maxVectorOf(listOf(actor))))
+        assertEquals(0, root.garbageLength)
     }
 
     @Test

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/GCTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/GCTest.kt
@@ -6,6 +6,7 @@ import dev.yorkie.Step
 import dev.yorkie.TestCase
 import dev.yorkie.TestOperation
 import dev.yorkie.document.Document
+import dev.yorkie.document.json.JsonArray
 import dev.yorkie.document.json.JsonObject
 import dev.yorkie.document.json.JsonText
 import dev.yorkie.document.json.JsonTree
@@ -223,5 +224,28 @@ class GCTest {
             doc.garbageCollect(versionVector)
             assertEquals(0, doc.garbageLength)
         }
+    }
+
+    // #1227: an array move creates a dead position node that must be garbage-collected.
+    @Test
+    fun `should garbage collect the dead position node after an array move`() = runTest {
+        val doc = Document("")
+        doc.updateAsync { root, _ ->
+            root.setNewArray("arr").apply {
+                put(0)
+                put(1)
+                put(2)
+            }
+        }.await()
+        assertEquals(0, doc.garbageLength)
+
+        // move the element at index 2 after index 0 → its old position becomes a dead node
+        doc.updateAsync { root, _ ->
+            root.getAs<JsonArray>("arr").moveAfterByIndex(0, 2)
+        }.await()
+        assertEquals(1, doc.garbageLength)
+
+        doc.garbageCollect(maxVectorOf(listOf()))
+        assertEquals(0, doc.garbageLength)
     }
 }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/RgaTreeListTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/RgaTreeListTest.kt
@@ -3,6 +3,7 @@ package dev.yorkie.document.crdt
 import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.util.YorkieException
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
@@ -250,6 +251,165 @@ class RgaTreeListTest {
         assertNotNull(loserDead)
         assertNotNull(loserDead?.positionRemovedAt)
         assertNull(loserDead?.elementEntry)
+    }
+
+    @Test
+    fun `should throw when the insertAfter anchor does not exist`() {
+        target.insert(crdtElements[0])
+
+        assertThrows(YorkieException::class.java) {
+            target.insertAfter(createTimeTicket(), crdtElements[1])
+        }
+    }
+
+    @Test
+    fun `should resolve the insertAfter anchor by element key after its position was purged`() {
+        // given — [A, B]; move A after B so A's original position becomes a dead node
+        val list = RgaTreeList()
+        val a = CrdtPrimitive("A", tick(1))
+        val b = CrdtPrimitive("B", tick(2))
+        listOf(a, b).forEach(list::insert)
+        val dead = requireNotNull(list.moveAfter(b.createdAt, a.createdAt, tick(3)))
+
+        // when — purge the dead position node and anchor an insert on A's element key
+        list.delete(dead)
+        list.insertAfter(a.createdAt, CrdtPrimitive("C", tick(4)))
+
+        // then — the anchor resolves to A's current position: [B, A, C]
+        assertEquals("B", valueAt(list, 0))
+        assertEquals("A", valueAt(list, 1))
+        assertEquals("C", valueAt(list, 2))
+    }
+
+    @Test
+    fun `should throw when the moveAfter previous node does not exist`() {
+        target.insert(crdtElements[0])
+        target.insert(crdtElements[1])
+
+        assertThrows(YorkieException::class.java) {
+            target.moveAfter(createTimeTicket(), timeTickets[0], createTimeTicket())
+        }
+    }
+
+    @Test
+    fun `should ignore a duplicate moveAfter with the same executedAt`() {
+        val list = RgaTreeList()
+        val a = CrdtPrimitive("A", tick(1))
+        val b = CrdtPrimitive("B", tick(2))
+        listOf(a, b).forEach(list::insert)
+
+        val dead = list.moveAfter(b.createdAt, a.createdAt, tick(3))
+        val duplicate = list.moveAfter(b.createdAt, a.createdAt, tick(3))
+
+        assertNotNull(dead)
+        assertNull(duplicate)
+        assertEquals("B", valueAt(list, 0))
+        assertEquals("A", valueAt(list, 1))
+    }
+
+    @Test
+    fun `should apply a later move over an earlier applied move`() {
+        // given — [A, B, C]; first move A after B
+        val list = RgaTreeList()
+        val a = CrdtPrimitive("A", tick(1))
+        val b = CrdtPrimitive("B", tick(2))
+        val c = CrdtPrimitive("C", tick(3))
+        listOf(a, b, c).forEach(list::insert)
+        list.moveAfter(b.createdAt, a.createdAt, tick(4))
+
+        // when — a later move of the same element (executedAt > posMovedAt) wins
+        val dead = list.moveAfter(c.createdAt, a.createdAt, tick(5))
+
+        // then — [B, C, A] and the first move's position is returned dead
+        assertNotNull(dead)
+        assertEquals("B", valueAt(list, 0))
+        assertEquals("C", valueAt(list, 1))
+        assertEquals("A", valueAt(list, 2))
+    }
+
+    @Test
+    fun `should purge a dead position node only once`() {
+        val list = RgaTreeList()
+        val a = CrdtPrimitive("A", tick(1))
+        val b = CrdtPrimitive("B", tick(2))
+        listOf(a, b).forEach(list::insert)
+        val dead = requireNotNull(list.moveAfter(b.createdAt, a.createdAt, tick(3)))
+        assertEquals(3, list.allNodes().size)
+
+        list.delete(dead)
+        assertEquals(2, list.allNodes().size)
+
+        // purging the same position again is a no-op
+        list.delete(dead)
+        assertEquals(2, list.allNodes().size)
+    }
+
+    @Test
+    fun `should skip dead positions and removed elements in getPrevCreatedAt`() {
+        // given — [A, B, C]; move B after C leaves a dead node between A and C
+        val list = RgaTreeList()
+        val a = CrdtPrimitive("A", tick(1))
+        val b = CrdtPrimitive("B", tick(2))
+        val c = CrdtPrimitive("C", tick(3))
+        listOf(a, b, c).forEach(list::insert)
+        list.moveAfter(c.createdAt, b.createdAt, tick(4))
+
+        // then — C's previous skips the dead position node back to A
+        assertEquals(a.createdAt, list.getPrevCreatedAt(c.createdAt))
+
+        // and — removing A makes C's previous the dummy head
+        list.delete(a.createdAt, tick(5))
+        assertEquals(TimeTicket.InitialTimeTicket, list.getPrevCreatedAt(c.createdAt))
+    }
+
+    @Test
+    fun `should throw from subPathOf for an unknown element`() {
+        assertThrows(NoSuchElementException::class.java) {
+            target.subPathOf(createTimeTicket())
+        }
+    }
+
+    @Test
+    fun `should replace an element with set`() {
+        val list = RgaTreeList()
+        val a = CrdtPrimitive("A", tick(1))
+        val b = CrdtPrimitive("B", tick(2))
+        listOf(a, b).forEach(list::insert)
+
+        val removed = list.set(a.createdAt, CrdtPrimitive("A2", tick(3)), tick(3))
+
+        assertEquals(a, removed)
+        assertEquals(2, list.length)
+        assertEquals("A2", valueAt(list, 0))
+        assertEquals("B", valueAt(list, 1))
+
+        assertThrows(YorkieException::class.java) {
+            list.set(tick(99), CrdtPrimitive("X", tick(100)), tick(100))
+        }
+    }
+
+    @Test
+    fun `should compare lists by their element entries`() {
+        val list = RgaTreeList().apply { insert(CrdtPrimitive("A", tick(1))) }
+
+        assertEquals(list, list)
+        assertNotEquals(list, "not a list")
+        assertEquals(list.hashCode(), list.hashCode())
+        assertEquals("", RgaTreeList().toTestString())
+    }
+
+    @Test
+    fun `should count the position removal timestamp in the data size of a dead node`() {
+        val list = RgaTreeList()
+        val a = CrdtPrimitive("A", tick(1))
+        val b = CrdtPrimitive("B", tick(2))
+        listOf(a, b).forEach(list::insert)
+
+        val live = requireNotNull(list.getByIndex(0))
+        assertEquals(TimeTicket.TIME_TICKET_SIZE, live.dataSize.meta)
+
+        val dead = requireNotNull(list.moveAfter(b.createdAt, a.createdAt, tick(3)))
+        assertEquals(TimeTicket.TIME_TICKET_SIZE * 2, dead.dataSize.meta)
     }
 
     private fun tick(lamport: Long) = TimeTicket(lamport, TimeTicket.INITIAL_DELIMITER, "x")

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/RgaTreeListTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/RgaTreeListTest.kt
@@ -3,7 +3,9 @@ package dev.yorkie.document.crdt
 import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.util.YorkieException
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
@@ -171,6 +173,89 @@ class RgaTreeListTest {
         assertEquals(null, target.get(newTimeTicket))
         assertNotSame(null, target.get(timeTickets[0]))
     }
+
+    // Ported from yorkie-js-sdk v0.7.6 (#1227): concurrent moves of the same element
+    // resolve by LWW on the position; the later executedAt wins and the earlier one loses.
+    @Test
+    fun `should keep the later move on concurrent moves of the same element`() {
+        // given — list [A, B, C, D]
+        val list = RgaTreeList()
+        val a = CrdtPrimitive("A", tick(1))
+        val b = CrdtPrimitive("B", tick(2))
+        val c = CrdtPrimitive("C", tick(3))
+        val d = CrdtPrimitive("D", tick(4))
+        listOf(a, b, c, d).forEach(list::insert)
+        assertEquals(4, list.length)
+
+        // when — op2 (lamport 6): move A after D → [B, C, D, A]
+        val dead2 = list.moveAfter(d.createdAt, a.createdAt, tick(6))
+
+        // then — op2 wins and returns a dead node for the old position
+        assertNotNull(dead2)
+        assertEquals(4, list.length)
+        assertEquals("A", valueAt(list, 3))
+
+        // when — op1 (lamport 5 < 6): move A after C → loses LWW
+        val dead1 = list.moveAfter(c.createdAt, a.createdAt, tick(5))
+
+        // then — op1 loses but still creates a bare dead position node; list unchanged
+        assertNotNull(dead1)
+        assertNotNull(dead1?.positionRemovedAt)
+        assertNull(dead1?.elementEntry)
+        assertEquals(4, list.length)
+        assertEquals("A", valueAt(list, 3))
+    }
+
+    // Ported from yorkie-js-sdk v0.7.6 (#1227): concurrent moves of different elements commute.
+    @Test
+    fun `should commute concurrent moves of different elements`() {
+        val list = RgaTreeList()
+        val a = CrdtPrimitive("A", tick(1))
+        val b = CrdtPrimitive("B", tick(2))
+        val c = CrdtPrimitive("C", tick(3))
+        val d = CrdtPrimitive("D", tick(4))
+        listOf(a, b, c, d).forEach(list::insert)
+
+        // op1 (lamport 5): move A after B → [B, A, C, D]
+        list.moveAfter(b.createdAt, a.createdAt, tick(5))
+        // op2 (lamport 6): move C after D → [B, A, D, C]
+        list.moveAfter(d.createdAt, c.createdAt, tick(6))
+
+        assertEquals(4, list.length)
+        assertEquals("B", valueAt(list, 0))
+        assertEquals("A", valueAt(list, 1))
+        assertEquals("D", valueAt(list, 2))
+        assertEquals("C", valueAt(list, 3))
+    }
+
+    // Ported from yorkie-js-sdk v0.7.6 (#1227): moveAfter returns a dead position node for GC
+    // whether it wins or loses the LWW race.
+    @Test
+    fun `should return a dead position node on both LWW win and loss`() {
+        val list = RgaTreeList()
+        val a = CrdtPrimitive("A", tick(1))
+        val b = CrdtPrimitive("B", tick(2))
+        val c = CrdtPrimitive("C", tick(3))
+        listOf(a, b, c).forEach(list::insert)
+
+        // win: move A after C (lamport 5)
+        val winnerDead = list.moveAfter(c.createdAt, a.createdAt, tick(5))
+        assertNotNull(winnerDead)
+        assertNotNull(winnerDead?.positionRemovedAt)
+        assertNull(winnerDead?.elementEntry)
+        assertEquals(3, list.length)
+
+        // loss: move A again with an older executedAt (lamport 4)
+        val loserDead = list.moveAfter(b.createdAt, a.createdAt, tick(4))
+        assertNotNull(loserDead)
+        assertNotNull(loserDead?.positionRemovedAt)
+        assertNull(loserDead?.elementEntry)
+    }
+
+    private fun tick(lamport: Long) = TimeTicket(lamport, TimeTicket.INITIAL_DELIMITER, "x")
+
+    private fun valueAt(list: RgaTreeList, index: Int): Any? =
+        (list.getByIndex(index)?.value as? CrdtPrimitive)?.value
 
     private fun createTimeTicket(): TimeTicket {
         return TimeTicket(crdtElements.size.toLong(), TimeTicket.INITIAL_DELIMITER, "H")

--- a/yorkie/src/test/kotlin/dev/yorkie/document/operation/MoveOperationTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/operation/MoveOperationTest.kt
@@ -1,0 +1,66 @@
+package dev.yorkie.document.operation
+
+import dev.yorkie.document.crdt.CrdtArray
+import dev.yorkie.document.crdt.CrdtObject
+import dev.yorkie.document.crdt.CrdtPrimitive
+import dev.yorkie.document.crdt.CrdtRoot
+import dev.yorkie.document.crdt.ElementRht
+import dev.yorkie.document.time.TimeTicket
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MoveOperationTest {
+
+    private fun tick(lamport: Long) = TimeTicket(lamport, TimeTicket.INITIAL_DELIMITER, "A")
+
+    @Test
+    fun `should move the element and register the dead position node for gc`() {
+        // given — root.arr = [0, 1, 2]
+        val array = CrdtArray(tick(1))
+        val elements = (0..2).map { CrdtPrimitive(it, tick(2L + it)) }
+        elements.forEach { array.insertAfter(array.lastCreatedAt, it) }
+        val rootObject = CrdtObject(TimeTicket.InitialTimeTicket, memberNodes = ElementRht())
+        rootObject.set("arr", array, tick(5))
+        val root = CrdtRoot(rootObject)
+        assertEquals(0, root.garbageLength)
+
+        // when — move the element at index 2 after index 0
+        val operation = MoveOperation(
+            prevCreatedAt = elements[0].createdAt,
+            createdAt = elements[2].createdAt,
+            parentCreatedAt = array.createdAt,
+            executedAt = tick(6),
+        )
+        val result = operation.execute(root)
+
+        // then — [0, 2, 1], with a MoveOpInfo and the dead position registered for GC
+        val opInfo = result.opInfos.single() as OperationInfo.MoveOpInfo
+        assertEquals(2, opInfo.previousIndex)
+        assertEquals(1, opInfo.index)
+        assertEquals("1", array.subPathOf(elements[2].createdAt))
+        assertEquals(1, root.garbageLength)
+
+        // and — re-executing the same operation is idempotent and registers nothing new
+        operation.execute(root)
+        assertEquals("1", array.subPathOf(elements[2].createdAt))
+        assertEquals(1, root.garbageLength)
+    }
+
+    @Test
+    fun `should not execute when the parent is not an array`() {
+        // given — root.obj is an object, not an array
+        val rootObject = CrdtObject(TimeTicket.InitialTimeTicket, memberNodes = ElementRht())
+        val child = CrdtObject(tick(1), memberNodes = ElementRht())
+        rootObject.set("obj", child, tick(2))
+        val root = CrdtRoot(rootObject)
+
+        val result = MoveOperation(
+            prevCreatedAt = tick(1),
+            createdAt = tick(1),
+            parentCreatedAt = child.createdAt,
+            executedAt = tick(3),
+        ).execute(root)
+
+        assertEquals(emptyList<OperationInfo>(), result.opInfos)
+    }
+}


### PR DESCRIPTION
> **RTCOLLABPLATFORM-712**: [[Android] Sync-up Yorkie JS SDK v0.7.6](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-712)

## Summary
Ports **#1227** (LWW position register for array-move convergence) from yorkie-js-sdk v0.7.6 to Android, mirroring the merged iOS port ([yorkie-ios-sdk#258](https://github.com/yorkie-team/yorkie-ios-sdk/pull/258)). This is the large half of the v0.7.6 sync-up; the small fixes shipped in #334.

Without this, Android's array-move handling diverges from JS/iOS/the Go server under concurrency. The design separates **element identity** from **position identity**: concurrent moves of the same element resolve by LWW on the position, and the losing/old position becomes a **dead position node** that is garbage-collected.

## Changes
- **proto**: `RGANode` gains `position_created_at` / `position_moved_at` / `position_removed_at` (additive, wire-compatible; the Go server already supports them).
- **`RgaTreeList`**: rewritten around `ElementEntry` + position slots; `moveAfter` returns the dead node; `addDeadPosition` / `addMovedElement` for snapshot restore; iterator skips dead nodes; implements `GCParent`, `Node` implements `GCChild`.
- **`CrdtArray`**: `getRGATreeList` / `getAllRGANodes` / `posCreatedAt`; `deepCopy` preserves moved + dead positions.
- **`MoveOperation`**: registers the displaced dead node as a GC pair.
- **`JsonArray`**: converts element→position identity uniformly across all move paths (with fallback for position/head keys).
- **`ElementConverter`**: serializes/parses the three RGANode shapes (normal / moved / dead).
- **`CrdtRoot`**: registers array dead position nodes for GC.

## Test plan
- [ ] Instrumented `JsonArrayTest` `array_concurrency_table_test_move_*` suite stays green against a v0.7.6 server (primary convergence gate)
- [ ] Two clients performing concurrent array moves converge to the same order
- [ ] A moved array survives a snapshot round-trip (dead node not counted live)

> New unit tests (RgaTreeList LWW/dead-node, CrdtArray deepCopy + proto round-trip, GC of dead position node) and lint run automatically by CI.