### PR TITLE
RTCOLLABPLATFORM-713: Sync-up Yorkie JS SDK v0.7.7

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeConcurrencyTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeConcurrencyTest.kt
@@ -680,19 +680,17 @@ class JsonTreeConcurrencyTest {
                 element("p") {
                     element("p") {
                         element("p") {
-                            element("p") {
-                                text { "abcd" }
-                                attrs { mapOf("italic" to "a") }
-                            }
-                            element("p") {
-                                text { "efgh" }
-                                attrs { mapOf("italic" to "a") }
-                            }
-                        }
-                        element("p") {
-                            text { "ijkl" }
+                            text { "abcd" }
                             attrs { mapOf("italic" to "a") }
                         }
+                        element("p") {
+                            text { "efgh" }
+                            attrs { mapOf("italic" to "a") }
+                        }
+                    }
+                    element("p") {
+                        text { "ijkl" }
+                        attrs { mapOf("italic" to "a") }
                     }
                 }
             }

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeConcurrencyTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeConcurrencyTest.kt
@@ -12,7 +12,6 @@ import dev.yorkie.document.json.TreeBuilder.text
 import kotlin.test.assertEquals
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -485,9 +484,6 @@ class JsonTreeConcurrencyTest {
         }
     }
 
-    // splitLevel>=2 forward convergence still has unresolved offset and
-    // merge-redirect issues with nested elements.
-    @Ignore("splitLevel>=2 not yet supported; see RTCOLLABPLATFORM-651 design doc")
     @Test
     fun test_concurrent_split_and_split_L2() {
         runBlocking {
@@ -677,9 +673,6 @@ class JsonTreeConcurrencyTest {
         }
     }
 
-    // splitLevel>=2 split×edit tests fail due to the same nested element
-    // issues as the split×split suite above.
-    @Ignore("splitLevel>=2 not yet supported; see RTCOLLABPLATFORM-651 design doc")
     @Test
     fun test_concurrent_split_and_edit_L2() {
         runBlocking {

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeUndoTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeUndoTest.kt
@@ -508,6 +508,60 @@ class JsonTreeUndoTest {
     }
 
     /**
+     * Verifies undo/redo for splitLevel=2 (nested) split at front/middle/back (#1234).
+     * Tree: <doc><div><p>ABCD</p></div></doc> (indices: 2=before A, 4=between B/C, 6=after D).
+     */
+    @Test
+    fun test_undo_and_redo_split_l2_at_front() {
+        runL2SplitUndoRedoCase(
+            splitIdx = 2,
+            afterXml = "<doc><div><p></p></div><div><p>ABCD</p></div></doc>",
+        )
+    }
+
+    @Test
+    fun test_undo_and_redo_split_l2_at_middle() {
+        runL2SplitUndoRedoCase(
+            splitIdx = 4,
+            afterXml = "<doc><div><p>AB</p></div><div><p>CD</p></div></doc>",
+        )
+    }
+
+    @Test
+    fun test_undo_and_redo_split_l2_at_back() {
+        runL2SplitUndoRedoCase(
+            splitIdx = 6,
+            afterXml = "<doc><div><p>ABCD</p></div><div><p></p></div></doc>",
+        )
+    }
+
+    @Test
+    fun test_undo_redo_undo_split_l2_at_middle() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree(
+                    "tree",
+                    element("doc") {
+                        element("div") { element("p") { text { "ABCD" } } }
+                    },
+                )
+            }.await()
+            c1.syncAsync().await()
+            val before = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").edit(4, 4, 2)
+            }.await()
+            c1.syncAsync().await()
+
+            d1.history.undoAsync().await()
+            d1.history.redoAsync().await()
+            d1.history.undoAsync().await()
+            assertEquals(before, d1.getRoot().getAs<JsonTree>("tree").toXml())
+        }
+    }
+
+    /**
      * Verifies undo-redo-undo cycle for splitLevel=1 split returns to the
      * pre-split state.
      */
