### PR TITLE
RTCOLLABPLATFORM-717: Sync-up Yorkie JS SDK v0.7.11

### DIFF
--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -1,6 +1,6 @@
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.10'
+    image: 'yorkieteam/yorkie:0.7.11'
     container_name: 'yorkie'
     command: ['server', '--mongo-connection-uri', 'mongodb://mongo:27017']
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   yorkie:
-    image: 'yorkieteam/yorkie:0.7.10'
+    image: 'yorkieteam/yorkie:0.7.11'
     container_name: 'yorkie'
     restart: always
     ports:

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/DisableGCTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/DisableGCTest.kt
@@ -5,6 +5,7 @@ import dev.yorkie.document.Document
 import dev.yorkie.document.json.JsonCounter
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -55,6 +56,194 @@ class DisableGCTest {
             c2.deactivateAsync().await()
             c1.close()
             c2.close()
+        }
+    }
+
+    @Test
+    fun test_mixed_opt_in_and_opt_out_clients_converge_on_counter_value() {
+        runBlocking {
+            val c1 = createClient()
+            val c2 = createClient()
+            c1.activateAsync().await()
+            c2.activateAsync().await()
+
+            val documentKey = "disable-gc-mixed-${UUID.randomUUID()}".toDocKey()
+            val d1 = Document(documentKey)
+            val d2 = Document(documentKey)
+
+            c1.attachDocument(d1, syncMode = Client.SyncMode.Manual).await()
+            d1.updateAsync { root, _ ->
+                root.setNewCounter("counter", 0)
+            }.await()
+            c1.syncAsync(d1).await()
+
+            c2.attachDocument(d2, syncMode = Client.SyncMode.Manual, disableGC = true).await()
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonCounter>("counter").increase(1)
+            }.await()
+            d2.updateAsync { root, _ ->
+                root.getAs<JsonCounter>("counter").increase(1)
+            }.await()
+
+            c1.syncAsync(d1).await()
+            c2.syncAsync(d2).await()
+            c1.syncAsync(d1).await()
+
+            assertEquals("""{"counter":2}""", d1.toJson())
+            assertEquals("""{"counter":2}""", d2.toJson())
+
+            c1.detachDocument(d1).await()
+            c2.detachDocument(d2).await()
+            c1.deactivateAsync().await()
+            c2.deactivateAsync().await()
+            c1.close()
+            c2.close()
+        }
+    }
+
+    // Regression for yorkie-js-sdk #1270: without the syncLamport path, every remote
+    // actor was merged into the opt-out client's version vector via syncClocks, so the
+    // per-Change VV grew O(num_actors) and the opt-out's wire savings never materialized.
+    @Test
+    fun test_opt_out_clients_keep_version_vector_at_size_1_under_multi_actor_fanout() {
+        runBlocking {
+            val clients = List(3) { createClient() }
+            clients.forEach { it.activateAsync().await() }
+
+            val documentKey = "disable-gc-fanout-${UUID.randomUUID()}".toDocKey()
+            val documents = List(3) { Document(documentKey) }
+
+            clients.zip(documents).forEach { (client, document) ->
+                client.attachDocument(
+                    document,
+                    syncMode = Client.SyncMode.Manual,
+                    disableGC = true,
+                ).await()
+            }
+
+            documents[0].updateAsync { root, _ ->
+                root.setNewCounter("counter", 0)
+            }.await()
+            clients.zip(documents).forEach { (client, document) ->
+                client.syncAsync(document).await()
+            }
+
+            repeat(3) {
+                documents.forEach { document ->
+                    document.updateAsync { root, _ ->
+                        root.getAs<JsonCounter>("counter").increase(1)
+                    }.await()
+                }
+                clients.zip(documents).forEach { (client, document) ->
+                    client.syncAsync(document).await()
+                }
+            }
+            // Drain remaining pushed changes so every client sees them.
+            clients.zip(documents).forEach { (client, document) ->
+                client.syncAsync(document).await()
+            }
+            clients[0].syncAsync(documents[0]).await()
+
+            documents.forEach { document ->
+                assertEquals("""{"counter":9}""", document.toJson())
+            }
+
+            // The contract assertion: every opt-out doc's VV stays at size 1.
+            documents.forEachIndexed { index, document ->
+                assertEquals(
+                    1,
+                    document.getVersionVector().size(),
+                    "opt-out doc[$index].versionVector must stay at size 1",
+                )
+            }
+
+            clients.zip(documents).forEach { (client, document) ->
+                client.detachDocument(document).await()
+                client.deactivateAsync().await()
+                client.close()
+            }
+        }
+    }
+
+    @Test
+    fun test_reattach_without_disable_gc_restores_normal_sync_behavior() {
+        runBlocking {
+            val c = createClient()
+            c.activateAsync().await()
+
+            val documentKey = "disable-gc-reattach-${UUID.randomUUID()}".toDocKey()
+
+            // First attach: opt-out.
+            val d1 = Document(documentKey)
+            c.attachDocument(d1, syncMode = Client.SyncMode.Manual, disableGC = true).await()
+            d1.updateAsync { root, _ ->
+                root.setNewCounter("counter", 0)
+                root.getAs<JsonCounter>("counter").increase(1)
+            }.await()
+            c.syncAsync(d1).await()
+            c.detachDocument(d1).await()
+
+            // Re-attach without the option. The SDK reads the flag from the
+            // attachment, so this PushPull omits disableGC.
+            val d2 = Document(documentKey)
+            c.attachDocument(d2, syncMode = Client.SyncMode.Manual).await()
+            d2.updateAsync { root, _ ->
+                root.getAs<JsonCounter>("counter").increase(1)
+            }.await()
+            c.syncAsync(d2).await()
+
+            assertEquals("""{"counter":2}""", d2.toJson())
+
+            c.detachDocument(d2).await()
+            c.deactivateAsync().await()
+            c.close()
+        }
+    }
+
+    // Regression for the server-side issue where the response VV was nil'ed for opt-out
+    // clients even on snapshot pulls, preventing the opt-out client's change clock from
+    // catching up to the server's actual state.
+    @Test
+    fun test_opt_out_client_picks_up_server_lamport_when_attach_returns_snapshot() {
+        runBlocking {
+            val documentKey = "disable-gc-snapshot-${UUID.randomUUID()}".toDocKey()
+
+            val cA = createClient()
+            cA.activateAsync().await()
+            val dA = Document(documentKey)
+            cA.attachDocument(dA, syncMode = Client.SyncMode.Manual).await()
+            repeat(DEFAULT_SNAPSHOT_THRESHOLD + 1) { index ->
+                dA.updateAsync { root, _ ->
+                    root["k$index"] = index
+                }.await()
+            }
+            cA.syncAsync(dA).await()
+
+            // The opt-out attach pull crosses the snapshot threshold, so the
+            // response is a snapshot.
+            val cB = createClient()
+            cB.activateAsync().await()
+            val dB = Document(documentKey)
+            cB.attachDocument(dB, syncMode = Client.SyncMode.Manual, disableGC = true).await()
+
+            assertTrue(
+                dB.changeID.lamport >= DEFAULT_SNAPSHOT_THRESHOLD,
+                "opt-out client must catch up to server lamport via snapshot, " +
+                    "lamport: ${dB.changeID.lamport}",
+            )
+            assertEquals(
+                1,
+                dB.getVersionVector().size(),
+                "opt-out doc.VV must stay size 1 after snapshot pull",
+            )
+
+            cB.detachDocument(dB).await()
+            cB.deactivateAsync().await()
+            cB.close()
+            cA.detachDocument(dA).await()
+            cA.deactivateAsync().await()
+            cA.close()
         }
     }
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -1043,6 +1043,10 @@ public class Client(
                 }
 
                 val pack = response.changePack.toChangePack()
