### PR TITLE
RTCOLLABPLATFORM-714: Sync-up Yorkie JS SDK v0.7.8

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/SyncModePollingTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/SyncModePollingTest.kt
@@ -1,0 +1,71 @@
+package dev.yorkie.core
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.yorkie.document.Document
+import dev.yorkie.document.json.JsonPrimitive
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies [Client.SyncMode.Polling]: a document synced without a watch stream
+ * still pushes local changes and pulls remote changes on the poll interval.
+ * Mirrors JS SDK PR #1243.
+ */
+@RunWith(AndroidJUnit4::class)
+class SyncModePollingTest {
+
+    @Test
+    fun test_polling_pushes_and_pulls_without_watch_stream() {
+        runBlocking {
+            // Short poll interval keeps the test fast.
+            val poller = createClient(Client.Options(documentPollInterval = 200.milliseconds))
+            val peer = createClient()
+            val key = UUID.randomUUID().toString().toDocKey()
+            val pollingDoc = Document(key)
+            val peerDoc = Document(key)
+
+            poller.activateAsync().await()
+            peer.activateAsync().await()
+            poller.attachDocument(pollingDoc, syncMode = Client.SyncMode.Polling).await()
+            peer.attachDocument(peerDoc, syncMode = Client.SyncMode.Manual).await()
+
+            // Remote change committed by the peer — the poller must pull it on
+            // its interval without any local activity or manual sync.
+            peerDoc.updateAsync { root, _ -> root["k1"] = "v1" }.await()
+            peer.syncAsync(peerDoc).await()
+
+            withTimeout(5_000) {
+                while (pollingDoc.getRoot().getOrNull("k1") == null) {
+                    delay(100)
+                }
+            }
+            assertEquals("v1", pollingDoc.getRoot().getAs<JsonPrimitive>("k1").value)
+
+            // Local change on the poller must be pushed on its interval so the
+            // peer sees it after a manual pull.
+            pollingDoc.updateAsync { root, _ -> root["k2"] = "v2" }.await()
+            withTimeout(5_000) {
+                while (peerDoc.getRoot().getOrNull("k2") == null) {
+                    delay(100)
+                    peer.syncAsync(peerDoc).await()
+                }
+            }
+            assertEquals("v2", peerDoc.getRoot().getAs<JsonPrimitive>("k2").value)
+
+            poller.detachDocument(pollingDoc).await()
+            peer.detachDocument(peerDoc).await()
+            poller.deactivateAsync().await()
+            peer.deactivateAsync().await()
+            pollingDoc.close()
+            peerDoc.close()
+            poller.close()
+            peer.close()
+        }
+    }
+}

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/UndoRedoTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/UndoRedoTest.kt
@@ -109,11 +109,36 @@ class UndoRedoTest {
     }
 
     @Test
-    fun test_undo_empty_stack_throws() {
+    fun test_attach_clears_undo_history() {
+        // Pre-attach (offline) edits must not be reachable via undo after
+        // attach, so setup/initialRoot ops cannot be undone. JS SDK PR #1238.
+        withTwoClientsAndDocuments(
+            attachDocuments = false,
+            detachDocuments = false,
+            syncMode = Manual,
+        ) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root["k1"] = "v1"
+            }.await()
+            assertTrue(d1.history.canUndo())
+
+            c1.attachDocument(d1, syncMode = Manual).await()
+            assertFalse(d1.history.canUndo())
+            assertFalse(d1.history.canRedo())
+
+            c1.detachDocument(d1).await()
+        }
+    }
+
+    @Test
+    fun test_undo_empty_stack_is_noop() {
         withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
             assertFalse(d1.history.canUndo())
-            val result = d1.history.undoAsync().await()
-            assertTrue(result.isFailure)
+            // Empty stack undo/redo is a silent no-op (JS SDK PR #1238).
+            assertTrue(d1.history.undoAsync().await().isSuccess)
+            assertTrue(d1.history.redoAsync().await().isSuccess)
+            assertFalse(d1.history.canUndo())
+            assertFalse(d1.history.canRedo())
         }
     }
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTextHistoryTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTextHistoryTest.kt
@@ -116,10 +116,10 @@ class JsonTextHistoryTest {
             // Only the setNewText op was pushed — undo the set to get to empty undo stack
             d1.history.undoAsync().await()
 
-            // Now undo stack should be empty
+            // Now undo stack should be empty — undo is a silent no-op (JS SDK PR #1238)
             assertFalse(d1.history.canUndo())
             val result = d1.history.undoAsync().await()
-            assertTrue(result.isFailure)
+            assertTrue(result.isSuccess)
         }
     }
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeSplitMergeTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeSplitMergeTest.kt
@@ -6,6 +6,8 @@ import dev.yorkie.core.Client.SyncMode.Manual
 import dev.yorkie.core.withTwoClientsAndDocuments
 import dev.yorkie.document.json.JsonTreeTest.Companion.rootTree
 import dev.yorkie.document.json.JsonTreeTest.Companion.updateAndSync
