### PR TITLE
RTCOLLABPLATFORM-716: Sync-up Yorkie JS SDK v0.7.10

### DIFF
--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -1,6 +1,6 @@
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.9'
+    image: 'yorkieteam/yorkie:0.7.10'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.9'
+    image: 'yorkieteam/yorkie:0.7.10'
     container_name: 'yorkie'
     restart: always
     ports:

--- a/yorkie/proto/yorkie/v1/yorkie.proto
+++ b/yorkie/proto/yorkie/v1/yorkie.proto
@@ -70,6 +70,10 @@ message AttachDocumentRequest {
   string client_id = 1;
   ChangePack change_pack = 2;
   string schema_key = 3;
+  // disable_gc declares that this attachment will not produce or consume
+  // tombstones. The server skips minVV tracking and omits the response
+  // VersionVector for this client.
+  bool disable_gc = 4;
 }
 
 message AttachDocumentResponse {
@@ -171,6 +175,9 @@ message PushPullChangesRequest {
   string document_id = 2;
   ChangePack change_pack = 3;
   bool push_only = 4;
+  // disable_gc mirrors the attach-time option; the server reads it per
+  // request.
+  bool disable_gc = 5;
 }
 
 message PushPullChangesResponse {
@@ -201,10 +208,17 @@ message RefreshChannelRequest {
   string client_id = 1;
   string channel_key = 2;
   string session_id = 3;
+  // client_key/metadata are read only when session_id is empty (first call).
+  // The first call activates the client lazily and creates the session.
+  string client_key = 4;
+  map<string, string> metadata = 5;
 }
 
 message RefreshChannelResponse {
   int64 session_count = 1;
+  // client_id/session_id are populated only on the first-call response.
+  string client_id = 2;
+  string session_id = 3;
 }
 
 // PeekChannel reads the current session_count of a channel without creating

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/DisableGCTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/DisableGCTest.kt
@@ -1,0 +1,60 @@
+package dev.yorkie.core
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.yorkie.document.Document
+import dev.yorkie.document.json.JsonCounter
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DisableGCTest {
+
+    @Test
+    fun test_disable_gc_attachment_converges_on_counter_workload() {
+        runBlocking {
+            val c1 = createClient()
+            val c2 = createClient()
+            c1.activateAsync().await()
+            c2.activateAsync().await()
+
+            val documentKey = "disable-gc-${UUID.randomUUID()}".toDocKey()
+            val d1 = Document(documentKey)
+            val d2 = Document(documentKey)
+
+            // Both clients opt out of server-side GC tracking; the wire flag
+            // rides on attach and every push-pull
+            c1.attachDocument(d1, syncMode = Client.SyncMode.Manual, disableGC = true).await()
+            c2.attachDocument(d2, syncMode = Client.SyncMode.Manual, disableGC = true).await()
+
+            d1.updateAsync { root, _ ->
+                root.setNewCounter("counter", 0)
+            }.await()
+            c1.syncAsync(d1).await()
+            c2.syncAsync(d2).await()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonCounter>("counter").increase(5)
+            }.await()
+            d2.updateAsync { root, _ ->
+                root.getAs<JsonCounter>("counter").increase(3)
+            }.await()
+
+            c1.syncAsync(d1).await()
+            c2.syncAsync(d2).await()
+            c1.syncAsync(d1).await()
+
+            assertEquals("""{"counter":8}""", d1.toJson())
+            assertEquals("""{"counter":8}""", d2.toJson())
+
+            c1.detachDocument(d1).await()
+            c2.detachDocument(d2).await()
+            c1.deactivateAsync().await()
+            c2.deactivateAsync().await()
+            c1.close()
+            c2.close()
+        }
+    }
+}

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/presence/ChannelTest.kt
@@ -8,7 +8,6 @@ import dev.yorkie.core.toDocKey
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineStart
@@ -20,8 +19,23 @@ import kotlinx.coroutines.withTimeout
 import org.junit.Test
 import org.junit.runner.RunWith
 
+/**
+ * Detach is local-only since v0.7.10: the server reclaims a session via its
+ * ChannelSessionTTL (15s) once heartbeats stop, so remote counts drop only
+ * after the TTL. Polls asserting that decrease use this longer timeout.
+ */
+private const val SESSION_TTL_TIMEOUT = 40_000L
+
 @RunWith(AndroidJUnit4::class)
 class ChannelTest {
+
+    private suspend fun Channel.awaitSessionCount(count: Long, timeoutMs: Long = GENERAL_TIMEOUT) {
+        withTimeout(timeoutMs) {
+            while (getSessionCount() != count) {
+                delay(50)
+            }
+        }
+    }
 
     @Test
     fun test_single_client_channel_counter() {
@@ -39,13 +53,12 @@ class ChannelTest {
             assertFalse(channel.isAttached())
             assertEquals(0L, channel.getSessionCount())
 
-            // Attach channel counter
+            // Attach channel counter; the server session is created by the
+            // first heartbeat, so poll instead of asserting immediately
             c1.attachChannel(channel).await()
-
-            // Verify attached state
+            channel.awaitSessionCount(1L)
             assertEquals(ResourceStatus.Attached, channel.getStatus())
             assertTrue(channel.isAttached())
-            assertEquals(1L, channel.getSessionCount())
 
             // Detach channel counter
             c1.detachChannel(channel).await()
@@ -78,45 +91,28 @@ class ChannelTest {
 
             // First client attaches
             c1.attachChannel(channel1).await()
-            assertEquals(1L, channel1.getSessionCount())
+            channel1.awaitSessionCount(1L)
 
             // Second client attaches
             c2.attachChannel(channel2).await()
-            assertEquals(2L, channel2.getSessionCount())
+            channel2.awaitSessionCount(2L)
 
             // First client should receive the update
-            withTimeout(GENERAL_TIMEOUT) {
-                while (channel1.getSessionCount() != 2L) {
-                    delay(50)
-                }
-            }
-            assertEquals(2L, channel1.getSessionCount())
+            channel1.awaitSessionCount(2L)
 
             // Third client attaches
             c3.attachChannel(channel3).await()
-            assertEquals(3L, channel3.getSessionCount())
+            channel3.awaitSessionCount(3L)
 
             // Wait for all clients to sync
-            withTimeout(GENERAL_TIMEOUT) {
-                while (channel1.getSessionCount() != 3L || channel2.getSessionCount() != 3L) {
-                    delay(50)
-                }
-            }
-            assertEquals(3L, channel1.getSessionCount())
-            assertEquals(3L, channel2.getSessionCount())
+            channel1.awaitSessionCount(3L)
+            channel2.awaitSessionCount(3L)
 
-            // One client detaches
+            // One client detaches (local-only); other clients see the count
+            // decrease once the server reclaims the session via TTL
             c2.detachChannel(channel2).await()
-            assertEquals(2L, channel2.getSessionCount())
-
-            // Other clients should see the count decrease
-            withTimeout(GENERAL_TIMEOUT) {
-                while (channel1.getSessionCount() != 2L || channel3.getSessionCount() != 2L) {
-                    delay(50)
-                }
-            }
-            assertEquals(2L, channel1.getSessionCount())
-            assertEquals(2L, channel3.getSessionCount())
+            channel1.awaitSessionCount(2L, SESSION_TTL_TIMEOUT)
+            channel3.awaitSessionCount(2L, SESSION_TTL_TIMEOUT)
 
             // Cleanup
             c1.detachChannel(channel1).await()
@@ -142,7 +138,7 @@ class ChannelTest {
             val channelKey = "channel-peek-${UUID.randomUUID()}".toDocKey()
             val channel = Channel(channelKey)
             c1.attachChannel(channel).await()
-            assertEquals(1L, channel.getSessionCount())
+            channel.awaitSessionCount(1L)
 
             // Client B peeks without attaching
             val peeked = c2.peekChannel(channelKey).await().getOrThrow()
@@ -176,6 +172,43 @@ class ChannelTest {
     }
 
     @Test
+    fun test_peek_channel_without_activation() {
+        runBlocking {
+            // peekChannel no longer requires a prior activate()
+            val c1 = createClient()
+
+            val channelKey = "channel-peek-inactive-${UUID.randomUUID()}".toDocKey()
+            val peeked = c1.peekChannel(channelKey).await().getOrThrow()
+            assertEquals(0L, peeked)
+
+            c1.close()
+        }
+    }
+
+    @Test
+    fun test_channel_attach_without_activation_lazily_activates_client() {
+        runBlocking {
+            // A channel-only client never calls activateAsync(); the first
+            // RefreshChannel heartbeat activates it lazily
+            val c1 = createClient()
+            assertFalse(c1.isActive)
+
+            val channelKey = "channel-lazy-${UUID.randomUUID()}".toDocKey()
+            val channel = Channel(channelKey)
+            c1.attachChannel(channel).await()
+
+            channel.awaitSessionCount(1L)
+            assertTrue(c1.isActive)
+            assertTrue(channel.isAttached())
+            assertEquals(c1.requireClientId(), channel.getActorID())
+
+            c1.detachChannel(channel).await()
+            c1.deactivateAsync().await()
+            c1.close()
+        }
+    }
+
+    @Test
     fun test_channel_counter_event_subscription() {
         runBlocking {
             val c1 = createClient()
@@ -196,29 +229,29 @@ class ChannelTest {
                 }
             }
 
-            // First client attaches
+            // First client attaches. The first refresh may publish Changed(1)
+            // before the watch stream delivers Initialized, so wait for the
+            // Initialized event rather than asserting on event order.
             c1.attachChannel(channel1).await()
             withTimeout(GENERAL_TIMEOUT) {
-                while (events.isEmpty()) {
+                while (events.none { it is ChannelEvent.Initialized }) {
                     delay(50)
                 }
             }
-
-            // Should receive initialized event
-            assertIs<ChannelEvent.Initialized>(events[0])
-            assertEquals(1L, events[0].sessionCount)
+            assertEquals(
+                1L,
+                events.filterIsInstance<ChannelEvent.Initialized>().first().sessionCount,
+            )
 
             // Second client attaches
             c2.attachChannel(channel2).await()
             withTimeout(GENERAL_TIMEOUT) {
-                while (events.size < 2) {
+                while (
+                    events.none { it is ChannelEvent.Changed && it.sessionCount == 2L }
+                ) {
                     delay(50)
                 }
             }
-
-            // Should receive count-changed event
-            assertIs<ChannelEvent.Changed>(events.last())
-            assertEquals(2L, events.last().sessionCount)
 
             // Cleanup
             collectJob.cancel()
@@ -247,26 +280,13 @@ class ChannelTest {
             // Both attach
             c1.attachChannel(channel1).await()
             c2.attachChannel(channel2).await()
+            channel1.awaitSessionCount(2L)
+            channel2.awaitSessionCount(2L)
 
-            withTimeout(GENERAL_TIMEOUT) {
-                while (channel1.getSessionCount() != 2L || channel2.getSessionCount() != 2L) {
-                    delay(50)
-                }
-            }
-            assertEquals(2L, channel1.getSessionCount())
-            assertEquals(2L, channel2.getSessionCount())
-
-            // One detaches
+            // One detaches (local-only); the remaining channel sees the
+            // decrease once the server reclaims the session via TTL
             c1.detachChannel(channel1).await()
-            assertEquals(1L, channel1.getSessionCount())
-
-            // Other channel should also see the decrease
-            withTimeout(GENERAL_TIMEOUT) {
-                while (channel2.getSessionCount() != 1L) {
-                    delay(50)
-                }
-            }
-            assertEquals(1L, channel2.getSessionCount())
+            channel2.awaitSessionCount(1L, SESSION_TTL_TIMEOUT)
 
             // Cleanup
             c2.detachChannel(channel2).await()
@@ -293,7 +313,7 @@ class ChannelTest {
 
             // Attach channel counter
             c1.attachChannel(channel).await()
-            assertEquals(1L, channel.getSessionCount())
+            channel.awaitSessionCount(1L)
 
             // Wait for 3 heartbeat cycles (3 seconds)
             // The channel should still be active because heartbeat refreshes TTL
@@ -324,12 +344,17 @@ class ChannelTest {
             val p1 = Channel(channelKey)
             val p2 = Channel(channelKey)
 
-            // Attach client1 with manual sync mode (no watch stream)
+            // Attach client1 with manual sync mode (no watch stream). In
+            // manual mode nothing reaches the server until an explicit sync:
+            // the first syncAsync performs the first-call refresh.
             c1.attachChannel(p1, isRealtime = false).await()
+            assertEquals(0L, p1.getSessionCount())
+            c1.syncAsync(p1).await()
             assertEquals(1L, p1.getSessionCount())
 
             // Attach client2 with manual sync mode
             c2.attachChannel(p2, isRealtime = false).await()
+            c2.syncAsync(p2).await()
             assertEquals(2L, p2.getSessionCount())
 
             // In manual mode, p1's count doesn't update automatically
@@ -341,13 +366,19 @@ class ChannelTest {
             c1.syncAsync(p1).await()
             assertEquals(2L, p1.getSessionCount())
 
-            // Detach p2 and verify p1 doesn't auto-update
+            // Detach p2 (local-only) and verify p1 doesn't auto-update
             c2.detachChannel(p2).await()
             delay(500)
             assertEquals(2L, p1.getSessionCount())
 
-            // Sync to refresh TTL and fetch latest count after c2 detached
-            c1.syncAsync(p1).await()
+            // p2's server session dies by TTL; keep syncing p1 until the
+            // decrease becomes visible
+            withTimeout(SESSION_TTL_TIMEOUT) {
+                while (p1.getSessionCount() != 1L) {
+                    c1.syncAsync(p1).await()
+                    delay(500)
+                }
+            }
             assertEquals(1L, p1.getSessionCount())
 
             // Cleanup
@@ -377,34 +408,27 @@ class ChannelTest {
 
             // c1: Attach with realtime mode (default)
             c1.attachChannel(realtimeChannel).await()
-            assertEquals(1L, realtimeChannel.getSessionCount())
+            realtimeChannel.awaitSessionCount(1L)
 
-            // c2: Attach with manual mode
+            // c2: Attach with manual mode; needs an explicit sync to create
+            // the session
             c2.attachChannel(manualChannel, isRealtime = false).await()
+            c2.syncAsync(manualChannel).await()
             assertEquals(2L, manualChannel.getSessionCount())
 
             // c1's realtime channel should automatically receive the update
-            withTimeout(GENERAL_TIMEOUT) {
-                while (realtimeChannel.getSessionCount() != 2L) {
-                    delay(50)
-                }
-            }
-            assertEquals(2L, realtimeChannel.getSessionCount())
+            realtimeChannel.awaitSessionCount(2L)
 
             // c2's manual channel doesn't receive updates
             assertEquals(2L, manualChannel.getSessionCount())
 
             // c3: Attach another client
             c3.attachChannel(thirdChannel, isRealtime = false).await()
+            c3.syncAsync(thirdChannel).await()
             assertEquals(3L, thirdChannel.getSessionCount())
 
             // c1's realtime channel receives the update automatically
-            withTimeout(GENERAL_TIMEOUT) {
-                while (realtimeChannel.getSessionCount() != 3L) {
-                    delay(50)
-                }
-            }
-            assertEquals(3L, realtimeChannel.getSessionCount())
+            realtimeChannel.awaitSessionCount(3L)
 
             // c2's manual channel still doesn't update
             assertEquals(2L, manualChannel.getSessionCount())
@@ -500,7 +524,7 @@ class ChannelTest {
 
             c1.attachChannel(ch1).await()
             c2.attachDocument(d2).await()
-            delay(200)
+            ch1.awaitSessionCount(1L)
 
             val docBroadcastEvents =
                 mutableListOf<dev.yorkie.document.Document.Event.Broadcast>()

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
@@ -8,12 +8,36 @@ import kotlinx.coroutines.Job
  */
 internal class Attachment<R : Attachable>(
     val resource: R,
-    val resourceId: String,
+    /**
+     * Document ID for documents. Channel session ID for channels: starts
+     * empty, populated by the first RefreshChannel response, cleared again
+     * when the session expires (ErrSessionNotFound recovery).
+     */
+    var resourceId: String = "",
     var syncMode: Client.SyncMode? = null,
+    /**
+     * Declares that this attachment will not produce or consume tombstones.
+     * The server skips minVV tracking and omits the response VersionVector
+     * for this client. Documents only; carried on every PushPullChanges.
+     */
+    val disableGC: Boolean = false,
 ) {
     var changeEventReceived: Boolean? = syncMode?.let { false }
     var cancelled: Boolean = false
-    private var lastHeartbeatTime: Long = System.currentTimeMillis()
+
+    /**
+     * Set before detaching so an in-flight refresh that resumes from its
+     * network await drops its side effects instead of resurrecting the
+     * session. The mutex alone cannot do this: it only delays new acquirers,
+     * it cannot alter an already-running critical section.
+     */
+    @Volatile
+    var detaching: Boolean = false
+
+    // Init 0 so the first sync-loop tick fires immediately: channel attach no
+    // longer performs an RPC, the first RefreshChannel must not wait a full
+    // heartbeat interval. Mirrors JS SDK v0.7.10.
+    private var lastHeartbeatTime: Long = 0L
     var watchJobHolder: WatchJobHolder? = null
 
     /**

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -21,13 +21,11 @@ import dev.yorkie.api.v1.DocEventType
 import dev.yorkie.api.v1.WatchResponse
 import dev.yorkie.api.v1.YorkieServiceClient
 import dev.yorkie.api.v1.YorkieServiceClientInterface
-import dev.yorkie.api.v1.attachChannelRequest
 import dev.yorkie.api.v1.attachDocumentRequest
 import dev.yorkie.api.v1.broadcastRequest
 import dev.yorkie.api.v1.channelDescriptor
 import dev.yorkie.api.v1.createRevisionRequest
 import dev.yorkie.api.v1.deactivateClientRequest
-import dev.yorkie.api.v1.detachChannelRequest
 import dev.yorkie.api.v1.detachDocumentRequest
 import dev.yorkie.api.v1.documentDescriptor
 import dev.yorkie.api.v1.getRevisionRequest
@@ -63,6 +61,7 @@ import dev.yorkie.util.YorkieException.Code.ErrClientNotActivated
 import dev.yorkie.util.YorkieException.Code.ErrDocumentNotAttached
 import dev.yorkie.util.YorkieException.Code.ErrDocumentNotDetached
 import dev.yorkie.util.YorkieException.Code.ErrEpochMismatch
+import dev.yorkie.util.YorkieException.Code.ErrSessionNotFound
 import dev.yorkie.util.YorkieException.Code.ErrUnauthenticated
 import dev.yorkie.util.checkYorkieError
 import dev.yorkie.util.createSingleThreadDispatcher
@@ -145,6 +144,7 @@ public class Client(
     @Volatile
     @VisibleForTesting
     internal var deactivating = false
+    private var syncLoopJob: Job? = null
 
     private val _status = MutableStateFlow<Status>(Status.Deactivated)
     public val status = _status.asStateFlow()
@@ -246,10 +246,19 @@ public class Client(
      * the server and pulls remote changes from the server.
      */
     private fun runSyncLoop() {
+        // Check-then-launch is race-free only because this is a non-suspending
+        // fun and both callers (activateAsync, attachChannel) run on the
+        // client's single-threaded dispatcher; keep it that way.
+        if (syncLoopJob?.isActive == true) {
+            return
+        }
         conditions[ClientCondition.SYNC_LOOP] = true
-        scope.launch(activationJob) {
+        syncLoopJob = scope.launch(activationJob) {
             while (true) {
-                if (!isActive || deactivating) {
+                // A channel-only client that has not activated yet keeps the
+                // loop alive as long as it has an attachment: the first
+                // RefreshChannel is what activates it.
+                if ((!isActive && attachments.isEmpty()) || deactivating) {
                     conditions[ClientCondition.SYNC_LOOP] = false
                     return@launch
                 }
@@ -302,8 +311,10 @@ public class Client(
      */
     public fun syncAsync(resource: Attachable? = null): Deferred<OperationResult> {
         return scope.async {
+            // Channels may sync pre-activation: the first RefreshChannel
+            // activates the client lazily. Documents still require activate.
             checkYorkieError(
-                isActive,
+                isActive || resource is Channel,
                 YorkieException(ErrClientNotActivated, "client is not active"),
             )
 
@@ -367,6 +378,7 @@ public class Client(
                             changePack = resource.createChangePack().toPBChangePack()
                             documentId = attachment.resourceId
                             pushOnly = syncMode == SyncMode.RealtimePushOnly
+                            disableGc = attachment.disableGC
                         }
                         val response = service.pushPullChanges(
                             request,
@@ -403,17 +415,68 @@ public class Client(
                     }
                 } else if (resource is Channel) {
                     resource.mutex.withLock {
+                        // Stale-attachment guard: detachInternal removes the per-key
+                        // mutex, so a loop iteration that already selected this
+                        // attachment could mint a fresh mutex and run against a
+                        // detached channel.
+                        if (attachment.cancelled || attachment.detaching ||
+                            attachments[resource.getKey()] !== attachment
+                        ) {
+                            return@runCatching
+                        }
+                        val isFirstCall = resource.getSessionId().isNullOrEmpty()
                         val request = refreshChannelRequest {
-                            clientId = requireClientId()
+                            clientId = if (isActive) requireClientId() else ""
                             channelKey = resource.getKey()
                             resource.getSessionId()?.let {
                                 sessionId = it
+                            }
+                            if (isFirstCall) {
+                                // The first call activates lazily: it carries the
+                                // client identity and receives the assigned ids.
+                                clientKey = options.key
+                                metadata.putAll(options.metadata)
                             }
                         }
                         val response = service.refreshChannel(
                             request,
                             resource.getKey().attachmentBasedRequestHeader,
-                        ).getOrThrow()
+                        ).getOrElse {
+                            if (!isFirstCall && it is ConnectException &&
+                                errorCodeOf(it) == ErrSessionNotFound.codeString
+                            ) {
+                                // Session reclaimed (TTL). Clear ids so the next
+                                // heartbeat tick re-enters the first-call path and
+                                // re-attaches transparently. Not applied on first
+                                // calls: recovery there would clear already-empty
+                                // ids and hot-retry on every loop tick.
+                                resource.setSessionId(null)
+                                attachment.resourceId = ""
+                                attachment.updateHeartbeatTime()
+                                return@runCatching
+                            }
+                            throw it
+                        }
+                        // Drop a stale response if the channel was detached while
+                        // the RPC was in flight; applying it would resurrect the
+                        // session the user just detached.
+                        if (attachment.detaching ||
+                            attachments[resource.getKey()] !== attachment
+                        ) {
+                            return@runCatching
+                        }
+                        if (response.clientId.isNotEmpty() && !isActive) {
+                            _status.emit(Status.Activated(response.clientId))
+                        }
+                        if (isActive) {
+                            resource.setActor(requireClientId())
+                        }
+                        if (response.sessionId.isNotEmpty()) {
+                            resource.setSessionId(response.sessionId)
+                            attachment.resourceId = response.sessionId
+                            // Attached only once a real server session exists.
+                            resource.applyStatus(ResourceStatus.Attached)
+                        }
                         // Publish on value change, not on seq freshness like the watch
                         // path: refresh pins seq=0 which is always accepted, so the
                         // freshness check alone would fire on every refresh tick. #1247.
@@ -428,10 +491,25 @@ public class Client(
                             )
                         }
                         attachment.updateHeartbeatTime()
+                        // Realtime watch stream is deferred to here: the Watch RPC
+                        // needs the client id, which the first refresh populates.
+                        if (isFirstCall && attachment.syncMode == SyncMode.Realtime &&
+                            attachment.watchJobHolder == null
+                        ) {
+                            runWatchLoop(resource.getKey())
+                        }
                     }
                 }
             }.onFailure {
                 coroutineContext.ensureActive()
+
+                // Suppressed during detach/deactivate teardown so callers do not
+                // see a spurious error flash on the way out.
+                if (resource is Channel && !attachment.detaching &&
+                    attachments[resource.getKey()] === attachment
+                ) {
+                    resource.publish(ChannelEvent.SyncError(cause = it))
+                }
 
                 if (resource is Document) {
                     resource.publish(
@@ -471,11 +549,12 @@ public class Client(
      */
     private fun runWatchLoop(key: String) {
         scope.launch(activationJob) {
-            val attachment = attachments[key]
-                ?: throw YorkieException(
-                    ErrDocumentNotAttached,
-                    "$key is not attached",
-                )
+            // Detached while this launch was pending; throwing here would
+            // crash the process from an unhandled coroutine exception.
+            val attachment = attachments[key] ?: run {
+                logDebug("WD", "watch loop skipped, $key is not attached")
+                return@launch
+            }
 
             conditions[ClientCondition.WATCH_LOOP] = true
 
@@ -898,12 +977,20 @@ public class Client(
      * @param initialPresence: is the initial presence of the client.
      * @param syncMode: defines the synchronization mode of the document.
      * @param schema: is the schema of the document. It is used to validate the document.
+     * @param disableGC: declares that this attachment will not produce or consume
+     * tombstones. The server skips minVV tracking and omits the response
+     * VersionVector for this client. Use only with Counter or primitive
+     * workloads where no client consumes tombstones; misuse on a document
+     * that uses Tree, Text, or Array deletions leads to undefined GC behavior
+     * on this client. Controls only the wire contract and is distinct from
+     * any local-only [Document] GC pass.
      */
     public fun attachDocument(
         document: Document,
         initialPresence: P = emptyMap(),
         syncMode: SyncMode = SyncMode.Realtime,
         schema: String? = null,
+        disableGC: Boolean = false,
     ): Deferred<OperationResult> {
         return scope.async {
             checkYorkieError(
@@ -930,6 +1017,7 @@ public class Client(
                     schema?.let {
                         schemaKey = it
                     }
+                    disableGc = disableGC
                 }
                 val response = service.attachDocument(
                     request = request,
@@ -969,6 +1057,7 @@ public class Client(
                     resource = document,
                     resourceId = response.documentId,
                     syncMode = syncMode,
+                    disableGC = disableGC,
                 )
                 // Manual and Polling are stream-less modes; only realtime modes
                 // open a watch stream. Mirrors JS SDK PR #1243.
@@ -1053,7 +1142,14 @@ public class Client(
 
     /**
      * `attachChannel` attaches the given channel counter to this client.
-     * It tells the server that this client will track the channel count.
+     * It registers the channel locally; the server is notified by the first
+     * RefreshChannel heartbeat, which creates the session and — for a client
+     * that never called [activateAsync] — activates the client lazily.
+     *
+     * The returned [Deferred] completing only means local registration.
+     * Server-side attach finishes asynchronously: observe
+     * [ChannelEvent.Initialized]/[ChannelEvent.Changed] or [Channel.getSessionId]
+     * for server state. Requires a Yorkie server >= 0.7.10.
      *
      * @param channel The channel counter to attach.
      * @param isRealtime If true (default), starts watching for channel changes in realtime.
@@ -1065,110 +1161,66 @@ public class Client(
         isRealtime: Boolean? = null,
     ): Deferred<OperationResult> {
         return scope.async {
+            val channelKey = channel.getKey()
+            // Status stays Detached until the first refresh returns a real
+            // session id, so the attachments map is the double-attach guard.
             checkYorkieError(
-                isActive,
-                YorkieException(ErrClientNotActivated, "client is not active"),
+                channel.getStatus() == ResourceStatus.Detached &&
+                    !attachments.containsKey(channelKey),
+                YorkieException(ErrDocumentNotDetached, "$channelKey is not detached"),
             )
 
-            checkYorkieError(
-                channel.getStatus() == ResourceStatus.Detached,
-                YorkieException(ErrDocumentNotDetached, "${channel.getKey()} is not detached"),
-            )
-
-            channel.setActor(requireClientId())
+            if (isActive) {
+                channel.setActor(requireClientId())
+            }
 
             channel.mutex.withLock {
-                val channelKey = channel.getKey()
-                val request = attachChannelRequest {
-                    clientId = requireClientId()
-                    this.channelKey = channelKey
-                }
-
-                val response = service.attachChannel(
-                    request,
-                    channelKey.attachmentBasedRequestHeader,
-                ).getOrElse {
-                    ensureActive()
-                    handleConnectException(it) { exception ->
-                        if (errorCodeOf(exception) == ErrUnauthenticated.codeString) {
-                            shouldRefreshToken = true
-                        }
-                        deactivateInternal()
-                    }
-                    return@async Result.failure(it)
-                }
-
-                channel.setSessionId(response.sessionId)
-                channel.updateSessionCount(response.sessionCount, 0L)
-                channel.applyStatus(ResourceStatus.Attached)
-
-                val syncMode = if (isRealtime != false) {
-                    SyncMode.Realtime
-                } else {
-                    SyncMode.Manual
-                }
-
                 attachments[channelKey] = Attachment(
                     resource = channel,
-                    resourceId = response.sessionId,
-                    syncMode = syncMode,
+                    resourceId = "",
+                    syncMode = if (isRealtime != false) {
+                        SyncMode.Realtime
+                    } else {
+                        SyncMode.Manual
+                    },
                 )
-
-                // Only start watch loop for realtime mode
-                if (syncMode == SyncMode.Realtime) {
-                    runWatchLoop(channelKey)
-                }
             }
+            // Lazy activation entry point: the loop's first tick performs the
+            // first-call RefreshChannel. The watch loop is deferred to that
+            // tick as well, because the Watch RPC needs the client id.
+            runSyncLoop()
             SUCCESS
         }
     }
 
     /**
      * `detachChannel` detaches the given channel counter from this client.
-     * It tells the server that this client will no longer track the channel count.
+     * Cleanup is local-only: heartbeats stop and the server reclaims the
+     * session via TTL. No RPC is sent.
      */
     public fun detachChannel(channel: Channel): Deferred<OperationResult> {
         return scope.async {
-            checkYorkieError(
-                isActive,
-                YorkieException(ErrClientNotActivated, "client is not active"),
-            )
-
-            attachments[channel.getKey()]
+            val channelKey = channel.getKey()
+            val attachment = attachments[channelKey]
                 ?: throw YorkieException(
                     ErrDocumentNotAttached,
-                    "${channel.getKey()} is not attached",
+                    "$channelKey is not attached",
                 )
 
-            val channelKey = channel.getKey()
+            // Set before taking the mutex so an in-flight refresh resuming
+            // from its network await drops its side effects instead of
+            // resurrecting the session.
+            attachment.detaching = true
 
-            val request = detachChannelRequest {
-                clientId = requireClientId()
-                this.channelKey = channelKey
-                channel.getSessionId()?.let {
-                    sessionId = it
-                }
+            channel.mutex.withLock {
+                // Clear the session id: the server-side session dies by TTL,
+                // and a stale id on re-attach would force a guaranteed
+                // ErrSessionNotFound round trip before recovery.
+                channel.setSessionId(null)
+                channel.applyStatus(ResourceStatus.Detached)
+                channel.close()
+                detachInternal(channelKey)
             }
-
-            val response = service.detachChannel(
-                request,
-                channelKey.attachmentBasedRequestHeader,
-            ).getOrElse {
-                ensureActive()
-                handleConnectException(it) { exception ->
-                    if (errorCodeOf(exception) == ErrUnauthenticated.codeString) {
-                        shouldRefreshToken = true
-                    }
-                    deactivateInternal()
-                }
-                return@async Result.failure(it)
-            }
-
-            channel.updateSessionCount(response.sessionCount, 0L)
-            channel.applyStatus(ResourceStatus.Detached)
-            channel.close()
-
-            detachInternal(channelKey)
 
             SUCCESS
         }
@@ -1189,11 +1241,6 @@ public class Client(
      */
     public fun peekChannel(channelKey: String): Deferred<Result<Long>> {
         return scope.async {
-            checkYorkieError(
-                isActive,
-                YorkieException(ErrClientNotActivated, "client is not active"),
-            )
-
             val request = peekChannelRequest {
                 this.channelKey = channelKey
             }
@@ -1246,6 +1293,17 @@ public class Client(
         deactivateOptions: DeactivateOptions = DeactivateOptions(),
     ): Deferred<OperationResult> {
         if (!isActive) {
+            // A channel-only client that never activated may still have a
+            // running sync loop and attachments; tear them down locally so a
+            // pending first-call refresh cannot activate the client after
+            // deactivation. No RPC: the client has no server identity yet.
+            if (attachments.isNotEmpty() || syncLoopJob?.isActive == true) {
+                activationJob.cancelChildren()
+                return scope.async {
+                    deactivateInternal()
+                    SUCCESS
+                }
+            }
             return CompletableDeferred(SUCCESS)
         }
 
@@ -1742,9 +1800,11 @@ public class Client(
         /**
          * `channelHeartbeatInterval` is the interval of the channel heartbeat.
          * The client sends a heartbeat to the server to refresh the channel TTL.
-         * The default value is `30000`(ms).
+         * Applies to both Realtime and Manual/Polling channels.
+         * The default value is `5000`(ms) — TTL/3 for the server's 15s
+         * ChannelSessionTTL. Mirrors JS SDK v0.7.10.
          */
-        public val channelHeartbeatInterval: Duration = 30_000.milliseconds,
+        public val channelHeartbeatInterval: Duration = 5_000.milliseconds,
         /**
          * `documentPollInterval` is the push-pull interval for documents attached
          * with [SyncMode.Polling]. Unused in other sync modes.

--- a/yorkie/src/main/kotlin/dev/yorkie/presence/Channel.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/presence/Channel.kt
@@ -36,6 +36,17 @@ sealed interface ChannelEvent : ResourceEvent {
     ) : ChannelEvent {
         override val sessionCount: Long = 0L
     }
+
+    /**
+     * Published when a RefreshChannel heartbeat fails non-recoverably.
+     * Recoverable session expiry (ErrSessionNotFound) is handled internally
+     * by a transparent re-attach and does not emit this event.
+     */
+    data class SyncError(
+        val cause: Throwable,
+    ) : ChannelEvent {
+        override val sessionCount: Long = 0L
+    }
 }
 
 class Channel(
@@ -89,9 +100,10 @@ class Channel(
     }
 
     /**
-     * `setSessionId` sets the session ID from the server.
+     * `setSessionId` sets the session ID from the server, or clears it with
+     * null so the next refresh runs as a first call. SDK-internal use.
      */
-    fun setSessionId(sessionId: String) {
+    fun setSessionId(sessionId: String?) {
         this.sessionId = sessionId
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/util/YorkieException.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/YorkieException.kt
@@ -62,6 +62,12 @@ public data class YorkieException(
         // ErrEpochMismatch is returned when the document has been compacted
         // and the client's epoch no longer matches the server's epoch.
         ErrEpochMismatch("ErrEpochMismatch"),
+
+        // ErrSessionNotFound is returned when the server no longer recognizes
+        // a channel session_id (e.g. reclaimed after TTL). Treated as
+        // "session expired": the next refresh retries as a first call
+        // (empty session_id).
+        ErrSessionNotFound("ErrSessionNotFound"),
     }
 }
 

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -21,6 +21,7 @@ import dev.yorkie.core.MockYorkieService.Companion.ATTACH_ERROR_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.AUTH_ERROR_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.DETACH_ERROR_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.EPOCH_MISMATCH_DOCUMENT_KEY
+import dev.yorkie.core.MockYorkieService.Companion.MOCK_SESSION_ID
 import dev.yorkie.core.MockYorkieService.Companion.NORMAL_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.REMOVE_ERROR_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.TEST_ACTOR_ID
@@ -326,6 +327,56 @@ class ClientTest {
         val detachmentChange =
             detachRequestCaptor.captured.changePack.toChangePack().changes.last()
         assertIs<PresenceChange.Clear>(detachmentChange.presenceChange)
+        target.deactivateAsync().await()
+    }
+
+    @Test
+    fun `attachDocument carries disableGc on attach and every push-pull`() = runTest {
+        // given
+        val document = Document(NORMAL_DOCUMENT_KEY)
+        target.activateAsync().await()
+
+        // when
+        val attachRequestCaptor = slot<AttachDocumentRequest>()
+        target.attachDocument(document, syncMode = Manual, disableGC = true).await()
+
+        // then
+        coVerify {
+            service.attachDocument(capture(attachRequestCaptor), any())
+        }
+        assertTrue(attachRequestCaptor.captured.disableGc)
+
+        // when
+        val syncRequestCaptor = slot<PushPullChangesRequest>()
+        target.syncAsync().await()
+
+        // then
+        coVerify {
+            service.pushPullChanges(capture(syncRequestCaptor), any())
+        }
+        assertTrue(syncRequestCaptor.captured.disableGc)
+
+        target.detachDocument(document).await()
+        target.deactivateAsync().await()
+    }
+
+    @Test
+    fun `attachDocument sends disableGc false by default`() = runTest {
+        // given
+        val document = Document(NORMAL_DOCUMENT_KEY)
+        target.activateAsync().await()
+
+        // when
+        val attachRequestCaptor = slot<AttachDocumentRequest>()
+        target.attachDocument(document, syncMode = Manual).await()
+
+        // then
+        coVerify {
+            service.attachDocument(capture(attachRequestCaptor), any())
+        }
+        assertFalse(attachRequestCaptor.captured.disableGc)
+
+        target.detachDocument(document).await()
         target.deactivateAsync().await()
     }
 
@@ -833,11 +884,240 @@ class ClientTest {
     }
 
     @Test
-    fun `peekChannel fails when client is not active`() = runTest {
-        val exception = assertFailsWith<YorkieException> {
-            target.peekChannel("test-channel").await()
+    fun `peekChannel succeeds without prior activation`() = runTest {
+        // given
+        val mockService = MockYorkieService().apply { peekChannelSessionCount = 7L }
+        val client = Client(
+            host = "0.0.0.0",
+            options = Client.Options(key = TEST_KEY, apiKey = TEST_KEY),
+        )
+        client.service = mockService
+
+        // when
+        val result = client.peekChannel("test-channel").await()
+
+        // then
+        assertEquals(7L, result.getOrNull())
+        client.close()
+    }
+
+    @Test
+    fun `channel attach without activate populates client id via first refresh`() = runTest {
+        runBlocking {
+            // given
+            val mockService = MockYorkieService()
+            val client = Client(
+                host = "0.0.0.0",
+                options = Client.Options(key = TEST_KEY, apiKey = TEST_KEY),
+            )
+            client.service = mockService
+            val channel = Channel("test-channel")
+
+            // when: attach registers locally only
+            client.attachChannel(channel, isRealtime = false).await()
+
+            // then: nothing on the server yet, client not activated
+            assertFalse(client.isActive)
+            assertEquals(null, channel.getSessionId())
+            assertFalse(channel.isAttached())
+
+            // when: the first refresh performs the first call
+            client.syncAsync(channel).await()
+
+            // then: lazy activation happened
+            assertTrue(client.isActive)
+            assertEquals(TEST_ACTOR_ID, client.requireClientId())
+            assertEquals(TEST_ACTOR_ID, channel.getActorID())
+            assertEquals(MOCK_SESSION_ID, channel.getSessionId())
+            assertTrue(channel.isAttached())
+            assertEquals(1, mockService.refreshChannelFirstCallCount)
+
+            client.detachChannel(channel).await()
+            client.deactivateAsync().await()
+            client.close()
         }
-        assertEquals(YorkieException.Code.ErrClientNotActivated, exception.code)
+    }
+
+    @Test
+    fun `channel attach and detach do not call attachChannel or detachChannel rpc`() = runTest {
+        runBlocking {
+            // given
+            val mockService = MockYorkieService()
+            val spiedService = spyk<YorkieServiceClientInterface>(mockService)
+            val client = Client(
+                host = "0.0.0.0",
+                options = Client.Options(key = TEST_KEY, apiKey = TEST_KEY),
+            )
+            client.service = spiedService
+            client.activateAsync().await()
+            val channel = Channel("test-channel")
+
+            // when
+            client.attachChannel(channel, isRealtime = false).await()
+            client.syncAsync(channel).await()
+            client.detachChannel(channel).await()
+
+            // then
+            coVerify(exactly = 0) { spiedService.attachChannel(any(), any()) }
+            coVerify(exactly = 0) { spiedService.detachChannel(any(), any()) }
+            coVerify(atLeast = 1) { spiedService.refreshChannel(any(), any()) }
+
+            client.deactivateAsync().await()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `session not found clears session id and re-attaches on next refresh`() = runTest {
+        runBlocking {
+            // given
+            val mockService = MockYorkieService()
+            val client = Client(
+                host = "0.0.0.0",
+                options = Client.Options(key = TEST_KEY, apiKey = TEST_KEY),
+            )
+            client.service = mockService
+            client.activateAsync().await()
+            val channel = Channel("test-channel")
+            client.attachChannel(channel, isRealtime = false).await()
+            client.syncAsync(channel).await()
+            assertEquals(MOCK_SESSION_ID, channel.getSessionId())
+
+            // when: the server reclaimed the session
+            mockService.refreshChannelSessionNotFoundOnce = true
+            val recoveryResult = client.syncAsync(channel).await()
+
+            // then: swallowed, ids cleared for transparent re-attach
+            assertTrue(recoveryResult.isSuccess)
+            assertEquals(null, channel.getSessionId())
+
+            // when: next refresh re-enters the first-call path
+            client.syncAsync(channel).await()
+
+            // then
+            assertEquals(MOCK_SESSION_ID, channel.getSessionId())
+            assertEquals(2, mockService.refreshChannelFirstCallCount)
+
+            client.detachChannel(channel).await()
+            client.deactivateAsync().await()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `channel refresh publishes sync error event on non-recoverable failure`() = runTest {
+        runBlocking {
+            // given
+            val mockService = MockYorkieService()
+            val client = Client(
+                host = "0.0.0.0",
+                options = Client.Options(key = TEST_KEY, apiKey = TEST_KEY),
+            )
+            client.service = mockService
+            client.activateAsync().await()
+            val channel = Channel("test-channel")
+            client.attachChannel(channel, isRealtime = false).await()
+
+            val events = mutableListOf<ChannelEvent.SyncError>()
+            val collectJob = launch(start = CoroutineStart.UNDISPATCHED) {
+                channel.eventStream.filterIsInstance<ChannelEvent.SyncError>()
+                    .take(1)
+                    .toList(events)
+            }
+
+            // when
+            mockService.refreshChannelFails = true
+            val result = client.syncAsync(channel).await()
+
+            // then
+            assertTrue(result.isFailure)
+            withTimeout(3_000) { collectJob.join() }
+            assertIs<ConnectException>(events.single().cause)
+
+            client.close()
+        }
+    }
+
+    @Test
+    fun `detach during in-flight refresh does not resurrect session`() = runTest {
+        runBlocking {
+            // given
+            val mockService = MockYorkieService().apply { refreshChannelDelayMs = 200L }
+            val client = Client(
+                host = "0.0.0.0",
+                options = Client.Options(key = TEST_KEY, apiKey = TEST_KEY),
+            )
+            client.service = mockService
+            client.activateAsync().await()
+            val channel = Channel("test-channel")
+            client.attachChannel(channel, isRealtime = false).await()
+
+            // when: first refresh suspends in the RPC while detach runs
+            val syncDeferred = client.syncAsync(channel)
+            delay(50)
+            client.detachChannel(channel).await()
+            syncDeferred.await()
+
+            // then: the stale response was dropped
+            assertEquals(null, channel.getSessionId())
+            assertFalse(channel.isAttached())
+            assertFalse(client.has(channel.getKey()))
+
+            client.deactivateAsync().await()
+            client.close()
+        }
+    }
+
+    @Test
+    fun `deactivate tears down never-activated channel-only client`() = runTest {
+        runBlocking {
+            // given
+            val mockService = MockYorkieService()
+            val client = Client(
+                host = "0.0.0.0",
+                options = Client.Options(key = TEST_KEY, apiKey = TEST_KEY),
+            )
+            client.service = mockService
+            val channel = Channel("test-channel")
+            client.attachChannel(channel, isRealtime = false).await()
+
+            // when
+            client.deactivateAsync().await()
+
+            // then: local teardown removed the attachment
+            assertFalse(client.isActive)
+            assertFalse(client.has(channel.getKey()))
+            assertFalse(channel.isAttached())
+
+            client.close()
+        }
+    }
+
+    @Test
+    fun `activate after channel attach keeps channel syncing`() = runTest {
+        runBlocking {
+            // given
+            val mockService = MockYorkieService()
+            val client = Client(
+                host = "0.0.0.0",
+                options = Client.Options(key = TEST_KEY, apiKey = TEST_KEY),
+            )
+            client.service = mockService
+            val channel = Channel("test-channel")
+            client.attachChannel(channel, isRealtime = false).await()
+
+            // when: explicit activation lands after the lazy entry point
+            client.activateAsync().await()
+            client.syncAsync(channel).await()
+
+            // then
+            assertTrue(client.isActive)
+            assertEquals(MOCK_SESSION_ID, channel.getSessionId())
+
+            client.detachChannel(channel).await()
+            client.deactivateAsync().await()
+            client.close()
+        }
     }
 
     @Test

--- a/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
@@ -85,6 +85,7 @@ import dev.yorkie.document.operation.SetOperation
 import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
 import dev.yorkie.document.time.VersionVector
 import dev.yorkie.util.YorkieException
+import dev.yorkie.util.YorkieException.Code.ErrSessionNotFound
 import dev.yorkie.util.YorkieException.Code.ErrUnauthenticated
 import io.mockk.every
 import io.mockk.mockk
@@ -107,6 +108,18 @@ class MockYorkieService(
 
     var refreshChannelSessionCount = 0L
     var peekChannelSessionCount = 0L
+
+    /** Fails the next non-first-call refresh with ErrSessionNotFound once. */
+    var refreshChannelSessionNotFoundOnce = false
+
+    /** Fails every refresh with a non-retryable generic error while true. */
+    var refreshChannelFails = false
+
+    /** Number of refreshChannel calls that carried an empty session_id. */
+    var refreshChannelFirstCallCount = 0
+
+    /** Suspends each refresh for this long, to simulate an in-flight RPC. */
+    var refreshChannelDelayMs = 0L
 
     override suspend fun activateClient(
         request: ActivateClientRequest,
@@ -454,9 +467,45 @@ class MockYorkieService(
         request: RefreshChannelRequest,
         headers: Headers,
     ): ResponseMessage<RefreshChannelResponse> {
+        if (refreshChannelDelayMs > 0L) {
+            delay(refreshChannelDelayMs)
+        }
+        if (refreshChannelFails) {
+            return ResponseMessage.Failure(
+                cause = ConnectException(Code.FAILED_PRECONDITION),
+                headers = emptyMap(),
+                trailers = emptyMap(),
+            )
+        }
+        if (refreshChannelSessionNotFoundOnce && request.sessionId.isNotEmpty()) {
+            refreshChannelSessionNotFoundOnce = false
+            val errorInfo = ErrorInfo.newBuilder()
+                .putMetadata("code", ErrSessionNotFound.codeString)
+                .build()
+            val connectException = mockk<ConnectException>(relaxed = true) {
+                every { code } returns Code.FAILED_PRECONDITION
+                every {
+                    unpackedDetails(ErrorInfo::class)
+                } returns listOf(errorInfo)
+            }
+            return ResponseMessage.Failure(
+                cause = connectException,
+                headers = emptyMap(),
+                trailers = emptyMap(),
+            )
+        }
+        val isFirstCall = request.sessionId.isEmpty()
+        if (isFirstCall) {
+            refreshChannelFirstCallCount++
+        }
         return ResponseMessage.Success(
             message = refreshChannelResponse {
                 sessionCount = refreshChannelSessionCount
+                // The server assigns ids only on the first call.
+                if (isFirstCall) {
+                    clientId = TEST_ACTOR_ID
+                    sessionId = MOCK_SESSION_ID
+                }
             },
             headers = emptyMap(),
             trailers = emptyMap(),
@@ -596,6 +645,7 @@ class MockYorkieService(
         internal const val AUTH_ERROR_DOCUMENT_KEY = "AUTH_ERROR_DOCUMENT_KEY"
         internal const val EPOCH_MISMATCH_DOCUMENT_KEY = "EPOCH_MISMATCH_DOCUMENT_KEY"
         internal val TEST_ACTOR_ID = "0000000000ffff0000000000"
+        internal const val MOCK_SESSION_ID = "mock-session-id"
         internal const val TEST_USER_ID = "TEST_USER_ID"
 
         internal val defaultError: MutableMap<String, Code> = mutableMapOf(

--- a/yorkie/src/test/kotlin/dev/yorkie/presence/ChannelTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/presence/ChannelTest.kt
@@ -2,6 +2,7 @@ package dev.yorkie.presence
 
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.Test
 
@@ -38,5 +39,24 @@ class ChannelTest {
     @Test
     fun `hasLocalChanges always returns false`() {
         assertFalse(Channel("key").hasLocalChanges())
+    }
+
+    @Test
+    fun `getSessionId returns null before any session id is set`() {
+        assertNull(Channel("key").getSessionId())
+    }
+
+    @Test
+    fun `setSessionId accepts null to clear a previously set session id`() {
+        // given
+        val channel = Channel("key")
+        channel.setSessionId("session-1")
+        assertEquals("session-1", channel.getSessionId())
+
+        // when
+        channel.setSessionId(null)
+
+        // then
+        assertNull(channel.getSessionId())
     }
 }


### PR DESCRIPTION
> **RTCOLLABPLATFORM-716**: [[Android] Sync-up Yorkie JS SDK v0.7.10](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-716)

## Summary
- Port yorkie-js-sdk v0.7.10: `disableGC` attach option (js#1265) + channel lifecycle via RefreshChannel only (js#1258)
- js#1263 (connect-rpc AbortError suppression) intentionally skipped — browser-fetch concern, no OkHttp analog (iOS skipped it too)
- Requires Yorkie server >= 0.7.10; docker images bumped

## Changes
- **disableGC**: new `bool disable_gc` on `AttachDocumentRequest`(4) / `PushPullChangesRequest`(5); `Client.attachDocument` gains trailing `disableGC: Boolean = false`; flag stored on `Attachment`, carried on every push-pull
- **Channel lifecycle**: `attachChannel` registers locally only; the first heartbeat `RefreshChannel` carries `client_key`+`metadata` and receives `client_id`+`session_id` (lazy activation — no `activateAsync()` needed for channel-only clients); `detachChannel` is local-only (server reclaims the session via TTL); watch stream deferred until the first refresh populates the client id; heartbeat default 30s→5s (TTL/3); transparent re-attach on `ErrSessionNotFound`; new `ChannelEvent.SyncError` for non-recoverable refresh failures; proto keeps AttachChannel/DetachChannel RPC declarations for wire compat — only the calls were dropped
- **Hardening beyond JS** (from plan review): stale-attachment/`detaching` guards in `syncInternal` so a detach racing an in-flight first-call refresh cannot resurrect the session; `deactivateAsync` tears down never-activated channel-only clients; `runWatchLoop` no longer throws from an unhandled coroutine when the attachment is gone
- **Behavioral notes for consumers**: `attachChannel().await()` no longer implies server contact (observe `ChannelEvent.Initialized`/`Changed`); channel APIs no longer throw `ErrClientNotActivated` (document APIs still do); new sealed member `ChannelEvent.SyncError` needs a branch in exhaustive `when` blocks
- Deferred (pre-existing gap vs JS): per-attach `channelHeartbeatInterval` override

## Test plan
- [ ] Instrumented suite against Yorkie 0.7.10 (`ChannelTest`, new `DisableGCTest`) — verified locally: channel/disableGC tests all green (2 failures are pre-existing `JsonTree*` cases that fail on clean HEAD too)
- [ ] Verify a channel-only app (no `activateAsync`) attaches and shows session counts

> Items run automatically by CI (lint, unit tests, coverage) are excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