+                // Record the opt-out decision before applying the attach response
+                // so the first applyChangePack already routes remote changes
+                // through the lamport-only sync path.
+                document.setDisableGC(disableGC)
                 document.applyChangePack(pack)
 
                 // Clear undo/redo stacks so that initialRoot setup operations

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -100,6 +100,16 @@ public class Document(
     @Volatile
     private var schemaRules: List<Rule> = emptyList()
 
+    /**
+     * Declares that this document does not produce or consume tombstones.
+     * Set by the client on attach and consumed by applyChanges to skip merging
+     * remote actors' version vectors into [changeID], keeping each subsequent
+     * local Change's version vector at O(1) for high-fan-out Counter workloads.
+     * Distinct from [Options.disableGC], which gates the local GC pass.
+     */
+    @Volatile
+    private var disableGC = false
+
     private val eventStream = MutableSharedFlow<Event>()
     public val events = eventStream.asSharedFlow()
 
@@ -673,7 +683,11 @@ public class Document(
             newPresences?.let {
                 emitPresences(it, presenceEvent)
             }
-            changeID = changeID.syncClocks(change.id)
+            changeID = if (disableGC) {
+                changeID.syncLamport(change.id)
+            } else {
+                changeID.syncClocks(change.id)
+            }
         }
     }
 