+import dev.yorkie.document.json.TreeBuilder.element
+import dev.yorkie.document.json.TreeBuilder.text
 import kotlin.test.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -827,6 +829,56 @@ class JsonTreeSplitMergeTest {
             }
 
             JsonTreeTest.assertTreesXmlEquals(d1.getRoot().rootTree().toXml(), d1, d2)
+        }
+    }
+
+    /**
+     * Split a block then merge it back via editByPath (wafflebase backspace).
+     * Phase 3 range narrowing must not suppress the merge when toLeft is the
+     * leftmost child (offset 0), which would leave the split in place. JS SDK
+     * PR #1237.
+     */
+    @Test
+    fun test_split_then_merge_blocks_using_editByPath() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree(
+                    "t",
+                    element("doc") {
+                        element("block") {
+                            element("inline") { text { "asdf" } }
+                        }
+                    },
+                )
+            }.await()
+            c1.syncAsync().await()
+            assertEquals(
+                "<doc><block><inline>asdf</inline></block></doc>",
+                d1.getRoot().getAs<JsonTree>("t").toXml(),
+            )
+
+            // Split at offset 2 with splitLevel = 2 (Enter after "as").
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>(
+                    "t",
+                ).editByPath(listOf(0, 0, 2), listOf(0, 0, 2), splitLevel = 2)
+            }.await()
+            c1.syncAsync().await()
+            assertEquals(
+                "<doc><block><inline>as</inline></block>" +
+                    "<block><inline>df</inline></block></doc>",
+                d1.getRoot().getAs<JsonTree>("t").toXml(),
+            )
+
+            // Merge via backspace at start of the second block.
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("t").editByPath(listOf(0, 1), listOf(1, 0))
+            }.await()
+            c1.syncAsync().await()
+            assertEquals(
+                "<doc><block><inline>as</inline><inline>df</inline></block></doc>",
+                d1.getRoot().getAs<JsonTree>("t").toXml(),
+            )
         }
     }
 }

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeUndoTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeUndoTest.kt
@@ -760,4 +760,99 @@ class JsonTreeUndoTest {
             assertEquals(afterXml, d1.getRoot().getAs<JsonTree>("tree").toXml())
         }
     }