@@ -668,6 +722,33 @@ class JsonTreeUndoTest {
 
             d1.updateAsync { root, _ ->
                 root.getAs<JsonTree>("tree").edit(splitIdx, splitIdx, 1)
+            }.await()
+            c1.syncAsync().await()
+            assertEquals(afterXml, d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.undoAsync().await()
+            assertEquals(before, d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.redoAsync().await()
+            assertEquals(afterXml, d1.getRoot().getAs<JsonTree>("tree").toXml())
+        }
+    }
+
+    private fun runL2SplitUndoRedoCase(splitIdx: Int, afterXml: String) {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree(
+                    "tree",
+                    element("doc") {
+                        element("div") { element("p") { text { "ABCD" } } }
+                    },
+                )
+            }.await()
+            c1.syncAsync().await()
+            val before = d1.getRoot().getAs<JsonTree>("tree").toXml()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").edit(splitIdx, splitIdx, 2)
             }.await()
             c1.syncAsync().await()
             assertEquals(afterXml, d1.getRoot().getAs<JsonTree>("tree").toXml())

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -330,14 +330,10 @@ internal data class CrdtTree(
                 val next = findFloorNode(nextID) ?: break
                 if (next.isText) break
                 if (next.parent === toParent) {
-                    // Skip narrowing when toLeft === toParent (leftmost child
-                    // position, offset 0). The narrowed collectFromLeft would
-                    // be a child at offset >= 1, producing a backwards range
-                    // that suppresses the intended merge.
-                    if (toLeft !== toParent) {
-                        collectFromLeft = next
-                        collectFromParent = toParent
-                    }
+                    // Narrow unconditionally once a split sibling is found in
+                    // toParent, matching JS #1233 §3 / iOS narrowedCollectRange.
+                    collectFromLeft = next
+                    collectFromParent = toParent
                     break
                 }
                 current = next
@@ -524,15 +520,40 @@ internal data class CrdtTree(
         if (splitLevel > 0 && issueTimeTicket != null) {
             var parent = fromParent
             var left = fromLeft
-            repeat(splitLevel) {
-                parent.split(
-                    this,
-                    parent.findOffset(left, includeRemoved = true) + 1,
-                    issueTimeTicket,
-                    versionVector,
-                )
-                left = parent
-                parent = parent.parent ?: return@repeat
+            // `run` so an exhausted ancestor chain terminates the whole loop
+            // (return@run), rather than re-splitting the same node.
+            run {
+                repeat(splitLevel) {
+                    // §7.5 per-iteration advance: skip past unknown element split
+                    // siblings at this ancestor level. skipActorID (§7.7) prevents
+                    // advancing past our own split products.
+                    if (left !== parent) {
+                        left = advancePastUnknownSplitSiblings(
+                            left,
+                            versionVector,
+                            relaxParentCheck = true,
+                            skipActorID = executedAt.actorID,
+                        )
+                        val leftParent = left.parent
+                        if (leftParent != null && leftParent !== parent) {
+                            parent = leftParent
+                        }
+                    }
+
+                    val splitOffset = if (left !== parent) {
+                        parent.findOffset(left, includeRemoved = true) + 1
+                    } else {
+                        0
+                    }
+                    parent.split(
+                        this,
+                        splitOffset,
+                        issueTimeTicket,
+                        versionVector,
+                    )
+                    left = parent
+                    parent = parent.parent ?: return@run
+                }
             }
             changes.add(
                 TreeChange(
@@ -966,6 +987,8 @@ internal data class CrdtTree(
     private fun advancePastUnknownSplitSiblings(
         node: CrdtTreeNode,
         versionVector: VersionVector?,
+        relaxParentCheck: Boolean = false,
+        skipActorID: String? = null,
     ): CrdtTreeNode {
         if (versionVector == null || versionVector.size() == 0) return node
 
@@ -974,9 +997,16 @@ internal data class CrdtTree(
             val nextID = current.insNextID ?: return current
             val next = findFloorNode(nextID) ?: return current
             if (next.isText) return current
-            if (next.parent !== current.parent) return current
+            // §7.5: skip the parent check at ancestor iterations of the split
+            // loop, where a concurrent recursive split may have moved the
+            // sibling to a different parent.
+            if (!relaxParentCheck && next.parent !== current.parent) return current
 
             val actorID = next.id.createdAt.actorID
+            // §7.7: stop at siblings created by the current operation's actor —
+            // they are our own split products, not concurrent ones.
+            if (skipActorID != null && actorID == skipActorID) return current
+
             val knownLamport = versionVector.get(actorID)
             val isUnknown = knownLamport == null || knownLamport < next.id.createdAt.lamport
             if (!isUnknown) return current
@@ -1414,9 +1444,32 @@ internal data class CrdtTreeNode(
         val node = this
         split?.apply {
             split.insPrevID = node.id
-            node.insNextID?.let {
-                tree.findFloorNode(it)?.insPrevID = split.id
-                split.insNextID = node.insNextID
+            node.insNextID?.let { insNextID ->
+                val insNext = tree.findFloorNode(insNextID)
+                split.insNextID = insNextID
+                if (insNext != null) {
+                    insNext.insPrevID = split.id
+
+                    // §7.4 Empty Sibling Re-Parenting: when the existing insNext
+                    // sibling lives in a different parent (from a prior parent-
+                    // level split), move the new empty split sibling into that
+                    // parent. Skip when insNext is tombstoned (e.g. by an undo
+                    // boundary deletion): re-parenting into a removed element
+                    // would make the new split sibling invisible.
+                    val insNextParent = insNext.parent
+                    if (!node.isText &&
+                        insNextParent != null &&
+                        !insNext.isRemoved &&
+                        insNextParent !== split.parent &&
+                        split.allChildren.isEmpty()
+                    ) {
+                        // No try/catch: `split` was just inserted by splitElement,
+                        // so detachChild cannot fail here. Let a throw surface a
+                        // real structural bug (matches JS invariant).
+                        split.parent?.detachChild(split)
+                        insNextParent.insertBefore(insNext, split)
+                    }
+                }
             }
             node.insNextID = split.id
             tree.registerNode(split)
@@ -1446,6 +1499,14 @@ internal data class CrdtTreeNode(
         val mergedFrom = child.mergedFrom ?: return false
         if (versionVector.afterOrEqual(mergedAt)) return false
         return allChildren.any { sibling -> sibling.id == mergedFrom }
+    }
+
+    override fun isSplitSiblingSkipForBoundaryMigration(child: CrdtTreeNode): Boolean =
+        child.insPrevID != null && !child.isText
+
+    override fun isUnknownToEditor(child: CrdtTreeNode, versionVector: VersionVector): Boolean {
+        val knownLamport = versionVector.get(child.id.createdAt.actorID)
+        return knownLamport == null || knownLamport < child.id.createdAt.lamport
     }
 
     fun setAttributes(

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
@@ -140,10 +140,10 @@ internal data class TreeEditOperation(
                         .filterIsInstance<OperationInfo.TreeEditOpInfo>()
                         .firstOrNull()
                         ?.from ?: 0
-                val isPureL1Split =
-                    splitLevel == 1 && editContents.isNullOrEmpty() && result.removedNodes.isEmpty()
+                val isPureSplit =
+                    splitLevel > 0 && editContents.isNullOrEmpty() && result.removedNodes.isEmpty()
                 val reverseOp =
-                    if (isPureL1Split) {
+                    if (isPureSplit) {
                         toSplitReverseOperation(tree, fromIndex)
                     } else if (splitLevel == 0) {
                         toReverseOperation(
@@ -233,7 +233,7 @@ internal data class TreeEditOperation(
     }
 
     /**
-     * Builds the reverse [TreeEditOperation] for a pure splitLevel=1 split.
+     * Builds the reverse [TreeEditOperation] for a pure split (splitLevel > 0).
      *
      * A split creates 2*splitLevel boundary tokens (one close + one open tag
      * per level). The reverse is a boundary-deletion: a splitLevel=0 edit

--- a/yorkie/src/main/kotlin/dev/yorkie/document/yson/YsonParser.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/yson/YsonParser.kt
@@ -134,7 +134,11 @@ internal class YsonParser(private val input: String) {
             }
             'I' -> parseIntConstructor()
             'L' -> parseLongConstructor()
-            'D' -> parseDateConstructor()
+            'D' -> when {
+                matches("DedupCounter") -> parseDedupCounterConstructor()
+                matches("Date") -> parseDateConstructor()
+                else -> throw error("Unknown keyword starting with 'D'")
+            }
             'B' -> parseBinDataConstructor()
             'C' -> parseCounterConstructor()
             '-', in '0'..'9' -> parseNumber()
@@ -355,6 +359,28 @@ internal class YsonParser(private val input: String) {
         skipWhitespace()
         expect(')')
         return YsonValue.YsonCounter(inner)
+    }
+
+    private fun parseDedupCounterConstructor(): YsonValue.YsonDedupCounter {
+        expectKeyword("DedupCounter")
+        expect('(')
+        skipWhitespace()
+        val inner = parseValue()
+        if (inner !is YsonValue.YsonInt) {
+            throw YorkieException(
+                YorkieException.Code.ErrInvalidArgument,
+                "DedupCounter must contain Int",
+            )
+        }
+        expect(',')
+        skipWhitespace()
+        if (peek() != '"') {
+            throw error("DedupCounter expects a string literal for registers")
+        }
+        val registers = parseString()
+        skipWhitespace()
+        expect(')')
+        return YsonValue.YsonDedupCounter(inner, registers)
     }
 
     private fun parseTextConstructor(): YsonValue.YsonText {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/yson/YsonValue.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/yson/YsonValue.kt
@@ -79,6 +79,24 @@ public sealed interface YsonValue {
     }
 
     /**
+     * [YsonDedupCounter] represents a DedupCounter CRDT that counts unique actors via
+     * HyperLogLog, serialized as `DedupCounter(Int(...),"base64")`.
+     *
+     * [value] is constrained at construction to be a [YsonInt] (dedup counters are always
+     * Int-valued); [registers] is the Base64-encoded HLL register state.
+     */
+    public data class YsonDedupCounter(
+        public val value: YsonValue,
+        public val registers: String,
+    ) : YsonValue {
+        init {
+            require(value is YsonInt) {
+                "DedupCounter must contain Int"
+            }
+        }
+    }
+
+    /**
      * [YsonText] represents a Text CRDT, serialized as `Text([...])`.
      */
     public data class YsonText(public val nodes: List<YsonTextNode>) : YsonValue
@@ -151,6 +169,11 @@ public fun isBinData(value: Any?): Boolean = value is YsonValue.YsonBinData
  * [isCounter] returns true when [value] is a [YsonValue.YsonCounter].
  */
 public fun isCounter(value: Any?): Boolean = value is YsonValue.YsonCounter
+
+/**
+ * [isDedupCounter] returns true when [value] is a [YsonValue.YsonDedupCounter].
+ */
+public fun isDedupCounter(value: Any?): Boolean = value is YsonValue.YsonDedupCounter
 
 /**
  * [isObject] returns true when [value] is a plain [YsonValue.YsonObject], not a CRDT or special type.

--- a/yorkie/src/main/kotlin/dev/yorkie/util/IndexTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/IndexTree.kt
@@ -806,6 +806,39 @@ abstract class IndexTreeNode<T : IndexTreeNode<T>> {
             child.parent = this as T
         }
 
+        // §7.3 Boundary Insert Migration: move concurrent inserts sitting at the
+        // split boundary back to the left node so a split whose range was decided
+        // before those inserts still covers them. Element split siblings are
+        // skipped (handled by §7.4 re-parenting) but scanning continues past them.
+        // Two-list (snapshot/classify/reassign) to avoid mutate-while-iterate.
+        if (versionVector != null && versionVector.size() > 0) {
+            val migrate = mutableListOf<T>()
+            val remaining = mutableListOf<T>()
+            var boundaryReached = false
+            for (child in clone.childNodes.toList()) {
+                if (!boundaryReached) {
+                    if (isSplitSiblingSkipForBoundaryMigration(child)) {
+                        remaining.add(child)
+                        continue
+                    }
+                    if (isUnknownToEditor(child, versionVector)) {
+                        migrate.add(child)
+                        continue
+                    }
+                }
+                boundaryReached = true
+                remaining.add(child)
+            }
+            if (migrate.isNotEmpty()) {
+                clone.childNodes.clear()
+                remaining.forEach { clone.childNodes.add(it) }
+                migrate.forEach { child ->
+                    childNodes.add(child)
+                    child.parent = this as T
+                }
+            }
+        }
+
         visibleSize = childNodes.fold(0) { acc, child ->
             acc + if (child.isRemoved) 0 else child.paddedSize(false)
         }
@@ -844,6 +877,19 @@ abstract class IndexTreeNode<T : IndexTreeNode<T>> {
         versionVector: VersionVector?,
         allChildren: List<T>,
     ): Boolean = false
+
+    /**
+     * Returns true when [child] is an element split sibling that the §7.3
+     * boundary-insert migration must skip (not migrate) but keep scanning past.
+     * Subclasses override; the default returns false.
+     */
+    open fun isSplitSiblingSkipForBoundaryMigration(child: T): Boolean = false
+
+    /**
+     * Returns true when [child] was created by an operation the editor did not
+     * yet know about (per [versionVector]). Subclasses override; default false.
+     */
+    open fun isUnknownToEditor(child: T, versionVector: VersionVector): Boolean = false
 
     private fun insertAfterInternal(targetNode: T, newNode: T) {
         check(!isText) {

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTreeTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtTreeTest.kt
@@ -830,6 +830,140 @@ class CrdtTreeTest {
         assertEquals(mergeTicket, clonedText.mergedAt)
     }
 
+    @Test
+    fun `split re-parents an empty split sibling into the insNext parent`() {
+        // given a multi-level split tree where the first <b>'s insNext is the
+        // second <b> living in another parent
+        val tree = createMultiLevelSplitTree()
+        assertEquals("<root><p><b>a</b></p><p><b>b</b></p></root>", tree.toXml())
+
+        // when splitting the first <b> at its end, producing an empty split sibling
+        var delimiter = 0u
+        tree.editAt(3, null, tick(SPLIT_LAMPORT + 2, 99u), splitLevel = 1) {
+            tick(SPLIT_LAMPORT + 2, delimiter++)
+        }
+
+        // then the empty sibling is re-parented next to its insNext sibling (§7.4)
+        assertEquals("<root><p><b>a</b></p><p><b></b><b>b</b></p></root>", tree.toXml())
+    }
+
+    @Test
+    fun `split loop advances parent when the left node lives in a split sibling parent`() {
+        // given a multi-level split tree where the first <b>'s unknown split
+        // sibling (the second <b>) was moved to another parent by the L2 split
+        val tree = createMultiLevelSplitTree()
+
+        // when an editor unaware of the split (vv lamport 4 < split lamport 6)
+        // splits right after the first <b>
+        var delimiter = 0u
+        val pos = tree.findPos(4)
+        tree.edit(
+            pos to pos,
+            null,
+            1,
+            tick(SPLIT_LAMPORT + 2, 99u, ACTOR_B),
+            { tick(SPLIT_LAMPORT + 2, delimiter++, ACTOR_B) },
+            VersionVector(mapOf(ACTOR_A to 4L)),
+        )
+
+        // then the advance crosses into the sibling's parent (§7.5) and the
+        // second <p> is split instead of the first
+        assertEquals(
+            "<root><p><b>a</b></p><p><b>b</b></p><p></p></root>",
+            tree.toXml(),
+        )
+    }
+
+    @Test
+    fun `split keeps an empty sibling local when its insNext sibling is tombstoned`() {
+        // given a multi-level split tree whose second <b> is deleted
+        val tree = createMultiLevelSplitTree()
+        tree.edit(
+            tree.findPos(6) to tree.findPos(9),
+            null,
+            0,
+            tick(SPLIT_LAMPORT + 2, 99u),
+        )
+        assertEquals("<root><p><b>a</b></p><p></p></root>", tree.toXml())
+
+        // when splitting the first <b> at its end
+        var delimiter = 0u
+        tree.editAt(3, null, tick(SPLIT_LAMPORT + 3, 99u), splitLevel = 1) {
+            tick(SPLIT_LAMPORT + 3, delimiter++)
+        }
+
+        // then the empty sibling is not re-parented next to the removed insNext (§7.4)
+        assertEquals("<root><p><b>a</b><b></b></p><p></p></root>", tree.toXml())
+    }
+
+    @Test
+    fun `split skips re-parenting when the insNext sibling shares the parent`() {
+        // given <root><p>a</p><p>b</p></root> where both split siblings are
+        // children of the root
+        val tree = createSplitTree()
+
+        // when splitting the first <p> at its end
+        var delimiter = 0u
+        tree.editAt(2, null, tick(SPLIT_LAMPORT + 2, 99u), splitLevel = 1) {
+            tick(SPLIT_LAMPORT + 2, delimiter++)
+        }
+
+        // then the empty sibling stays in place (§7.4 needs a different parent)
+        assertEquals("<root><p>a</p><p></p><p>b</p></root>", tree.toXml())
+    }
+
+    @Test
+    fun `split skips re-parenting when the new sibling has children`() {
+        // given a multi-level split tree
+        val tree = createMultiLevelSplitTree()
+
+        // when splitting the first <b> at its front so the new sibling takes the text
+        var delimiter = 0u
+        tree.editAt(2, null, tick(SPLIT_LAMPORT + 2, 99u), splitLevel = 1) {
+            tick(SPLIT_LAMPORT + 2, delimiter++)
+        }
+
+        // then the non-empty sibling stays in place (§7.4 only moves empty siblings)
+        assertEquals("<root><p><b></b><b>a</b></p><p><b>b</b></p></root>", tree.toXml())
+    }
+
+    @Test
+    fun `edit with splitLevel exceeding tree depth stops at the root`() {
+        //       0   1 2 3    4
+        // <root> <p> a b </p> </root>
+        target.edit(0 to 0, CrdtTreeElement(issuePos(), "p").toList())
+        target.edit(1 to 1, CrdtTreeText(issuePos(), "ab").toList())
+        assertEquals("<root><p>ab</p></root>", target.toXml())
+
+        // splitLevel 2 splits <p> and then the root itself; the loop stops when
+        // the root has no parent instead of re-splitting the same node
+        target.edit(3 to 3, null, 2)
+        assertEquals("<root><p>ab</p></root>", target.toXml())
+        assertEquals(4, target.size)
+    }
+
+    @Test
+    fun `boundary insert migration follows the editor version vector`() {
+        // given <root><p>ab</p></root> with the text created by actor A (lamport 3)
+
+        // when the editor knows the text's creation, it stays in the split sibling
+        var tree = createBoundaryMigrationTree()
+        splitAtFront(tree, VersionVector(mapOf(ACTOR_A to 5L)))
+        assertEquals("<root><p></p><p>ab</p></root>", tree.toXml())
+
+        // when the text's actor is missing from the version vector, it migrates
+        // back to the left node (§7.3)
+        tree = createBoundaryMigrationTree()
+        splitAtFront(tree, VersionVector(mapOf(ACTOR_B to 5L)))
+        assertEquals("<root><p>ab</p><p></p></root>", tree.toXml())
+
+        // when the editor's known lamport is older than the text's creation,
+        // it also migrates back to the left node
+        tree = createBoundaryMigrationTree()
+        splitAtFront(tree, VersionVector(mapOf(ACTOR_A to 2L)))
+        assertEquals("<root><p>ab</p><p></p></root>", tree.toXml())
+    }
+
     private fun issuePos(offset: Int = 0) = CrdtTreeNodeID(issueTime(), offset)
 
     private fun CrdtTreeNode.toList() = listOf(this)
@@ -908,6 +1042,35 @@ class CrdtTreeTest {
             tick(SPLIT_LAMPORT + 1, delimiter++)
         }
         return tree
+    }
+
+    /**
+     * Builds `<root><p>ab</p></root>` where the text is created by [ACTOR_A]
+     * at lamport 3, for §7.3 boundary-insert migration tests.
+     */
+    private fun createBoundaryMigrationTree(): CrdtTree {
+        val tree = CrdtTree(CrdtTreeElement(CrdtTreeNodeID(tick(1), 0), "root"), tick(1))
+        tree.editAt(0, CrdtTreeElement(CrdtTreeNodeID(tick(2), 0), "p").toList(), tick(2, 1u))
+        tree.editAt(1, CrdtTreeText(CrdtTreeNodeID(tick(3), 0), "ab").toList(), tick(3, 1u))
+        return tree
+    }
+
+    /**
+     * Splits the `<p>` of [tree] at its front (offset 0) as [ACTOR_B] with the
+     * given [versionVector], so all children land in the split sibling unless
+     * the §7.3 boundary-insert migration moves them back.
+     */
+    private fun splitAtFront(tree: CrdtTree, versionVector: VersionVector) {
+        var delimiter = 0u
+        val pos = tree.findPos(1)
+        tree.edit(
+            pos to pos,
+            null,
+            1,
+            tick(SPLIT_LAMPORT, 99u, ACTOR_B),
+            { tick(SPLIT_LAMPORT, delimiter++, ACTOR_B) },
+            versionVector,
+        )
     }
 
     companion object {

--- a/yorkie/src/test/kotlin/dev/yorkie/document/operation/TreeEditOperationReverseTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/operation/TreeEditOperationReverseTest.kt
@@ -41,6 +41,7 @@ class TreeEditOperationReverseTest {
         toIndex: Int,
         contents: List<CrdtTreeNode>?,
         lamport: Long,
+        splitLevel: Int = 0,
     ): TreeEditOperation {
         val ticket = makeTicket(lamport)
         val (fromPos, toPos) = tree.indexRangeToPosRange(fromIndex to toIndex)
@@ -49,7 +50,7 @@ class TreeEditOperationReverseTest {
             fromPos = fromPos,
             toPos = toPos,
             contents = contents,
-            splitLevel = 0,
+            splitLevel = splitLevel,
             executedAt = ticket,
         )
     }
@@ -128,6 +129,73 @@ class TreeEditOperationReverseTest {
         assertTrue(snapshots.isNotEmpty())
         val snapshot = snapshots[0] as TreeElementNode
         assertEquals("p", snapshot.type)
+    }
+
+    // #1234: pure splits at any level > 0 produce a boundary-deletion reverse op tagged
+    // with redoSplitLevel so redo re-splits (was only splitLevel == 1 before).
+
+    @Test
+    fun `reverse of pure L1 split is a boundary-deletion tagged for redo`() {
+        // given: <root><p>ab</p></root>
+        val (tree, root) = buildTreeRoot()
+        val pNode = CrdtTreeElement(CrdtTreeNodeID(makeTicket(3), 0), "p")
+        makeTreeEditOp(tree, 0, 0, listOf(pNode), 3).execute(root, OpSource.Local, null)
+        val textNode = CrdtTreeText(CrdtTreeNodeID(makeTicket(4), 0), "ab")
+        makeTreeEditOp(tree, 1, 1, listOf(textNode), 4).execute(root, OpSource.Local, null)
+
+        // when: pure splitLevel=1 split between a and b
+        val op = makeTreeEditOp(tree, 2, 2, null, 5, splitLevel = 1)
+        val result = op.execute(root, OpSource.Local, null)
+
+        // then: reverse is a splitLevel=0 boundary deletion tagged redoSplitLevel=1
+        assertEquals(1, result.reverseOps.size)
+        val reverseOp = result.reverseOps[0] as TreeEditOperation
+        assertTrue(reverseOp.isUndoOp)
+        assertEquals(null, reverseOp.contents)
+        assertEquals(0, reverseOp.splitLevel)
+        assertEquals(1, reverseOp.redoSplitLevel)
+    }
+
+    @Test
+    fun `reverse of pure L2 split is generated`() {
+        // given: <root><div><p>ab</p></div></root>
+        val (tree, root) = buildTreeRoot()
+        val divNode = CrdtTreeElement(CrdtTreeNodeID(makeTicket(3), 0), "div")
+        makeTreeEditOp(tree, 0, 0, listOf(divNode), 3).execute(root, OpSource.Local, null)
+        val pNode = CrdtTreeElement(CrdtTreeNodeID(makeTicket(4), 0), "p")
+        makeTreeEditOp(tree, 1, 1, listOf(pNode), 4).execute(root, OpSource.Local, null)
+        val textNode = CrdtTreeText(CrdtTreeNodeID(makeTicket(5), 0), "ab")
+        makeTreeEditOp(tree, 2, 2, listOf(textNode), 5).execute(root, OpSource.Local, null)
+
+        // when: pure splitLevel=2 split (splits both p and div)
+        val op = makeTreeEditOp(tree, 3, 3, null, 6, splitLevel = 2)
+        val result = op.execute(root, OpSource.Local, null)
+
+        // then: a reverse op IS produced (before #1234, splitLevel>1 gave null)
+        assertEquals(1, result.reverseOps.size)
+        val reverseOp = result.reverseOps[0] as TreeEditOperation
+        assertTrue(reverseOp.isUndoOp)
+        assertEquals(null, reverseOp.contents)
+        assertEquals(0, reverseOp.splitLevel)
+        assertEquals(2, reverseOp.redoSplitLevel)
+    }
+
+    @Test
+    fun `split with content is not treated as a pure split`() {
+        // given: <root><p>ab</p></root>
+        val (tree, root) = buildTreeRoot()
+        val pNode = CrdtTreeElement(CrdtTreeNodeID(makeTicket(3), 0), "p")
+        makeTreeEditOp(tree, 0, 0, listOf(pNode), 3).execute(root, OpSource.Local, null)
+        val textNode = CrdtTreeText(CrdtTreeNodeID(makeTicket(4), 0), "ab")
+        makeTreeEditOp(tree, 1, 1, listOf(textNode), 4).execute(root, OpSource.Local, null)
+
+        // when: splitLevel=1 AND inserting content — not a pure split
+        val insNode = CrdtTreeText(CrdtTreeNodeID(makeTicket(5), 0), "X")
+        val op = makeTreeEditOp(tree, 2, 2, listOf(insNode), 5, splitLevel = 1)
+        val result = op.execute(root, OpSource.Local, null)
+
+        // then: no reverse op (isPureSplit false, splitLevel != 0)
+        assertTrue(result.reverseOps.isEmpty())
     }
 
     @Test

--- a/yorkie/src/test/kotlin/dev/yorkie/document/yson/YsonParserTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/yson/YsonParserTest.kt
@@ -299,6 +299,68 @@ class YsonParserTest {
         assertEquals(100L, (counter.value as YsonValue.YsonLong).value)
     }
 
+    // --- dedup counter (#1232) ---
+
+    @Test
+    fun `parse should decode DedupCounter with Int value and HLL registers`() {
+        val result = parse("{\"value\":DedupCounter(Int(15),\"AQIDBA==\")}") as YsonValue.YsonObject
+        val value = result.entries["value"]
+        assertTrue(isDedupCounter(value))
+        val dedup = value as YsonValue.YsonDedupCounter
+        assertTrue(isInt(dedup.value))
+        assertEquals(15, (dedup.value as YsonValue.YsonInt).value)
+        assertEquals("AQIDBA==", dedup.registers)
+    }
+
+    @Test
+    fun `parse should decode DedupCounter with zero value`() {
+        val result = parse("{\"value\":DedupCounter(Int(0),\"AAAA\")}") as YsonValue.YsonObject
+        val dedup = result.entries["value"] as YsonValue.YsonDedupCounter
+        assertEquals(0, (dedup.value as YsonValue.YsonInt).value)
+        assertEquals("AAAA", dedup.registers)
+    }
+
+    @Test
+    fun `parse should decode DedupCounter alongside Counter`() {
+        val result = parse(
+            "{\"counter\":Counter(Int(10)),\"dedup\":DedupCounter(Int(5),\"dGVzdA==\")}",
+        ) as YsonValue.YsonObject
+        assertTrue(isCounter(result.entries["counter"]))
+        assertTrue(isDedupCounter(result.entries["dedup"]))
+    }
+
+    @Test
+    fun `isDedupCounter and isCounter are mutually exclusive`() {
+        val counter = parse("Counter(Int(10))")
+        val dedup = parse("DedupCounter(Int(5),\"dGVzdA==\")")
+        assertTrue(isCounter(counter))
+        assertFalse(isDedupCounter(counter))
+        assertTrue(isDedupCounter(dedup))
+        assertFalse(isCounter(dedup))
+        assertFalse(isObject(dedup))
+    }
+
+    @Test
+    fun `YsonDedupCounter constructor should reject non integer value`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            YsonValue.YsonDedupCounter(YsonValue.YsonString("nope"), "AAAA")
+        }
+    }
+
+    @Test
+    fun `parse should reject DedupCounter with Long payload`() {
+        assertThrows(YorkieException::class.java) {
+            parse("{\"value\":DedupCounter(Long(5),\"AAAA\")}")
+        }
+    }
+
+    @Test
+    fun `parse should reject DedupCounter missing registers argument`() {
+        assertThrows(YorkieException::class.java) {
+            parse("{\"value\":DedupCounter(Int(5))}")
+        }
+    }
+
     // --- complex document ---
 
     @Test
@@ -314,6 +376,7 @@ class YsonParserTest {
               "bytes": BinData("AQID"),
               "date": Date("2025-01-02T15:04:05.058Z"),
               "counter": Counter(Int(10)),
+              "dedup": DedupCounter(Int(3),"AQID"),
               "text": Text([{"val":"Hello"}]),
               "tree": Tree({"type":"p","children":[{"type":"text","value":"Hello World"}]})
             }
@@ -329,6 +392,7 @@ class YsonParserTest {
         assertTrue(isBinData(result.entries["bytes"]))
         assertTrue(isDate(result.entries["date"]))
         assertTrue(isCounter(result.entries["counter"]))
+        assertTrue(isDedupCounter(result.entries["dedup"]))
         assertTrue(isText(result.entries["text"]))
         assertTrue(isTree(result.entries["tree"]))
     }


### PR DESCRIPTION
> **RTCOLLABPLATFORM-713**: [[Android] Sync-up Yorkie JS SDK v0.7.7](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-713)

## Summary
Ports yorkie-js-sdk **v0.7.7** to Android, mirroring the merged iOS port ([yorkie-ios-sdk#259](https://github.com/yorkie-team/yorkie-ios-sdk/pull/259)). Three changes, no proto change.

> **Stacked on #335** (v0.7.6 #1227). Base will auto-retarget to `develop` once #335 merges. The v0.7.7 tree/YSON changes are disjoint from #335's array changes.

## Changes
- **#1232 — DedupCounter YSON parse**: parse the Go-server literal `DedupCounter(Int(n),"base64")` into a new `YsonDedupCounter` value (disambiguates the `'D'` Date/DedupCounter dispatch in `YsonParser`). Without it, snapshots containing dedup counters fail to parse.
- **#1233 — splitLevel≥2 convergence**: port the six §7.x fixes — §7.3 boundary-insert migration (via `IndexTreeNode` hooks so the generic tree stays CRDT-agnostic), §7.4 empty-sibling re-parenting in `split`, §7.5/§7.7 `advancePastUnknownSplitSiblings` (`relaxParentCheck`/`skipActorID`) + per-iteration ancestor advance in the split loop. The §3 range-narrowing is aligned to JS/iOS (removed the Android-only `toLeft !== toParent` guard).
- **#1234 — splitLevel≥2 undo/redo**: generalize pure-split reverse detection from `splitLevel == 1` to `splitLevel > 0` (`boundarySize = 2·splitLevel` re-splits on redo). The redo tombstone guard (`!insNext.isRemoved`) is the same §7.4 block.
- **Test fixture fix — `test_concurrent_split_and_edit_L2`**: the enabled L2 split-edit test had an extra `<p>` wrapper in its root tree (copied from the split-split L2 fixture) while keeping the L1 `initialXml`/ranges, so it failed the initial-XML assertion before exercising any concurrency logic. Aligned the fixture to JS v0.7.7 (`concurrently-split-edit-test (splitLevel>=2)` uses the same tree as L1 — only `splitLevel` differs).

## Tests
- Unit (green): `YsonParserTest` DedupCounter (positive/exclusivity/negative); `TreeEditOperationReverseTest` L1 baseline + **L2 pure-split reverse** + `isPureSplit` disjointness.
- Instrumented (enabled/added, run by CI against a v0.7.7 server): un-`@Ignore`d `test_concurrent_split_and_split_L2` / `test_concurrent_split_and_edit_L2`; added L2 split undo/redo cases (front/middle/back + undo-redo-undo).
- **`test_concurrent_split_and_edit_L2` verified green locally** (all 9 ranges × 8 edit ops) against a local Docker Yorkie server after the fixture fix.
- Full unit suite + `lintKotlin` + androidTest compilation all green locally.

## Test plan
- [ ] `JsonTreeConcurrencyTest` L2 suites converge against a v0.7.7 server (authoritative gate)
- [ ] `JsonTreeUndoTest` L2 undo/redo passes against a v0.7.7 server
- [ ] Snapshot containing a `DedupCounter` parses

> Instrumented convergence tests require a Docker Yorkie server v0.7.7 — exercised by CI.