@@ -876,6 +890,15 @@ public class Document(
 
     public fun toJson(): String {
         return root.toJson()
+    }
+
+    /**
+     * `setDisableGC` records whether this document participates in GC. The
+     * client calls this on attach so subsequent applyChanges runs use the
+     * lamport-only sync path.
+     */
+    internal fun setDisableGC(disableGC: Boolean) {
+        this.disableGC = disableGC
     }
 
     /**

--- a/yorkie/src/main/kotlin/dev/yorkie/document/change/ChangeID.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/change/ChangeID.kt
@@ -47,11 +47,33 @@ public data class ChangeID(
      *
      * {@link https://en.wikipedia.org/wiki/Lamport_timestamps#Algorithm}
      */
+    @Deprecated("Use syncLamport(other: ChangeID)", ReplaceWith("syncLamport(other)"))
     fun syncLamport(otherLamport: Long): ChangeID {
         if (otherLamport > lamport) {
             return copy(lamport = otherLamport)
         }
         return copy(lamport = lamport + 1)
+    }
+
+    /**
+     * Advances the lamport clock against the given ID without merging its
+     * version vector into the receiver's. It is the counterpart of
+     * [syncClocks] for attachments that have opted out of GC participation:
+     * the receiver does not need other actors' entries in its version vector
+     * because it never produces or consumes tombstones, and dropping them
+     * keeps each subsequent local Change's version vector at O(1) instead of
+     * O(num_actors). Lamport must still advance so that TimeTickets produced
+     * locally remain ordered against remote operations.
+     */
+    fun syncLamport(other: ChangeID): ChangeID {
+        if (!other.hasClocks()) {
+            return this
+        }
+
+        val newLamport = if (other.lamport > lamport) other.lamport + 1 else lamport + 1
+        val vector = versionVector.deepCopy()
+        vector.set(actor, newLamport)
+        return copy(lamport = newLamport, versionVector = vector)
     }
 
     private fun hasClocks(): Boolean {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtArray.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtArray.kt
@@ -15,8 +15,12 @@ internal data class CrdtArray(
     val head
         get() = elements.head
 
+    /**
+     * The value of the last live element, skipping bare position nodes left by
+     * moves. Not anchor-safe: use [lastCreatedAt] for anchoring inserts.
+     */
     val last
-        get() = elements.last.value
+        get() = elements.lastElement
 
     val length
         get() = elements.length

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeList.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/RgaTreeList.kt
@@ -4,7 +4,9 @@ import dev.yorkie.document.time.TimeTicket
 import dev.yorkie.document.time.TimeTicket.Companion.InitialTimeTicket
 import dev.yorkie.document.time.TimeTicket.Companion.TIME_TICKET_SIZE
 import dev.yorkie.util.DataSize
-import dev.yorkie.util.SplayTreeSet
+import dev.yorkie.util.TreeList
+import dev.yorkie.util.TreeListNode
+import dev.yorkie.util.TreeListValue
 import dev.yorkie.util.YorkieException
 
 /**
@@ -22,11 +24,7 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
     var last: Node = dummyHead
         private set
 
-    private val nodeMapByIndex = SplayTreeSet<Node> {
-        if (it.elementEntry == null || it.value.isRemoved) 0 else 1
-    }.apply {
-        insert(dummyHead)
-    }
+    private val nodeMapByIndex = TreeList(dummyHead.indexNode)
 
     /**
      * Maps a position node's `positionCreatedAt` to the node itself.
@@ -51,6 +49,20 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
      */
     val lastCreatedAt
         get() = last.positionCreatedAt
+
+    /**
+     * Returns the value of the last live node, skipping bare position nodes
+     * (created by moveAfter/addDeadPosition) that have no element. Falls back
+     * to the dummy head's value on an empty list.
+     */
+    val lastElement: CrdtElement
+        get() {
+            var node = last
+            while (node.elementEntry == null && node != dummyHead) {
+                node = requireNotNull(node.prev)
+            }
+            return node.value
+        }
 
     /**
      * Adds a new node with [value] after the last node.
@@ -114,7 +126,7 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
             last = node
         }
 
-        nodeMapByIndex.insertAfter(anchor, node)
+        nodeMapByIndex.insertAfter(anchor.indexNode, node.indexNode)
         nodeMapByPositionCreatedAt[node.positionCreatedAt] = node
     }
 
@@ -126,7 +138,7 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
         val node = Node.create(CrdtPrimitive(null, executedAt), executedAt)
         insertNodeIntoStructures(node, anchor)
         node.markDead(executedAt)
-        nodeMapByIndex.splay(node)
+        nodeMapByIndex.updateWeight(node.indexNode)
         return node
     }
 
@@ -178,10 +190,10 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
 
         insertNodeIntoStructures(newPositionNode, anchor)
 
-        // Kill the old position node but keep it splayed (length 0) until GC purges it:
-        // a later insert/append may still anchor after it (e.g. it was `last`).
+        // Kill the old position node but keep it in the index tree (weight 0) until GC
+        // purges it: a later insert/append may still anchor after it (e.g. it was `last`).
         oldPositionNode.markDead(executedAt)
-        nodeMapByIndex.splay(oldPositionNode)
+        nodeMapByIndex.updateWeight(oldPositionNode.indexNode)
 
         return oldPositionNode
     }
@@ -197,7 +209,7 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
         prevNode.next = node
         node.prev = prevNode
         last = node
-        nodeMapByIndex.insertAfter(prevNode, node)
+        nodeMapByIndex.insertAfter(prevNode.indexNode, node.indexNode)
         nodeMapByPositionCreatedAt[positionCreatedAt] = node
     }
 
@@ -256,7 +268,7 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
         val node = entry.positionNode
         val alreadyRemoved = node.isRemoved
         if (node.remove(editedAt) && !alreadyRemoved) {
-            nodeMapByIndex.splay(node)
+            nodeMapByIndex.updateWeight(node.indexNode)
         }
         return node.value
     }
@@ -266,7 +278,7 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
             last = requireNotNull(node.prev)
         }
         node.release()
-        nodeMapByIndex.delete(node)
+        nodeMapByIndex.delete(node.indexNode)
         nodeMapByPositionCreatedAt.remove(node.positionCreatedAt)
     }
 
@@ -283,7 +295,7 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
     fun subPathOf(createdAt: TimeTicket): String {
         val entry = elementMapByCreatedAt[createdAt]
             ?: throw NoSuchElementException("can't find the given node createdAt: $createdAt")
-        return nodeMapByIndex.indexOf(entry.positionNode).toString()
+        return nodeMapByIndex.indexOf(entry.positionNode.indexNode).toString()
     }
 
     /**
@@ -291,7 +303,7 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
      */
     fun getByIndex(index: Int): Node? {
         if (length <= index) return null
-        return nodeMapByIndex.findForArray(index)
+        return nodeMapByIndex.find(index).value
     }
 
     /**
@@ -304,7 +316,7 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
         var node: Node? = entry.positionNode
         do {
             node = node?.prev
-        } while (dummyHead != node && node != null && (node.elementEntry == null || node.isRemoved))
+        } while (dummyHead != node && node != null && node.isRemoved)
         return (node ?: dummyHead).positionCreatedAt
     }
 
@@ -339,7 +351,7 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
     fun removeByIndex(index: Int, executedAt: TimeTicket): CrdtElement? {
         val node = getByIndex(index) ?: return null
         if (node.remove(executedAt)) {
-            nodeMapByIndex.splay(node)
+            nodeMapByIndex.updateWeight(node.indexNode)
         }
         return node.value
     }
@@ -408,7 +420,12 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
     class Node private constructor(
         val value: CrdtElement,
         val positionCreatedAt: TimeTicket,
-    ) : GCChild {
+    ) : GCChild, TreeListValue {
+        /**
+         * The [TreeListNode] backing this node's slot in the index tree.
+         */
+        val indexNode = TreeListNode(this)
+
         var prev: Node? = null
         var next: Node? = null
 
@@ -426,8 +443,12 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
         val positionedAt: TimeTicket
             get() = positionCreatedAt
 
-        val isRemoved
-            get() = value.isRemoved
+        /**
+         * A node is removed when it is a bare position slot (no element) or
+         * its element is tombstoned. Drives the index tree's live-node weight.
+         */
+        override val isRemoved: Boolean
+            get() = elementEntry == null || value.isRemoved
 
         override val removedAt: TimeTicket?
             get() = positionRemovedAt
@@ -439,6 +460,9 @@ internal class RgaTreeList : Iterable<RgaTreeList.Node>, GCParent<RgaTreeList.No
             )
 
         fun remove(removedAt: TimeTicket): Boolean {
+            if (elementEntry == null) {
+                return false
+            }
             return value.remove(removedAt)
         }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/util/TreeList.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/util/TreeList.kt
@@ -1,0 +1,459 @@
+package dev.yorkie.util
+
+/**
+ * [TreeListValue] represents the data stored in the nodes of [TreeList].
+ */
+internal interface TreeListValue {
+    val isRemoved: Boolean
+}
+
+/**
+ * [TreeListNode] is a node of [TreeList].
+ *
+ * It tracks two aggregates over its subtree:
+ * - weight: number of non-removed (live) nodes (logical index)
+ * - count: total nodes including tombstones (structural index)
+ */
+internal class TreeListNode<V : TreeListValue>(val value: V) {
+    var left: TreeListNode<V>? = null
+    var right: TreeListNode<V>? = null
+    var parent: TreeListNode<V>? = null
+
+    var red: Boolean = true
+
+    /**
+     * Returns 1 if the node is live, 0 if removed (tombstone).
+     */
+    val size: Int
+        get() = if (value.isRemoved) 0 else 1
+
+    var weight: Int = size
+    var count: Int = 1
+
+    /**
+     * Returns the live-node weight of the left subtree, or 0 if absent.
+     */
+    val leftWeight: Int
+        get() = left?.weight ?: 0
+
+    /**
+     * Returns the live-node weight of the right subtree, or 0 if absent.
+     */
+    val rightWeight: Int
+        get() = right?.weight ?: 0
+
+    /**
+     * Returns the total node count of the left subtree, or 0 if absent.
+     */
+    val leftCount: Int
+        get() = left?.count ?: 0
+
+    /**
+     * Returns the total node count of the right subtree, or 0 if absent.
+     */
+    val rightCount: Int
+        get() = right?.count ?: 0
+}
+
+/**
+ * Reports whether the given node is a red link. A null node is treated as
+ * black, matching the standard LLRB convention.
+ */
+private fun <V : TreeListValue> isRed(node: TreeListNode<V>?): Boolean {
+    return node?.red == true
+}
+
+/**
+ * Recomputes the cached weight and count aggregates of [node] from its
+ * children. Call this whenever the structure or liveness of a child changes.
+ */
+private fun <V : TreeListValue> updateNode(node: TreeListNode<V>) {
+    node.weight = node.leftWeight + node.size + node.rightWeight
+    node.count = node.leftCount + 1 + node.rightCount
+}
+
+/**
+ * Performs a standard LLRB left rotation around [node], promoting its right
+ * child. Parent pointers and aggregate counters are refreshed and the new
+ * subtree root is returned.
+ */
+private fun <V : TreeListValue> rotateLeft(node: TreeListNode<V>): TreeListNode<V> {
+    val right = requireNotNull(node.right)
+
+    node.right = right.left
+    node.right?.parent = node
+
+    right.left = node
+    right.parent = node.parent
+    node.parent = right
+
+    right.red = node.red
+    node.red = true
+
+    updateNode(node)
+    updateNode(right)
+    return right
+}
+
+/**
+ * Performs a standard LLRB right rotation around [node], promoting its left
+ * child. Parent pointers and aggregate counters are refreshed and the new
+ * subtree root is returned.
+ */
+private fun <V : TreeListValue> rotateRight(node: TreeListNode<V>): TreeListNode<V> {
+    val left = requireNotNull(node.left)
+
+    node.left = left.right
+    node.left?.parent = node
+
+    left.right = node
+    left.parent = node.parent
+    node.parent = left
+
+    left.red = node.red
+    node.red = true
+
+    updateNode(node)
+    updateNode(left)
+    return left
+}
+
+/**
+ * Toggles the colors of [node] and both of its children, used during LLRB
+ * splits and merges.
+ */
+private fun <V : TreeListValue> flipColors(node: TreeListNode<V>) {
+    node.red = !node.red
+    requireNotNull(node.left).let { it.red = !it.red }
+    requireNotNull(node.right).let { it.red = !it.red }
+}
+
+/**
+ * Ensures the left child or one of its children is red so a deletion
+ * descending to the left can proceed without violating LLRB invariants.
+ * The new subtree root is returned.
+ */
+private fun <V : TreeListValue> moveRedLeft(node: TreeListNode<V>): TreeListNode<V> {
+    var current = node
+    flipColors(current)
+    if (isRed(current.right?.left)) {
+        current.right = rotateRight(requireNotNull(current.right))
+        current.right?.parent = current
+        current = rotateLeft(current)
+        flipColors(current)
+    }
+    return current
+}
+
+/**
+ * Ensures the right child or one of its children is red so a deletion
+ * descending to the right can proceed without violating LLRB invariants.
+ * The new subtree root is returned.
+ */
+private fun <V : TreeListValue> moveRedRight(node: TreeListNode<V>): TreeListNode<V> {
+    var current = node
+    flipColors(current)
+    if (isRed(current.left?.left)) {
+        current = rotateRight(current)
+        flipColors(current)
+    }
+    return current
+}
+
+/**
+ * Removes the minimum (left-most) node from the subtree rooted at [node] and
+ * returns the rebalanced subtree root. Used by delete when splicing in the
+ * in-order successor.
+ */
+private fun <V : TreeListValue> removeMin(node: TreeListNode<V>): TreeListNode<V>? {
+    var current = node
+    if (current.left == null) {
+        return null
+    }
+
+    if (!isRed(current.left) && !isRed(current.left?.left)) {
+        current = moveRedLeft(current)
+    }
+
+    current.left = removeMin(requireNotNull(current.left))
+    current.left?.parent = current
+
+    return fixUp(current)
+}
+
+/**
+ * Returns the left-most node of the subtree rooted at [node], which is the
+ * in-order successor used during deletion.
+ */
+private fun <V : TreeListValue> minNode(node: TreeListNode<V>): TreeListNode<V> {
+    var current = node
+    while (current.left != null) {
+        current = requireNotNull(current.left)
+    }
+    return current
+}
+
+/**
+ * Restores LLRB invariants on the way back up after an insertion or deletion:
+ * it leans right-red links left, splits 4-nodes, and refreshes the node's
+ * aggregate counters.
+ */
+private fun <V : TreeListValue> fixUp(node: TreeListNode<V>): TreeListNode<V> {
+    var current = node
+    if (isRed(current.right) && !isRed(current.left)) {
+        current = rotateLeft(current)
+    }
+    if (isRed(current.left) && isRed(current.left?.left)) {
+        current = rotateRight(current)
+    }
+    if (isRed(current.left) && isRed(current.right)) {
+        flipColors(current)
+    }
+    updateNode(current)
+    return current
+}
+
+/**
+ * Walks the subtree rooted at [node] in left-root-right order, invoking
+ * [action] on every node (live and tombstoned).
+ */
+private fun <V : TreeListValue> traverseInOrder(
+    node: TreeListNode<V>?,
+    action: (TreeListNode<V>) -> Unit,
+) {
+    if (node == null) {
+        return
+    }
+    traverseInOrder(node.left, action)
+    action(node)
+    traverseInOrder(node.right, action)
+}
+
+/**
+ * [TreeList] is an order-statistic tree based on Left-leaning Red-Black Tree.
+ * It is used by RgaTreeList to support index-based operations on a list with
+ * tombstones, guaranteeing O(log N) worst-case for all operations.
+ *
+ * It maintains two weights per node:
+ * - weight: count of non-removed nodes (for index-based lookup)
+ * - count: total nodes including tombstones (for structural operations)
+ */
+internal class TreeList<V : TreeListValue>(root: TreeListNode<V>? = null) {
+    private var root: TreeListNode<V>? = root?.also { it.red = false }
+
+    /**
+     * Returns the number of non-removed (live) nodes.
+     */
+    val length: Int
+        get() = root?.weight ?: 0
+
+    /**
+     * Inserts the [target] node right after [prev] in the in-order traversal.
+     * It uses structural (count-based) indexing to correctly handle tombstone
+     * nodes.
+     */
+    fun insertAfter(prev: TreeListNode<V>, target: TreeListNode<V>) {
+        target.left = null
+        target.right = null
+        target.parent = null
+        target.red = true
+        target.weight = target.size
+        target.count = 1
+
+        val index = structuralIndexOf(prev)
+        root = insertByCount(root, index + 1, target)
+        requireNotNull(root).apply {
+            red = false
+            parent = null
+        }
+    }
+
+    /**
+     * Inserts [newNode] at the given structural [index] within the subtree
+     * rooted at [node], descending the tree using each node's left count
+     * (tombstones included) and rebalancing on the way back up.
+     */
+    private fun insertByCount(
+        node: TreeListNode<V>?,
+        index: Int,
+        newNode: TreeListNode<V>,
+    ): TreeListNode<V> {
+        if (node == null) {
+            return newNode
+        }
+
+        if (index <= node.leftCount) {
+            node.left = insertByCount(node.left, index, newNode)
+            node.left?.parent = node
+        } else {
+            node.right = insertByCount(node.right, index - node.leftCount - 1, newNode)
+            node.right?.parent = node
+        }
+
+        return fixUp(node)
+    }
+
+    /**
+     * Returns the node at the given logical [index] (among non-removed nodes).
+     * @throws YorkieException when the index is out of range.
+     */
+    fun find(index: Int): TreeListNode<V> {
+        val rootNode = root
+        if (rootNode == null || index < 0 || index >= length) {
+            throw YorkieException(
+                code = YorkieException.Code.ErrInvalidArgument,
+                errorMessage = "out of index: tree size $length, index $index",
+            )
+        }
+
+        var node: TreeListNode<V> = rootNode
+        var target = index
+        while (true) {
+            when {
+                target < node.leftWeight -> node = requireNotNull(node.left)
+                target < node.leftWeight + node.size -> break
+                else -> {
+                    target -= node.leftWeight + node.size
+                    node = requireNotNull(node.right)
+                }
+            }
+        }
+        return node
+    }
+
+    /**
+     * Physically removes [node] from the tree. Unlike tombstoning, this
+     * completely removes the node from the tree structure. It uses structural
+     * (count-based) indexing and swaps the node structure (not values) with
+     * its successor to preserve node identity.
+     */
+    fun delete(node: TreeListNode<V>) {
+        val currentRoot = root ?: return
+
+        if (!isRed(currentRoot.left) && !isRed(currentRoot.right)) {
+            currentRoot.red = true
+        }
+
+        val index = structuralIndexOf(node)
+        root = deleteByCount(currentRoot, index)
+
+        root?.apply {
+            red = false
+            parent = null
+        }
+    }
+
+    /**
+     * Removes the node at the given structural [index] within the subtree
+     * rooted at [node]. When deleting an internal node, it swaps in the
+     * in-order successor by re-parenting rather than copying values so
+     * external references to the surviving node remain valid.
+     */
+    private fun deleteByCount(node: TreeListNode<V>, index: Int): TreeListNode<V>? {
+        var current = node
+        if (index < current.leftCount) {
+            if (!isRed(current.left) && !isRed(current.left?.left)) {
+                current = moveRedLeft(current)
+            }
+            current.left = deleteByCount(requireNotNull(current.left), index)
+            current.left?.parent = current
+        } else {
+            if (isRed(current.left)) {
+                current = rotateRight(current)
+            }
+
+            if (index == current.leftCount && current.right == null) {
+                return null
+            }
+
+            if (!isRed(current.right) && !isRed(current.right?.left)) {
+                current = moveRedRight(current)
+            }
+
+            if (index == current.leftCount) {
+                // Swap the successor into this position instead of copying values.
+                // This preserves node identity so external references remain valid.
+                val successor = minNode(requireNotNull(current.right))
+                val newRight = removeMin(requireNotNull(current.right))
+
+                successor.left = current.left
+                successor.right = newRight
+                successor.red = current.red
+                successor.left?.parent = successor
+                successor.right?.parent = successor
+
+                current.left = null
+                current.right = null
+                current.parent = null
+
+                current = successor
+            } else {
+                current.right =
+                    deleteByCount(requireNotNull(current.right), index - current.leftCount - 1)
+                current.right?.parent = current
+            }
+        }
+
+        return fixUp(current)
+    }
+
+    /**
+     * Propagates weight changes from the given [node] up to the root. Call
+     * this after a node's liveness changes (i.e., after tombstoning).
+     */
+    fun updateWeight(node: TreeListNode<V>) {
+        var current: TreeListNode<V>? = node
+        while (current != null) {
+            current.weight = current.leftWeight + current.size + current.rightWeight
+            current = current.parent
+        }
+    }
+
+    /**
+     * Returns a string containing the metadata of the nodes for debugging.
+     */
+    fun toTestString(): String {
+        val builder = StringBuilder()
+        traverseInOrder(root) { node ->
+            builder.append("[${node.weight},${node.size}]${node.value}")
+        }
+        return builder.toString()
+    }
+
+    /**
+     * Returns the logical (live-node) index of the given [node], or -1 if the
+     * node is a tombstone.
+     */
+    fun indexOf(node: TreeListNode<V>): Int {
+        if (node.size == 0) {
+            return -1
+        }
+        var index = node.leftWeight
+        var current = node
+        while (true) {
+            val parent = current.parent ?: break
+            if (current === parent.right) {
+                index += parent.leftWeight + parent.size
+            }
+            current = parent
+        }
+        return index
+    }
+
+    /**
+     * Returns the structural position of the [node], counting all nodes
+     * including tombstones.
+     */
+    private fun structuralIndexOf(node: TreeListNode<V>): Int {
+        var index = node.leftCount
+        var current = node
+        while (true) {
+            val parent = current.parent ?: break
+            if (current === parent.right) {
+                index += parent.leftCount + 1
+            }
+            current = parent
+        }
+        return index
+    }
+}

--- a/yorkie/src/test/kotlin/dev/yorkie/document/change/ChangeIDTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/change/ChangeIDTest.kt
@@ -1,0 +1,101 @@
+package dev.yorkie.document.change
+
+import dev.yorkie.document.time.VersionVector
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class ChangeIDTest {
+    private val actorA = "000000000000000000000001"
+    private val actorB = "000000000000000000000002"
+    private val actorC = "000000000000000000000003"
+
+    private fun changeID(
+        actor: String,
+        lamport: Long,
+        vector: Map<String, Long> = mapOf(actor to lamport),
+    ) = ChangeID(
+        clientSeq = 1u,
+        lamport = lamport,
+        actor = actor,
+        versionVector = VersionVector(vector),
+    )
+
+    @Test
+    fun `syncLamport should advance lamport past remote without merging version vector`() {
+        val local = changeID(actorA, 3)
+        val remote = changeID(actorB, 10, mapOf(actorB to 10L, actorC to 7L))
+
+        val synced = local.syncLamport(remote)
+
+        assertEquals(11, synced.lamport)
+        assertEquals(1, synced.versionVector.size())
+        assertEquals(11L, synced.versionVector.get(actorA))
+    }
+
+    @Test
+    fun `syncLamport should advance own lamport when remote is behind`() {
+        val local = changeID(actorA, 10)
+        val remote = changeID(actorB, 3)
+
+        val synced = local.syncLamport(remote)
+
+        assertEquals(11, synced.lamport)
+        assertEquals(1, synced.versionVector.size())
+        assertEquals(11L, synced.versionVector.get(actorA))
+    }
+
+    @Test
+    fun `syncLamport should return this when remote has no clocks`() {
+        val local = changeID(actorA, 3)
+        val remote = ChangeID(1u, 0, actorB, VersionVector())
+
+        assertSame(local, local.syncLamport(remote))
+    }
+
+    @Test
+    fun `syncClocks should merge remote version vector`() {
+        val local = changeID(actorA, 3)
+        val remote = changeID(actorB, 10, mapOf(actorB to 10L, actorC to 7L))
+
+        val synced = local.syncClocks(remote)
+
+        assertEquals(11, synced.lamport)
+        assertEquals(3, synced.versionVector.size())
+        assertEquals(11L, synced.versionVector.get(actorA))
+        assertEquals(10L, synced.versionVector.get(actorB))
+        assertEquals(7L, synced.versionVector.get(actorC))
+    }
+
+    @Test
+    fun `next should increase clientSeq and lamport and update version vector`() {
+        val id = changeID(actorA, 3)
+
+        val next = id.next()
+
+        assertEquals(2u, next.clientSeq)
+        assertEquals(4, next.lamport)
+        assertEquals(4L, next.versionVector.get(actorA))
+    }
+
+    @Test
+    fun `setClocks should catch up to remote lamport and merge vector`() {
+        val id = changeID(actorA, 3)
+
+        val updated = id.setClocks(10, VersionVector(mapOf(actorB to 10L)))
+
+        assertEquals(11, updated.lamport)
+        assertEquals(11L, updated.versionVector.get(actorA))
+        assertEquals(10L, updated.versionVector.get(actorB))
+    }
+
+    @Test
+    fun `setLamport should replace lamport only`() {
+        val id = changeID(actorA, 3)
+
+        val updated = id.setLamport(42)
+
+        assertEquals(42, updated.lamport)
+        assertEquals(3L, updated.versionVector.get(actorA))
+    }
+}

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtArrayTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtArrayTest.kt
@@ -107,6 +107,24 @@ class CrdtArrayTest {
         assertEquals(crdtElements.size, target.length)
     }
 
+    // Ported from yorkie-js-sdk v0.7.11 (#1272): `last` must skip the bare position node
+    // left at the tail after moving the last element, including through deepCopy.
+    @Test
+    fun `last should skip bare position nodes and survive deepCopy`() {
+        // given
+        crdtElements.forEach { target.insertAfter(target.last.createdAt, it) }
+
+        // when — move the current last element (G) after A; its old tail slot becomes bare
+        target.moveAfter(timeTickets[0], timeTickets[6], createTimeTicket())
+
+        // then — last resolves to F, the last live element
+        assertEquals(timeTickets[5], target.last.createdAt)
+
+        // and the reconstructed clone (which restores the bare tail node) agrees
+        val copied = target.deepCopy() as CrdtArray
+        assertEquals(timeTickets[5], copied.last.createdAt)
+    }
+
     @Test
     fun `should handle concurrent insertAfter operations`() {
         val sampleTarget1 = createSampleCrdtArray().apply {

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/RgaTreeListTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/RgaTreeListTest.kt
@@ -412,6 +412,67 @@ class RgaTreeListTest {
         assertEquals(TimeTicket.TIME_TICKET_SIZE * 2, dead.dataSize.meta)
     }
 
+    // Ported from yorkie-js-sdk v0.7.11 (#1272): the last-element accessor must skip
+    // bare position nodes left behind by moves.
+    @Test
+    fun `lastElement should skip bare position node left after moving the last element`() {
+        // given — list [A, B, C]
+        val list = RgaTreeList()
+        val a = CrdtPrimitive("A", tick(1))
+        val b = CrdtPrimitive("B", tick(2))
+        val c = CrdtPrimitive("C", tick(3))
+        listOf(a, b, c).forEach(list::insert)
+
+        // when — move the current last element (C) after A; its old tail slot
+        // becomes a bare node and `last` keeps pointing at it
+        list.moveAfter(a.createdAt, c.createdAt, tick(5))
+
+        // then — lastElement resolves the last live element (B), not the stale slot
+        assertEquals("B", (list.lastElement as CrdtPrimitive).value)
+    }
+
+    @Test
+    fun `lastElement should skip consecutive trailing bare position nodes`() {
+        // given — list [A, B, C]
+        val list = RgaTreeList()
+        val a = CrdtPrimitive("A", tick(1))
+        val b = CrdtPrimitive("B", tick(2))
+        val c = CrdtPrimitive("C", tick(3))
+        listOf(a, b, c).forEach(list::insert)
+
+        // when — two moves leave two consecutive bare nodes at the tail
+        list.moveAfter(a.createdAt, c.createdAt, tick(5))
+        list.moveAfter(a.createdAt, b.createdAt, tick(6))
+
+        // then
+        assertEquals("C", (list.lastElement as CrdtPrimitive).value)
+    }
+
+    @Test
+    fun `lastElement should fall back to dummy head on empty list`() {
+        val list = RgaTreeList()
+
+        assertEquals(list.head, list.lastElement)
+    }
+
+    // TreeList.indexOf returns -1 for tombstones — deliberate JS-parity behavior change
+    // from the SplayTreeSet migration (v0.7.11 #1269).
+    @Test
+    fun `subPathOf should return -1 for a removed element`() {
+        // given — list [A, B]
+        val list = RgaTreeList()
+        val a = CrdtPrimitive("A", tick(1))
+        val b = CrdtPrimitive("B", tick(2))
+        listOf(a, b).forEach(list::insert)
+
+        // when — tombstone B (not purged yet)
+        list.delete(b.createdAt, tick(3))
+
+        // then
+        assertEquals("0", list.subPathOf(a.createdAt))
+        assertEquals("-1", list.subPathOf(b.createdAt))
+    }
+
     private fun tick(lamport: Long) = TimeTicket(lamport, TimeTicket.INITIAL_DELIMITER, "x")
 
     private fun valueAt(list: RgaTreeList, index: Int): Any? =

--- a/yorkie/src/test/kotlin/dev/yorkie/util/TreeListTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/util/TreeListTest.kt
@@ -1,0 +1,474 @@
+package dev.yorkie.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TreeListTest {
+
+    private class TestValue(val content: String, override var isRemoved: Boolean = false) :
+        TreeListValue {
+        override fun toString() = content
+    }
+
+    private fun newNode(content: String) = TreeListNode(TestValue(content))
+
+    private fun newRemovedNode(content: String) = TreeListNode(TestValue(content, true))
+
+    private fun rebuildLiveList(tree: TreeList<TestValue>): List<TreeListNode<TestValue>> {
+        return (0 until tree.length).map(tree::find)
+    }
+
+    /**
+     * Simple seeded LCG so the stress test is deterministic across runs/platforms.
+     */
+    private class Rng(seed: Int) {
+        private var state = seed.toLong() and 0xFFFFFFFFL
+
+        fun next(): Double {
+            state = (state * 1664525 + 1013904223) and 0xFFFFFFFFL
+            return state.toDouble() / 0x100000000L
+        }
+    }
+
+    @Test
+    fun `should insert and find`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        assertEquals(0, tree.length)
+
+        val nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        assertEquals(1, tree.length)
+
+        val nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+        assertEquals(2, tree.length)
+
+        val nodeC = newNode("C")
+        tree.insertAfter(nodeB, nodeC)
+        assertEquals(3, tree.length)
+
+        assertSame(nodeA, tree.find(0))
+        assertSame(nodeB, tree.find(1))
+        assertSame(nodeC, tree.find(2))
+    }
+
+    @Test
+    fun `should insert in the middle`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        val nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        val nodeC = newNode("C")
+        tree.insertAfter(nodeA, nodeC)
+
+        val nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+        assertEquals(3, tree.length)
+
+        assertSame(nodeA, tree.find(0))
+        assertSame(nodeB, tree.find(1))
+        assertSame(nodeC, tree.find(2))
+    }
+
+    @Test
+    fun `should insert after tombstone`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        val nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        val nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+
+        nodeA.value.isRemoved = true
+        tree.updateWeight(nodeA)
+        assertEquals(1, tree.length)
+
+        val nodeC = newNode("C")
+        tree.insertAfter(nodeA, nodeC)
+        assertEquals(2, tree.length)
+
+        assertSame(nodeC, tree.find(0))
+        assertSame(nodeB, tree.find(1))
+    }
+
+    @Test
+    fun `should delete node`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        val nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        val nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+        val nodeC = newNode("C")
+        tree.insertAfter(nodeB, nodeC)
+        assertEquals(3, tree.length)
+
+        tree.delete(nodeB)
+        assertEquals(2, tree.length)
+
+        assertSame(nodeA, tree.find(0))
+        assertSame(nodeC, tree.find(1))
+    }
+
+    @Test
+    fun `should preserve node identity on delete`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        val nodes = mutableListOf<TreeListNode<TestValue>>()
+        var prev = dummyHead
+        repeat(5) { index ->
+            val node = newNode(('A' + index).toString())
+            tree.insertAfter(prev, node)
+            nodes.add(node)
+            prev = node
+        }
+        assertEquals(5, tree.length)
+
+        tree.delete(nodes[2])
+        assertEquals(4, tree.length)
+
+        assertSame(nodes[0], tree.find(0))
+        assertSame(nodes[1], tree.find(1))
+        assertSame(nodes[3], tree.find(2))
+        assertSame(nodes[4], tree.find(3))
+    }
+
+    @Test
+    fun `should delete first and last nodes`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        val nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        val nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+        val nodeC = newNode("C")
+        tree.insertAfter(nodeB, nodeC)
+
+        tree.delete(nodeA)
+        assertEquals(2, tree.length)
+        assertSame(nodeB, tree.find(0))
+
+        tree.delete(nodeC)
+        assertEquals(1, tree.length)
+        assertSame(nodeB, tree.find(0))
+    }
+
+    @Test
+    fun `should delete tombstoned node`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        val nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        val nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+        val nodeC = newNode("C")
+        tree.insertAfter(nodeB, nodeC)
+
+        nodeB.value.isRemoved = true
+        tree.updateWeight(nodeB)
+        assertEquals(2, tree.length)
+
+        tree.delete(nodeB)
+        assertEquals(2, tree.length)
+
+        assertSame(nodeA, tree.find(0))
+        assertSame(nodeC, tree.find(1))
+    }
+
+    @Test
+    fun `should delete all nodes`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        val nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        val nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+
+        tree.delete(nodeA)
+        tree.delete(nodeB)
+        tree.delete(dummyHead)
+
+        assertEquals(0, tree.length)
+    }
+
+    @Test
+    fun `should update weight on tombstone`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        val nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        val nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+        val nodeC = newNode("C")
+        tree.insertAfter(nodeB, nodeC)
+        assertEquals(3, tree.length)
+
+        nodeB.value.isRemoved = true
+        tree.updateWeight(nodeB)
+        assertEquals(2, tree.length)
+
+        assertSame(nodeA, tree.find(0))
+        assertSame(nodeC, tree.find(1))
+        assertThrows(YorkieException::class.java) { tree.find(2) }
+    }
+
+    @Test
+    fun `should handle multiple tombstones`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        val nodes = mutableListOf<TreeListNode<TestValue>>()
+        var prev = dummyHead
+        repeat(6) { index ->
+            val node = newNode(('A' + index).toString())
+            tree.insertAfter(prev, node)
+            nodes.add(node)
+            prev = node
+        }
+        assertEquals(6, tree.length)
+
+        listOf(1, 3, 5).forEach { index ->
+            nodes[index].value.isRemoved = true
+            tree.updateWeight(nodes[index])
+        }
+        assertEquals(3, tree.length)
+
+        assertSame(nodes[0], tree.find(0))
+        assertSame(nodes[2], tree.find(1))
+        assertSame(nodes[4], tree.find(2))
+    }
+
+    @Test
+    fun `should throw when find is out of bounds`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        assertThrows(YorkieException::class.java) { tree.find(0) }
+
+        val nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+
+        assertThrows(YorkieException::class.java) { tree.find(-1) }
+        assertThrows(YorkieException::class.java) { tree.find(1) }
+    }
+
+    @Test
+    fun `should handle single live node tree`() {
+        val node = newNode("A")
+        val tree = TreeList(node)
+        assertEquals(1, tree.length)
+
+        assertSame(node, tree.find(0))
+
+        tree.delete(node)
+        assertEquals(0, tree.length)
+    }
+
+    @Test
+    fun `should find after large sequential insert`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        val n = 100
+        val nodes = mutableListOf<TreeListNode<TestValue>>()
+        var prev = dummyHead
+        repeat(n) { index ->
+            val node = newNode("$index")
+            tree.insertAfter(prev, node)
+            nodes.add(node)
+            prev = node
+        }
+        assertEquals(n, tree.length)
+
+        repeat(n) { index ->
+            assertSame(nodes[index], tree.find(index))
+        }
+    }
+
+    @Test
+    fun `should find after large sequential insert and tombstone`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        val n = 100
+        val nodes = mutableListOf<TreeListNode<TestValue>>()
+        var prev = dummyHead
+        repeat(n) { index ->
+            val node = newNode("$index")
+            tree.insertAfter(prev, node)
+            nodes.add(node)
+            prev = node
+        }
+
+        for (index in 0 until n step 2) {
+            nodes[index].value.isRemoved = true
+            tree.updateWeight(nodes[index])
+        }
+        assertEquals(n / 2, tree.length)
+
+        var liveIndex = 0
+        for (index in 1 until n step 2) {
+            assertSame(nodes[index], tree.find(liveIndex))
+            liveIndex++
+        }
+    }
+
+    @Test
+    fun `should find after large sequential insert and delete`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        val n = 100
+        val nodes = mutableListOf<TreeListNode<TestValue>>()
+        var prev = dummyHead
+        repeat(n) { index ->
+            val node = newNode("$index")
+            tree.insertAfter(prev, node)
+            nodes.add(node)
+            prev = node
+        }
+
+        for (index in 0 until n step 2) {
+            tree.delete(nodes[index])
+        }
+        assertEquals(n / 2, tree.length)
+
+        var liveIndex = 0
+        for (index in 1 until n step 2) {
+            assertSame(nodes[index], tree.find(liveIndex))
+            liveIndex++
+        }
+    }
+
+    @Test
+    fun `should handle interleaved insert and delete`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        val nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        val nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+        val nodeC = newNode("C")
+        tree.insertAfter(nodeB, nodeC)
+
+        tree.delete(nodeB)
+        val nodeD = newNode("D")
+        tree.insertAfter(nodeA, nodeD)
+        assertEquals(3, tree.length)
+
+        assertSame(nodeA, tree.find(0))
+        assertSame(nodeD, tree.find(1))
+        assertSame(nodeC, tree.find(2))
+    }
+
+    @Test
+    fun `should insert after dummy head with existing nodes`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        val nodeB = newNode("B")
+        tree.insertAfter(dummyHead, nodeB)
+        val nodeC = newNode("C")
+        tree.insertAfter(nodeB, nodeC)
+
+        val nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        assertEquals(3, tree.length)
+
+        assertSame(nodeA, tree.find(0))
+        assertSame(nodeB, tree.find(1))
+        assertSame(nodeC, tree.find(2))
+    }
+
+    @Test
+    fun `should render metadata in toTestString`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        val nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        val nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+
+        val str = tree.toTestString()
+        assertTrue(str.contains("dummy"))
+        assertTrue(str.contains("A"))
+        assertTrue(str.contains("B"))
+    }
+
+    @Test
+    fun `should return logical index from indexOf and -1 for tombstone`() {
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        val nodeA = newNode("A")
+        tree.insertAfter(dummyHead, nodeA)
+        val nodeB = newNode("B")
+        tree.insertAfter(nodeA, nodeB)
+        val nodeC = newNode("C")
+        tree.insertAfter(nodeB, nodeC)
+
+        assertEquals(0, tree.indexOf(nodeA))
+        assertEquals(1, tree.indexOf(nodeB))
+        assertEquals(2, tree.indexOf(nodeC))
+        assertEquals(-1, tree.indexOf(dummyHead))
+
+        nodeB.value.isRemoved = true
+        tree.updateWeight(nodeB)
+
+        assertEquals(-1, tree.indexOf(nodeB))
+        assertEquals(1, tree.indexOf(nodeC))
+    }
+
+    @Test
+    fun `should stay consistent under random operations`() {
+        val rng = Rng(42)
+        val dummyHead = newRemovedNode("dummy")
+        val tree = TreeList(dummyHead)
+
+        var liveNodes = listOf<TreeListNode<TestValue>>()
+        val allNodes = mutableListOf(dummyHead)
+
+        val ops = 500
+        repeat(ops) { iteration ->
+            val op = (rng.next() * 3).toInt()
+
+            if (op == 0 || allNodes.size < 3) {
+                val prev = allNodes[(rng.next() * allNodes.size).toInt()]
+                val node = newNode("n$iteration")
+                tree.insertAfter(prev, node)
+                allNodes.add(node)
+                liveNodes = rebuildLiveList(tree)
+            } else if (op == 1 && liveNodes.isNotEmpty()) {
+                val node = liveNodes[(rng.next() * liveNodes.size).toInt()]
+                node.value.isRemoved = true
+                tree.updateWeight(node)
+                liveNodes = rebuildLiveList(tree)
+            } else if (op == 2 && allNodes.size > 1) {
+                val deleteIndex = 1 + (rng.next() * (allNodes.size - 1)).toInt()
+                tree.delete(allNodes[deleteIndex])
+                allNodes.removeAt(deleteIndex)
+                liveNodes = rebuildLiveList(tree)
+            }
+
+            assertEquals("iteration $iteration", liveNodes.size, tree.length)
+            liveNodes.forEachIndexed { index, node ->
+                assertSame("iteration $iteration, find index $index", node, tree.find(index))
+            }
+        }
+    }
+}