+
+    /**
+     * Undo of a cross-boundary merge (editByPath([0,2],[1,0])) must restore the
+     * two sibling paragraphs, not nest them. The merge moves children out of the
+     * second block before returning, so re-inserting the emptied shell would
+     * produce <p>AB<p></p>CD</p>; the reverse must be a split. JS SDK PR #1237.
+     */
+    @Test
+    fun test_undo_cross_boundary_merge_restores_siblings() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree(
+                    "t",
+                    element("doc") {
+                        element("p") { text { "AB" } }
+                        element("p") { text { "CD" } }
+                    },
+                )
+            }.await()
+            c1.syncAsync().await()
+            val before = "<doc><p>AB</p><p>CD</p></doc>"
+            assertEquals(before, d1.getRoot().getAs<JsonTree>("t").toXml())
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("t").editByPath(listOf(0, 2), listOf(1, 0))
+            }.await()
+            c1.syncAsync().await()
+            assertEquals("<doc><p>ABCD</p></doc>", d1.getRoot().getAs<JsonTree>("t").toXml())
+
+            assertTrue(d1.history.canUndo())
+            d1.history.undoAsync().await()
+            assertEquals(before, d1.getRoot().getAs<JsonTree>("t").toXml())
+
+            d1.history.redoAsync().await()
+            assertEquals("<doc><p>ABCD</p></doc>", d1.getRoot().getAs<JsonTree>("t").toXml())
+        }
+    }
+
+    /**
+     * The redo reverse-op must not accumulate pre-tombstoned descendants across
+     * undo->redo cycles. Typing then fully undoing (through a block-insert) and
+     * redoing must keep the tree stable and let subsequent typing land in the
+     * right place. JS SDK PR #1239.
+     */
+    @Test
+    fun test_reverseOp_stable_across_redo_cycles() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree(
+                    "t",
+                    element("doc") {
+                        element("p") { element("inline") {} }
+                    },
+                )
+            }.await()
+            c1.syncAsync().await()
+
+            // Insert a sibling block: <doc><p><inline/></p><p><inline/></p></doc>
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("t").editByPath(
+                    listOf(1),
+                    listOf(1),
+                    element("p") { element("inline") {} },
+                )
+            }.await()
+            c1.syncAsync().await()
+
+            val stableXml =
+                "<doc><p><inline></inline></p><p><inline></inline></p></doc>"
+
+            repeat(3) {
+                // Type "asdf" into the second block's inline.
+                listOf("a", "s", "d", "f").forEachIndexed { cur, ch ->
+                    d1.updateAsync { root, _ ->
+                        root.getAs<JsonTree>("t")
+                            .editByPath(listOf(1, 0, cur), listOf(1, 0, cur), text { ch })
+                    }.await()
+                }
+                // Undo each char, then undo the block-insert.
+                repeat(5) { d1.history.undoAsync().await() }
+                // Redo just the block-insert for the next cycle.
+                d1.history.redoAsync().await()
+                assertEquals(stableXml, d1.getRoot().getAs<JsonTree>("t").toXml())
+            }
+
+            // Typing after the cycles must land in the second block.
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("t").editByPath(listOf(1, 0, 0), listOf(1, 0, 0), text { "z" })
+            }.await()
+            assertEquals(
+                "<doc><p><inline></inline></p><p><inline>z</inline></p></doc>",
+                d1.getRoot().getAs<JsonTree>("t").toXml(),
+            )
+        }
+    }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
@@ -39,9 +39,14 @@ internal class Attachment<R : Attachable>(
      * `needSync` determines if the attachment needs sync.
      * This includes both document sync and presence heartbeat.
      */
-    fun needSync(heartbeatInterval: Long): Boolean {
+    fun needSync(heartbeatInterval: Long, documentPollInterval: Long): Boolean {
         // For Document: check if realtime sync is needed
         if (resource is Document) {
+            // Polling has no watch stream, so it pushes and pulls on a fixed
+            // interval regardless of local changes. Mirrors JS SDK PR #1243.
+            if (syncMode == Client.SyncMode.Polling) {
+                return System.currentTimeMillis() - lastHeartbeatTime >= documentPollInterval
+            }
             return needRealTimeSync()
         }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -351,6 +351,16 @@ public class Client(
                 if (resource is Document) {
                     resource.mutex.withLock {
                         val documentKey = resource.getKey()
+
+                        // Reset the poll timer up front so a Polling document
+                        // syncs once per interval, not on every sync-loop tick.
+                        // Done before the RPC so a failed push-pull does not
+                        // retry every 50ms and drain battery / hammer the
+                        // server during outages. #1243.
+                        if (attachment.syncMode == SyncMode.Polling) {
+                            attachment.updateHeartbeatTime()
+                        }
+
                         val request = pushPullChangesRequest {
                             clientId = requireClientId()
                             changePack = resource.createChangePack().toPBChangePack()
@@ -366,8 +376,10 @@ public class Client(
                         // PushPull, ignore the response when the syncMode is PushOnly.
                         val currentSyncMode = attachments[documentKey]?.syncMode
                         if (responsePack.hasChanges &&
-                            currentSyncMode == SyncMode.RealtimePushOnly ||
-                            currentSyncMode == SyncMode.RealtimeSyncOff
+                            (
+                                currentSyncMode == SyncMode.RealtimePushOnly ||
+                                    currentSyncMode == SyncMode.RealtimeSyncOff
+                                )
                         ) {
                             return@runCatching
                         }
@@ -375,12 +387,6 @@ public class Client(
                         attachment.resource.publish(
                             event = SyncStatusChanged.Synced,
                         )
-
-                        // Reset the poll timer so a Polling document syncs once
-                        // per interval, not on every sync-loop tick. #1243.
-                        if (attachment.syncMode == SyncMode.Polling) {
-                            attachment.updateHeartbeatTime()
-                        }
 
                         // NOTE(chacha912): If a document has been removed, watchStream should
                         // be disconnected to not receive an event for that document.

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -259,7 +259,8 @@ public class Client(
                     }
 
                     val heartbeatInterval = options.channelHeartbeatInterval.inWholeMilliseconds
-                    if (!attachment.needSync(heartbeatInterval)) {
+                    val pollInterval = options.documentPollInterval.inWholeMilliseconds
+                    if (!attachment.needSync(heartbeatInterval, pollInterval)) {
                         continue
                     }
 
@@ -374,6 +375,12 @@ public class Client(
                         attachment.resource.publish(
                             event = SyncStatusChanged.Synced,
                         )
+
+                        // Reset the poll timer so a Polling document syncs once
+                        // per interval, not on every sync-loop tick. #1243.
+                        if (attachment.syncMode == SyncMode.Polling) {
+                            attachment.updateHeartbeatTime()
+                        }
 
                         // NOTE(chacha912): If a document has been removed, watchStream should
                         // be disconnected to not receive an event for that document.
@@ -925,6 +932,10 @@ public class Client(
                 val pack = response.changePack.toChangePack()
                 document.applyChangePack(pack)
 
+                // Clear undo/redo stacks so that initialRoot setup operations
+                // are not reachable via undo. Mirrors JS SDK PR #1238.
+                document.clearHistory()
+
                 if (document.getStatus() == ResourceStatus.Removed) {
                     return@async SUCCESS
                 }
@@ -934,7 +945,9 @@ public class Client(
                     resourceId = response.documentId,
                     syncMode = syncMode,
                 )
-                if (syncMode != SyncMode.Manual) {
+                // Manual and Polling are stream-less modes; only realtime modes
+                // open a watch stream. Mirrors JS SDK PR #1243.
+                if (syncMode != SyncMode.Manual && syncMode != SyncMode.Polling) {
                     runWatchLoop(documentKey)
                 }
             }
@@ -1541,7 +1554,9 @@ public class Client(
 
         attachment.syncMode = syncMode
 
-        if (syncMode == SyncMode.Manual) {
+        // Manual and Polling are stream-less: no watch stream. The global sync
+        // loop still drives Polling push-pull. Mirrors JS SDK PR #1243.
+        if (syncMode == SyncMode.Manual || syncMode == SyncMode.Polling) {
             attachment.cancelWatchJob()
             return
         }
@@ -1550,7 +1565,8 @@ public class Client(
             attachment.changeEventReceived = true
         }
 
-        if (prevSyncMode == SyncMode.Manual) {
+        // Restart the watch stream only when leaving a stream-less mode.
+        if (prevSyncMode == SyncMode.Manual || prevSyncMode == SyncMode.Polling) {
             runWatchLoop(document.getKey())
         }
     }
@@ -1609,6 +1625,14 @@ public class Client(
         Realtime(true),
         RealtimePushOnly(true),
         RealtimeSyncOff(false),
+
+        /**
+         * [Polling] runs the sync loop without opening a watch stream: local
+         * changes are pushed and remote changes pulled on a fixed interval
+         * ([Options.documentPollInterval]). Suited to low-frequency updates;
+         * use [Realtime] for collaborative editing. Mirrors JS SDK PR #1243.
+         */
+        Polling(false),
         Manual(false),
     }
 
@@ -1654,6 +1678,12 @@ public class Client(
          * The default value is `30000`(ms).
          */
         public val channelHeartbeatInterval: Duration = 30_000.milliseconds,
+        /**
+         * `documentPollInterval` is the push-pull interval for documents attached
+         * with [SyncMode.Polling]. Unused in other sync modes.
+         * The default value is `3000`(ms). Mirrors JS SDK PR #1243.
+         */
+        public val documentPollInterval: Duration = 3_000.milliseconds,
     ) {
         @Deprecated(
             "Renamed to channelHeartbeatInterval",

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -310,11 +310,9 @@ public class Document(
                 internalHistory.popRedo()
             }
             if (ops == null) {
-                return@async Result.failure(
-                    IllegalStateException(
-                        "There is no operation to be ${if (isUndo) "undone" else "redone"}",
-                    ),
-                )
+                // Empty stack is a no-op so callers need not always guard with
+                // canUndo()/canRedo(). Mirrors JS SDK PR #1238.
+                return@async Result.success(Unit)
             }
 
             val clone = ensureClone()
@@ -543,9 +541,18 @@ public class Document(
         changeID = changeID.setClocks(snapshotVector.maxLamport(), snapshotVector)
         clone = null
         removePushedLocalChanges(clientSeq)
+        clearHistory()
+        eventStream.emit(Event.Snapshot(snapshot))
+    }
+
+    /**
+     * Flushes both undo and redo stacks. Used after applying a snapshot or
+     * after attach so that setup operations are not reachable via undo.
+     * Mirrors JS SDK PR #1238.
+     */
+    internal fun clearHistory() {
         internalHistory.clearUndo()
         internalHistory.clearRedo()
-        eventStream.emit(Event.Snapshot(snapshot))
     }
 
     /**

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -330,10 +330,15 @@ internal data class CrdtTree(
                 val next = findFloorNode(nextID) ?: break
                 if (next.isText) break
                 if (next.parent === toParent) {
-                    // Narrow unconditionally once a split sibling is found in
-                    // toParent, matching JS #1233 §3 / iOS narrowedCollectRange.
-                    collectFromLeft = next
-                    collectFromParent = toParent
+                    // Narrow once a split sibling is found in toParent, matching
+                    // JS #1233 §3 / iOS narrowedCollectRange. Skip narrowing when
+                    // toLeft === toParent (leftmost child, offset 0): the narrowed
+                    // range would run backwards and suppress the intended merge
+                    // (JS #1237).
+                    if (toLeft !== toParent) {
+                        collectFromLeft = next
+                        collectFromParent = toParent
+                    }
                     break
                 }
                 current = next
@@ -619,7 +624,16 @@ internal data class CrdtTree(
                 }
             }
         }
-        return TreeOperationResult(changes, gcPairs, diff, removedNodes)
+        // Count merged boundaries before their children were moved (above), so
+        // the undo can regenerate them via split instead of re-inserting the
+        // emptied shells. Mirrors JS SDK PR #1237.
+        return TreeOperationResult(
+            changes,
+            gcPairs,
+            diff,
+            removedNodes,
+            mergeLevel = toBeMergedNodes.size,
+        )
     }
 
     /**

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeList.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeList.kt
@@ -241,7 +241,6 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
             result.add(current)
             current = current.next
         }
-        return result
     }
 
     /**

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeList.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeList.kt
@@ -241,6 +241,7 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
             result.add(current)
             current = current.next
         }
+        return result
     }
 
     /**

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TreeInfo.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/TreeInfo.kt
@@ -97,4 +97,11 @@ internal data class TreeOperationResult(
      * node.  The reverse op must remove them to restore the prior state.
      */
     val attributesToRemove: List<String> = emptyList(),
+    /**
+     * Number of element boundaries merged by this edit, counted before their
+     * children were moved.  A cross-boundary merge is reversed by a split of
+     * this many levels rather than by re-inserting the emptied shells.
+     * Mirrors JS SDK PR #1237.
+     */
+    val mergeLevel: Int = 0,
 )

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
@@ -152,6 +152,7 @@ internal data class TreeEditOperation(
                             fromIndex,
                             editContents,
                             result.removedNodes,
+                            result.mergeLevel,
                         )
                     } else {
                         null
@@ -181,6 +182,12 @@ internal data class TreeEditOperation(
      * Special case: if [redoSplitLevel] > 0, this op is a boundary-deletion
      * that undid a split. Its redo must regenerate a proper split at the
      * merge point rather than re-inserting raw tombstoned boundary nodes.
+     *
+     * Special case: if [mergeLevel] > 0, this op is a cross-boundary merge that
+     * deleted element boundaries and moved their children into the target,
+     * leaving empty shells in [removedNodes]. Re-inserting those shells would
+     * nest the elements; instead the reverse is a split of [mergeLevel] levels
+     * that re-creates the boundaries. Mirrors JS SDK PR #1237.
      */
     private fun toReverseOperation(
         tree: CrdtTree,
@@ -188,6 +195,7 @@ internal data class TreeEditOperation(
         fromIndex: Int,
         editContents: List<CrdtTreeNode>?,
         removedNodes: List<CrdtTreeNode>,
+        mergeLevel: Int = 0,
     ): TreeEditOperation {
         if (redoSplitLevel > 0) {
             val splitFromPos = tree.findPos(fromIndex)
@@ -197,6 +205,20 @@ internal data class TreeEditOperation(
                 toPos = splitFromPos,
                 contents = null,
                 splitLevel = redoSplitLevel,
+                executedAt = executedAt,
+                undoFromOffset = fromIndex,
+                undoToOffset = fromIndex,
+            )
+        }
+
+        if (mergeLevel > 0) {
+            val splitFromPos = tree.findPos(fromIndex)
+            return TreeEditOperation(
+                parentCreatedAt = parentCreatedAt,
+                fromPos = splitFromPos,
+                toPos = splitFromPos,
+                contents = null,
+                splitLevel = mergeLevel,
                 executedAt = executedAt,
                 undoFromOffset = fromIndex,
                 undoToOffset = fromIndex,


### PR DESCRIPTION
> **RTCOLLABPLATFORM-714**: [[Android] Sync-up Yorkie JS SDK v0.7.8](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-714)

## Summary
- Ports the JS SDK v0.7.7→v0.7.8 delta to Android. Stacked on the v0.7.7 PR (#336).

## Changes
- **#1243 SyncMode.Polling** — new stream-less sync mode: pushes/pulls on a fixed interval (`Options.documentPollInterval`, default 3000ms) without opening a watch stream. Wired into the sync loop, attach, and `changeSyncMode`.
- **#1238 History** — clear undo/redo after attach so `initialRoot` setup ops aren't undoable; empty-stack undo/redo is now a silent no-op instead of throwing.
- **#1237 Tree** — fix `editByPath` split-then-merge (skip Phase-3 range narrowing when `toLeft === toParent`); reverse a cross-boundary merge with a split (`mergeLevel`) instead of re-inserting emptied shells.
- **#1239 Tree reverseOp** — verified Android already filters pre-tombstoned descendants (snapshots via `activeChildren`); added a regression test, no source change.
- **Skipped:** #1245 (isRealtime is React-only) and #1240 (npm Dependabot bumps — N/A to Gradle).

## Test plan
- [ ] `SyncModePollingTest` — Polling pushes & pulls without a watch stream (verified on emulator)
- [ ] `JsonTreeUndoTest` / `JsonTreeSplitMergeTest` — cross-boundary merge undo, split-then-merge, reverseOp stability (verified on emulator)
- [ ] `UndoRedoTest.test_attach_clears_undo_history` + empty-stack no-op (needs Docker server)
- [ ] Note: pre-existing `JsonTreeConcurrencyTest` flakiness / `L2` failure is unrelated to this PR (fails on clean base too)

> Items run automatically by CI (lint, unit tests, coverage) are excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added polling-based document synchronization without requiring a watch stream.
  - Added configurable document polling intervals.
  - Added support for switching between realtime, polling, and manual synchronization modes.

- **Bug Fixes**
  - Undo and redo now safely succeed as no-ops when history is empty.
  - Attaching a document clears its undo/redo history.
  - Improved JSON tree split, merge, undo, and redo behavior for complex editing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->