### PR TITLE
RTCOLLABPLATFORM-715: Sync-up Yorkie JS SDK v0.7.9

### DIFF
--- a/build-logic/convention/src/main/kotlin/dev/yorkie/ProtocolBufferGeneration.kt
+++ b/build-logic/convention/src/main/kotlin/dev/yorkie/ProtocolBufferGeneration.kt
@@ -72,6 +72,13 @@ internal fun Project.configureProtocolBufferGeneration() {
         dependsOn("bufGenerate")
     }
 
+    // Ensure buf generation runs before kotlinter tasks — the generated sources
+    // are part of the main source set, so lint/format read bufGenerate's output.
+    tasks.matching { it.name.startsWith("lintKotlin") || it.name.startsWith("formatKotlin") }
+        .configureEach {
+            dependsOn("bufGenerate")
+        }
+
     // Ensure buf generation runs before source JAR creation
     tasks.withType<SourceJarTask>().configureEach {
         if (name == "sourceReleaseJar") {

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -1,6 +1,6 @@
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.5'
+    image: 'yorkieteam/yorkie:0.7.9'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.5'
+    image: 'yorkieteam/yorkie:0.7.9'
     container_name: 'yorkie'
     restart: always
     ports:

--- a/yorkie/proto/yorkie/v1/yorkie.proto
+++ b/yorkie/proto/yorkie/v1/yorkie.proto
@@ -44,6 +44,7 @@ service YorkieService {
   rpc AttachChannel (AttachChannelRequest) returns (AttachChannelResponse) {}
   rpc DetachChannel (DetachChannelRequest) returns (DetachChannelResponse) {}
   rpc RefreshChannel (RefreshChannelRequest) returns (RefreshChannelResponse) {}
+  rpc PeekChannel (PeekChannelRequest) returns (PeekChannelResponse) {}
 
   rpc Broadcast (BroadcastRequest) returns (BroadcastResponse) {}
 }
@@ -203,6 +204,18 @@ message RefreshChannelRequest {
 }
 
 message RefreshChannelResponse {
+  int64 session_count = 1;
+}
+
+// PeekChannel reads the current session_count of a channel without creating
+// a session on the server. Use this when a client only needs to display the
+// count (e.g. "N people writing") without contributing to it and without
+// receiving broadcasts. Caller polls on its own cadence.
+message PeekChannelRequest {
+  string channel_key = 1;
+}
+
+message PeekChannelResponse {
   int64 session_count = 1;
 }
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt
@@ -131,6 +131,51 @@ class ChannelTest {
     }
 
     @Test
+    fun test_peek_channel_returns_count_without_creating_session() {
+        runBlocking {
+            val c1 = createClient()
+            val c2 = createClient()
+            c1.activateAsync().await()
+            c2.activateAsync().await()
+
+            // Client A attaches a channel (count = 1)
+            val channelKey = "channel-peek-${UUID.randomUUID()}".toDocKey()
+            val channel = Channel(channelKey)
+            c1.attachChannel(channel).await()
+            assertEquals(1L, channel.getSessionCount())
+
+            // Client B peeks without attaching
+            val peeked = c2.peekChannel(channelKey).await().getOrThrow()
+            assertEquals(1L, peeked)
+
+            // Peek created no session: A's refresh still sees count 1
+            c1.syncAsync(channel).await()
+            assertEquals(1L, channel.getSessionCount())
+
+            c1.detachChannel(channel).await()
+            c1.deactivateAsync().await()
+            c2.deactivateAsync().await()
+            c1.close()
+            c2.close()
+        }
+    }
+
+    @Test
+    fun test_peek_channel_on_unattached_channel_key_returns_zero() {
+        runBlocking {
+            val c1 = createClient()
+            c1.activateAsync().await()
+
+            val channelKey = "channel-peek-empty-${UUID.randomUUID()}".toDocKey()
+            val peeked = c1.peekChannel(channelKey).await().getOrThrow()
+            assertEquals(0L, peeked)
+
+            c1.deactivateAsync().await()
+            c1.close()
+        }
+    }
+
+    @Test
     fun test_channel_counter_event_subscription() {
         runBlocking {
             val c1 = createClient()

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -32,6 +32,7 @@ import dev.yorkie.api.v1.detachDocumentRequest
 import dev.yorkie.api.v1.documentDescriptor
 import dev.yorkie.api.v1.getRevisionRequest
 import dev.yorkie.api.v1.listRevisionsRequest
+import dev.yorkie.api.v1.peekChannelRequest
 import dev.yorkie.api.v1.pushPullChangesRequest
 import dev.yorkie.api.v1.refreshChannelRequest
 import dev.yorkie.api.v1.removeDocumentRequest
@@ -413,7 +414,19 @@ public class Client(
                             request,
                             resource.getKey().attachmentBasedRequestHeader,
                         ).getOrThrow()
-                        resource.updateSessionCount(response.sessionCount, 0L)
+                        // Publish on value change, not on seq freshness like the watch
+                        // path: refresh pins seq=0 which is always accepted, so the
+                        // freshness check alone would fire on every refresh tick. #1247.
+                        val previousSessionCount = resource.getSessionCount()
+                        if (resource.updateSessionCount(response.sessionCount, 0L) &&
+                            resource.getSessionCount() != previousSessionCount
+                        ) {
+                            resource.publish(
+                                ChannelEvent.Changed(
+                                    sessionCount = resource.getSessionCount(),
+                                ),
+                            )
+                        }
                         attachment.updateHeartbeatTime()
                     }
                 }
@@ -1158,6 +1171,48 @@ public class Client(
             detachInternal(channelKey)
 
             SUCCESS
+        }
+    }
+
+    /**
+     * `peekChannel` reads the current session count of a channel without creating
+     * a session on the server. Use this when the caller only needs to display the
+     * count (e.g. "N people writing") without contributing to it and without
+     * receiving broadcasts.
+     *
+     * Unlike attaching, this does not occupy a session entry on the server, does
+     * not generate heartbeat RPCs, and does not subscribe to channel events.
+     * Polling is the caller's responsibility.
+     *
+     * @param channelKey The key of the channel to peek.
+     * @return The current online session count of the channel.
+     */
+    public fun peekChannel(channelKey: String): Deferred<Result<Long>> {
+        return scope.async {
+            checkYorkieError(
+                isActive,
+                YorkieException(ErrClientNotActivated, "client is not active"),
+            )
+
+            val request = peekChannelRequest {
+                this.channelKey = channelKey
+            }
+
+            val response = service.peekChannel(
+                request,
+                channelKey.attachmentBasedRequestHeader,
+            ).getOrElse {
+                ensureActive()
+                handleConnectException(it) { exception ->
+                    if (errorCodeOf(exception) == ErrUnauthenticated.codeString) {
+                        shouldRefreshToken = true
+                    }
+                    deactivateInternal()
+                }
+                return@async Result.failure(it)
+            }
+
+            Result.success(response.sessionCount)
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -388,6 +388,12 @@ public class Client(
                             event = SyncStatusChanged.Synced,
                         )
 
+                        // Reset the poll timer so a Polling document syncs once
+                        // per interval, not on every sync-loop tick. #1243.
+                        if (attachment.syncMode == SyncMode.Polling) {
+                            attachment.updateHeartbeatTime()
+                        }
+
                         // NOTE(chacha912): If a document has been removed, watchStream should
                         // be disconnected to not receive an event for that document.
                         if (resource.getStatus() == ResourceStatus.Removed) {

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -39,6 +39,8 @@ import dev.yorkie.document.json.JsonText
 import dev.yorkie.document.presence.PresenceChange
 import dev.yorkie.document.time.VersionVector
 import dev.yorkie.document.time.VersionVector.Companion.INITIAL_VERSION_VECTOR
+import dev.yorkie.presence.Channel
+import dev.yorkie.presence.ChannelEvent
 import dev.yorkie.util.YorkieException
 import dev.yorkie.util.YorkieException.Code.ErrDocumentNotAttached
 import dev.yorkie.util.handleConnectException
@@ -62,8 +64,12 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -747,6 +753,127 @@ class ClientTest {
         val result = target.restoreRevision(document, "test-revision-id").await()
 
         assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `channel refresh publishes changed event only when session count changes`() = runTest {
+        runBlocking {
+            // given
+            val mockService = MockYorkieService()
+            val client = Client(
+                host = "0.0.0.0",
+                options = Client.Options(key = TEST_KEY, apiKey = TEST_KEY),
+            )
+            client.service = mockService
+            client.activateAsync().await()
+
+            val channel = Channel("test-channel")
+            client.attachChannel(channel, isRealtime = false).await()
+
+            val events = mutableListOf<ChannelEvent.Changed>()
+            val collectJob = launch(start = CoroutineStart.UNDISPATCHED) {
+                channel.eventStream.filterIsInstance<ChannelEvent.Changed>()
+                    .take(2)
+                    .toList(events)
+            }
+
+            // when
+            mockService.refreshChannelSessionCount = 2L
+            client.syncAsync(channel).await()
+            client.syncAsync(channel).await()
+            mockService.refreshChannelSessionCount = 3L
+            client.syncAsync(channel).await()
+
+            // then
+            withTimeout(3_000) { collectJob.join() }
+            assertEquals(listOf(2L, 3L), events.map { it.sessionCount })
+
+            client.detachChannel(channel).await()
+            client.deactivateAsync().await()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `channel refresh publishes changed event on count decrease`() = runTest {
+        runBlocking {
+            // given
+            val mockService = MockYorkieService()
+            val client = Client(
+                host = "0.0.0.0",
+                options = Client.Options(key = TEST_KEY, apiKey = TEST_KEY),
+            )
+            client.service = mockService
+            client.activateAsync().await()
+
+            val channel = Channel("test-channel")
+            client.attachChannel(channel, isRealtime = false).await()
+
+            val events = mutableListOf<ChannelEvent.Changed>()
+            val collectJob = launch(start = CoroutineStart.UNDISPATCHED) {
+                channel.eventStream.filterIsInstance<ChannelEvent.Changed>()
+                    .take(2)
+                    .toList(events)
+            }
+
+            // when
+            mockService.refreshChannelSessionCount = 3L
+            client.syncAsync(channel).await()
+            mockService.refreshChannelSessionCount = 2L
+            client.syncAsync(channel).await()
+
+            // then
+            withTimeout(3_000) { collectJob.join() }
+            assertEquals(listOf(3L, 2L), events.map { it.sessionCount })
+
+            client.detachChannel(channel).await()
+            client.deactivateAsync().await()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `peekChannel fails when client is not active`() = runTest {
+        val exception = assertFailsWith<YorkieException> {
+            target.peekChannel("test-channel").await()
+        }
+        assertEquals(YorkieException.Code.ErrClientNotActivated, exception.code)
+    }
+
+    @Test
+    fun `peekChannel returns session count without creating an attachment`() = runTest {
+        // given
+        val mockService = MockYorkieService().apply { peekChannelSessionCount = 5L }
+        val spiedService = spyk<YorkieServiceClientInterface>(mockService)
+        val client = Client(
+            host = "0.0.0.0",
+            options = Client.Options(key = TEST_KEY, apiKey = TEST_KEY),
+        )
+        client.service = spiedService
+        client.activateAsync().await()
+
+        // when
+        val result = client.peekChannel("test-channel").await()
+
+        // then
+        assertEquals(5L, result.getOrNull())
+        coVerify(exactly = 0) { spiedService.attachChannel(any(), any()) }
+
+        client.deactivateAsync().await()
+        client.close()
+    }
+
+    @Test
+    fun `peekChannel returns failure and refreshes token on auth error`() = runTest {
+        // given
+        target.activateAsync().await()
+
+        // when
+        val result = target.peekChannel(AUTH_ERROR_DOCUMENT_KEY).await()
+
+        // then
+        assertTrue(result.isFailure)
+        assertTrue(target.shouldRefreshToken)
     }
 
     private fun assertIsTestActorID(clientId: String) {

--- a/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
@@ -33,6 +33,8 @@ import dev.yorkie.api.v1.ListRevisionsRequest
 import dev.yorkie.api.v1.ListRevisionsResponse
 import dev.yorkie.api.v1.OperationKt.remove
 import dev.yorkie.api.v1.OperationKt.set
+import dev.yorkie.api.v1.PeekChannelRequest
+import dev.yorkie.api.v1.PeekChannelResponse
 import dev.yorkie.api.v1.PushPullChangesRequest
 import dev.yorkie.api.v1.PushPullChangesResponse
 import dev.yorkie.api.v1.RefreshChannelRequest
@@ -66,6 +68,7 @@ import dev.yorkie.api.v1.getRevisionResponse
 import dev.yorkie.api.v1.jSONElementSimple
 import dev.yorkie.api.v1.listRevisionsResponse
 import dev.yorkie.api.v1.operation
+import dev.yorkie.api.v1.peekChannelResponse
 import dev.yorkie.api.v1.pushPullChangesResponse
 import dev.yorkie.api.v1.refreshChannelResponse
 import dev.yorkie.api.v1.removeDocumentResponse
@@ -101,6 +104,9 @@ import dev.yorkie.api.v1.ChannelEvent.Type as PbChannelEventType
 class MockYorkieService(
     val customError: MutableMap<String, Code> = defaultError,
 ) : YorkieServiceClientInterface {
+
+    var refreshChannelSessionCount = 0L
+    var peekChannelSessionCount = 0L
 
     override suspend fun activateClient(
         request: ActivateClientRequest,
@@ -449,7 +455,39 @@ class MockYorkieService(
         headers: Headers,
     ): ResponseMessage<RefreshChannelResponse> {
         return ResponseMessage.Success(
-            message = refreshChannelResponse {},
+            message = refreshChannelResponse {
+                sessionCount = refreshChannelSessionCount
+            },
+            headers = emptyMap(),
+            trailers = emptyMap(),
+        )
+    }
+
+    override suspend fun peekChannel(
+        request: PeekChannelRequest,
+        headers: Headers,
+    ): ResponseMessage<PeekChannelResponse> {
+        if (request.channelKey == AUTH_ERROR_DOCUMENT_KEY) {
+            val errorInfo = ErrorInfo.newBuilder()
+                .putMetadata("code", ErrUnauthenticated.codeString)
+                .build()
+
+            val connectException = mockk<ConnectException>(relaxed = true) {
+                every { code } returns customError[AUTH_ERROR_DOCUMENT_KEY]!!
+                every {
+                    unpackedDetails(ErrorInfo::class)
+                } returns listOf(errorInfo)
+            }
+            return ResponseMessage.Failure(
+                cause = connectException,
+                headers = emptyMap(),
+                trailers = emptyMap(),
+            )
+        }
+        return ResponseMessage.Success(
+            message = peekChannelResponse {
+                sessionCount = peekChannelSessionCount
+            },
             headers = emptyMap(),
             trailers = emptyMap(),
         )


### PR DESCRIPTION
> **RTCOLLABPLATFORM-715**: [[Android] Sync-up Yorkie JS SDK v0.7.9](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-715)

## Summary
- Ports yorkie-js-sdk v0.7.9 to Android (reference: yorkie-team/yorkie-ios-sdk#262)
- Add `PeekChannel` client — read a channel's session count without joining (yorkie-js-sdk#1256)
- Fix polling channel subscriber notification (yorkie-js-sdk#1247)
- `usePeekChannel` React hook and React polling exposure have no Android counterpart (skipped)

## Changes
- **proto**: new `PeekChannel` RPC + `PeekChannelRequest`/`PeekChannelResponse` messages (wire-identical to JS v0.7.9 / server 0.7.9)
- **Client.peekChannel(channelKey): Deferred<Result<Long>>** — one-shot RPC; no session entry, no heartbeat, no subscription; polling is caller's responsibility
- **Polling fix**: sync-loop channel refresh now publishes `ChannelEvent.Changed` when the session count actually changes — previously manual/polling-mode subscribers never got notified
- **MockYorkieService**: `peekChannel` override, configurable session counts, auth-error branch
- **Tests**: 5 new unit tests (polling change/decrease/no-dup, peek not-active/success/auth-error), 2 new instrumented tests (peek without session, peek unattached key = 0)
- **docker**: bump `yorkieteam/yorkie` 0.7.5 → 0.7.9 (PeekChannel exists server-side from 0.7.9)
- **build-logic**: declare `bufGenerate` as dependency of kotlinter tasks (fixes Gradle task-ordering validation failure after any proto change)

## Review notes
- `Deferred<Result<Long>>` is a new return-type precedent (first `Result<T>` with `T != Unit`) — chosen over plain `Deferred<T>` because peek needs the same auth-refresh/deactivate error handling as `attachChannel`/`detachChannel`.
- Refresh-path publish rule (value-change) deliberately differs from watch-path rule (seq-freshness): refresh pins seq=0, which is always accepted, so freshness alone would fire every tick. Matches JS/iOS.
- Behavior change: polling/manual-mode channel subscribers now receive `ChannelEvent.Changed` events they previously never got.
- Pre-existing failure `JsonTreeConcurrencyTest.test_concurrent_split_and_edit_L2` fails on base branch too (both server 0.7.5 and 0.7.9) — unrelated to this PR.

## Test plan
- [ ] `./gradlew yorkie:connectedDebugAndroidTest` against local Docker server 0.7.9 — ChannelTest 11/11 pass (verified)
- [ ] Verify peek from a second client doesn't bump the channel count in a sample app

> Items run automatically by CI (lint, unit tests, coverage) are excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