### PR DESCRIPTION
> **RTCOLLABPLATFORM-717**: [[Android] Sync-up Yorkie JS SDK v0.7.11](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-717)

## Summary
- Ports yorkie-js-sdk v0.7.11 into the Android SDK (JS PRs #1269, #1270, #1272)
- New `TreeList` (LLRB order-statistic tree) replaces `SplayTreeSet` inside `RgaTreeList` for O(log N) worst-case random access in Array; `SplayTreeSet` remains for Text
- Opt-out (`disableGC`) attachments now use a lamport-only clock sync path, keeping each Change's version vector at size 1 under multi-actor fanout
- Last-element accessor skips bare position nodes left behind by array moves

## Changes
- `util/TreeList.kt` (new): order-statistic tree with dual aggregates (live weight + structural count), identity-preserving delete
- `crdt/RgaTreeList.kt`: index map migrated to `TreeList`; `Node.isRemoved` aligned to JS semantics; new `lastElement` with dummy-head guard; JS-parity guard in `Node.remove()`
- `crdt/CrdtArray.kt`: `last` now resolves the last live element (not anchor-safe; anchoring keeps `lastCreatedAt`)
- `change/ChangeID.kt`: new `syncLamport(other: ChangeID)`; old `syncLamport(Long)` deprecated (public API, kept for compatibility)
- `Document.kt` / `Client.kt`: attach-time `disableGC` flag routes `applyChanges` through `syncLamport`; set before the first `applyChangePack`
- `docker/*.yml`: Yorkie server 0.7.10 → 0.7.11 (needed for opt-out snapshot lamport fix)
- Tests: 20 `TreeListTest` cases ported from JS + indexOf additions, 7 `ChangeIDTest` cases, bare-node/`subPathOf` regressions in `RgaTreeListTest`/`CrdtArrayTest`, 4 new instrumented `DisableGCTest` cases (fanout VV=1, mixed-mode, re-attach, snapshot lamport)

## Test plan
- [ ] `./gradlew yorkie:connectedDebugAndroidTest` against local server 0.7.11 — verified: 245 tests, only pre-existing failure `JsonTreeConcurrencyTest.test_concurrent_split_and_edit_L2` (fails on base branch too, unrelated)
- [ ] Verify counter convergence with mixed opt-in/opt-out clients on a shared doc

> Items run automatically by CI (lint, unit tests, coverage) are excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
