### PR TITLE
fix: pull fallback on watch silence + unfreeze stalled event collectors

### DIFF
--- a/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Attachment.kt
@@ -1,6 +1,7 @@
 package dev.yorkie.core
 
 import dev.yorkie.document.Document
+import dev.yorkie.util.Logger.Companion.logDebug
 import kotlinx.coroutines.Job
 
 /**
@@ -27,6 +28,21 @@ internal class Attachment<R : Attachable>(
      * contract is set on the attach request, not on PushPullChanges.
      */
     val disablePresence: Boolean = false,
+    /**
+     * Clock used for all liveness/throttle timing. Defaults to the real wall clock;
+     * tests inject a fake `var now` to drive [needSync] deterministically without
+     * real delays, since the client runs its sync loop on a real (non-virtualizable)
+     * dispatcher (see `AttachmentTest`).
+     */
+    private val nowProvider: () -> Long = System::currentTimeMillis,
+    /**
+     * How long (ms) a realtime document's watch stream may stay silent before this
+     * attachment starts pull-fallback (see `Client.Options.watchFallbackDelay`, whose
+     * value this is populated from — `Duration.INFINITE.inWholeMilliseconds ==
+     * Long.MAX_VALUE`, so that value alone disables fallback with no separate
+     * null/branch). Channels never read this (fallback is Document-realtime-only).
+     */
+    private val watchFallbackDelay: Long = Long.MAX_VALUE,
 ) {
     var changeEventReceived: Boolean? = syncMode?.let { false }
     var cancelled: Boolean = false
@@ -45,6 +61,45 @@ internal class Attachment<R : Attachable>(
     // heartbeat interval. Mirrors JS SDK v0.7.10.
     private var lastHeartbeatTime: Long = 0L
     var watchJobHolder: WatchJobHolder? = null
+
+    /**
+     * Wall-clock time (per [nowProvider]) of the last watch-stream frame received for
+     * this attachment (any event kind — see `Client.markWatchResponseReceived` call
+     * sites). Seeded at construction so a freshly attached document is not treated as
+     * "instantly silent" before its watch stream has had a chance to connect.
+     */
+    var lastWatchResponseTime: Long = nowProvider()
+        private set
+
+    /**
+     * `true` once pull fallback has engaged for this attachment (watch stream judged
+     * silent past a threshold — see `Client.Options.watchFallbackDelay`) — used to log
+     * the engage/disengage transition exactly once each way, not on every sync-loop
+     * tick.
+     */
+    var watchFallbackEngaged: Boolean = false
+        private set
+
+    /**
+     * Records that a watch-stream frame was just received for this attachment,
+     * resetting its silence clock. Called from every received frame (proves the
+     * stream is alive) and from stream (re)connection (the revival signal) — see
+     * `Client.kt`'s watch-loop call sites.
+     *
+     * If fallback was engaged, this is the disengage signal: logs the transition via
+     * `Logger` before resetting, so the silent failure mode #351 went undiagnosed
+     * under is now itself observable.
+     */
+    fun markWatchResponseReceived() {
+        if (watchFallbackEngaged) {
+            watchFallbackEngaged = false
+            logDebug(
+                "WF",
+                "pull fallback disengaged for ${resource.getKey()}: watch frame received",
+            )
+        }
+        lastWatchResponseTime = nowProvider()
+    }
 
     /**
      * `needRealtimeSync` returns whether the resource needs to be synced in real time.
@@ -66,6 +121,44 @@ internal class Attachment<R : Attachable>(
     }
 
     /**
+     * Pull-fallback decision for #351 phase 1: in full [Client.SyncMode.Realtime], PULL is
+     * normally gated by [needRealTimeSync] alone, which only flips true on a watch event
+     * ([changeEventReceived]) or a local edit. If the watch stream dies silently (no error,
+     * no reconnect — see issue #351), [changeEventReceived] never flips true again and PULL
+     * starves forever. This degrades the attachment toward [Client.SyncMode.Polling]
+     * semantics — pull on every tick — once the watch stream has been silent past
+     * [watchFallbackDelay], throttled to at most once per [documentPollInterval] (via
+     * [lastHeartbeatTime], reused exactly as the Polling branch above does — broadened by
+     * `Client.syncInternal` to also reset for realtime attachments with fallback engaged,
+     * so this clause has a moving baseline instead of firing every 50ms sync-loop tick).
+     *
+     * Only applies to a Document attachment with a genuinely open watch stream in full
+     * realtime mode: [Client.SyncMode.RealtimePushOnly]/[Client.SyncMode.RealtimeSyncOff]
+     * never open one, and neither does the brief window between attach and the watch job
+     * actually starting.
+     */
+    private fun watchStreamSilent(documentPollInterval: Long): Boolean {
+        if (syncMode != Client.SyncMode.Realtime || watchJobHolder == null) {
+            return false
+        }
+
+        val now = nowProvider()
+        val silent = now - lastWatchResponseTime >= watchFallbackDelay &&
+            now - lastHeartbeatTime >= documentPollInterval
+
+        if (silent && !watchFallbackEngaged) {
+            watchFallbackEngaged = true
+            logDebug(
+                "WF",
+                "pull fallback engaged for ${resource.getKey()}: " +
+                    "watch silent >= ${watchFallbackDelay}ms",
+            )
+        }
+
+        return silent
+    }
+
+    /**
      * `needSync` determines if the attachment needs sync.
      * This includes both document sync and presence heartbeat.
      */
@@ -75,9 +168,9 @@ internal class Attachment<R : Attachable>(
             // Polling has no watch stream, so it pushes and pulls on a fixed
             // interval regardless of local changes. Mirrors JS SDK PR #1243.
             if (syncMode == Client.SyncMode.Polling) {
-                return System.currentTimeMillis() - lastHeartbeatTime >= documentPollInterval
+                return nowProvider() - lastHeartbeatTime >= documentPollInterval
             }
-            return needRealTimeSync()
+            return needRealTimeSync() || watchStreamSilent(documentPollInterval)
         }
 
         // For Channel in Manual mode: never auto-sync
@@ -86,14 +179,14 @@ internal class Attachment<R : Attachable>(
         }
 
         // For Channel: check if heartbeat is needed
-        return System.currentTimeMillis() - lastHeartbeatTime >= heartbeatInterval
+        return nowProvider() - lastHeartbeatTime >= heartbeatInterval
     }
 
     /**
      * `updateHeartbeatTime` updates the last heartbeat time.
      */
     fun updateHeartbeatTime() {
-        lastHeartbeatTime = System.currentTimeMillis()
+        lastHeartbeatTime = nowProvider()
     }
 
     fun cancelWatchJob() {

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -1870,6 +1870,12 @@ public class Client(
          *
          * Set to `Duration.INFINITE` to disable fallback entirely (a silent watch
          * stream then starves pull forever, matching pre-fallback behavior).
+         *
+         * Note: the fallback targets HALF-OPEN silence (stream object alive but
+         * delivering nothing — the shape that never triggers the reconnect loop).
+         * It runs inside the client's own sync loop, so it cannot help with hard
+         * outages where that loop itself stops; those surface as RPC errors through
+         * the existing retry/backoff path instead.
          */
         public val watchFallbackDelay: Duration = 10_000.milliseconds,
     ) {

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -369,7 +369,16 @@ public class Client(
                         // Done before the RPC so a failed push-pull does not
                         // retry every 50ms and drain battery / hammer the
                         // server during outages. #1243.
-                        if (attachment.syncMode == SyncMode.Polling) {
+                        // Also reset for Realtime: gives the watch-silence pull
+                        // fallback's own throttle a moving baseline (#351 phase
+                        // 1) — otherwise lastHeartbeatTime stays 0 for realtime
+                        // documents and the throttle is inert, i.e. a fallback
+                        // pull storm every sync-loop tick once engaged. Harmless
+                        // no-op for realtime documents with fallback disabled
+                        // (their throttle clause never engages regardless).
+                        if (attachment.syncMode == SyncMode.Polling ||
+                            attachment.syncMode == SyncMode.Realtime
+                        ) {
                             attachment.updateHeartbeatTime()
                         }
 
@@ -403,7 +412,12 @@ public class Client(
 
                         // Reset the poll timer so a Polling document syncs once
                         // per interval, not on every sync-loop tick. #1243.
-                        if (attachment.syncMode == SyncMode.Polling) {
+                        // Also reset for Realtime — see the matching comment above
+                        // this method's first updateHeartbeatTime() call (#351
+                        // phase 1 throttle baseline).
+                        if (attachment.syncMode == SyncMode.Polling ||
+                            attachment.syncMode == SyncMode.Realtime
+                        ) {
                             attachment.updateHeartbeatTime()
                         }
 
@@ -594,6 +608,10 @@ public class Client(
                         withTimeoutOrNull(streamTimeout) {
                             val receiveResult = responseChannel.receiveCatching()
                             receiveResult.onSuccess {
+                                // Every frame of any kind proves the watch stream is alive —
+                                // resets this attachment's silence clock, disengaging pull
+                                // fallback if it had engaged (#351 phase 1).
+                                attachment.markWatchResponseReceived()
                                 handleWatchDocumentResponse(
                                     documentKey = documentKey,
                                     response = it,
@@ -646,6 +664,9 @@ public class Client(
                 if (attachment.changeEventReceived != null) {
                     attachment.changeEventReceived = true
                 }
+                // Stream (re)connection is itself a liveness/revival signal — resets the
+                // silence clock the same as any received frame would (#351 phase 1).
+                attachment.markWatchResponseReceived()
 
                 streamJob.join()
             }
@@ -1077,6 +1098,7 @@ public class Client(
                     syncMode = syncMode,
                     disableGC = disableGC,
                     disablePresence = response.disablePresence,
+                    watchFallbackDelay = options.watchFallbackDelay.inWholeMilliseconds,
                 )
                 // Manual and Polling are stream-less modes; only realtime modes
                 // open a watch stream. Mirrors JS SDK PR #1243.
@@ -1830,6 +1852,26 @@ public class Client(
          * The default value is `3000`(ms). Mirrors JS SDK PR #1243.
          */
         public val documentPollInterval: Duration = 3_000.milliseconds,
+        /**
+         * `watchFallbackDelay` is how long a realtime document's watch stream may stay
+         * silent (no frame of any kind received) before that attachment starts pulling
+         * on every sync-loop tick (throttled to [documentPollInterval]) as if it were
+         * `Polling` — i.e. degrades toward polling semantics per-attachment until a
+         * watch frame arrives again. This bounds staleness instead of the permanent
+         * pull starvation a silently-dead watch stream otherwise causes (a dead watch
+         * stream never flips `changeEventReceived`, so pull would never re-engage on
+         * its own — see #351).
+         *
+         * Default is `10000`(ms), ON: healthy realtime streams deliver far more often
+         * than every 10s, so this default avoids false engagement on a healthy-but-quiet
+         * stream while bounding staleness to roughly `watchFallbackDelay +
+         * documentPollInterval`; 10s is also comfortably under the server's 15s
+         * ChannelSessionTTL, keeping recovery within a single session lifetime.
+         *
+         * Set to `Duration.INFINITE` to disable fallback entirely (a silent watch
+         * stream then starves pull forever, matching pre-fallback behavior).
+         */
+        public val watchFallbackDelay: Duration = 10_000.milliseconds,
     ) {
         @Deprecated(
             "Renamed to channelHeartbeatInterval",

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -793,7 +793,12 @@ public class Client(
         if (document.getStatus() == ResourceStatus.Attached && status.value is Status.Activated) {
             document.publishEvent(Initialized(document.presences.value))
             document.setOnlineClients(emptySet())
-            document.publishEvent(StreamConnectionChanged.Disconnected)
+            // Fire-and-forget: this runs on the watch reader coroutine for every
+            // stream failure/close/timeout. An inline publishEvent here is an
+            // unbuffered-flow emit that a stalled events collector can park
+            // forever, wedging the reader so streamJob.join() never returns and
+            // the watch loop never reconnects (#351 follow-up).
+            document.publish(StreamConnectionChanged.Disconnected)
         }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -121,7 +121,14 @@ public class Document(
 
     private var presenceDropWarned = false
 
-    private val eventStream = MutableSharedFlow<Event>()
+    // Buffered so emitters (notably applyChangePack, which the Client sync loop calls
+    // while holding the per-document mutex, and the watch-stream reader) are not
+    // rendezvous-coupled to every collector: with zero capacity a single stalled
+    // collector suspends emit() forever, freezing sync push+pull and watch reconnect
+    // while the client still reports itself Connected (#351 follow-up). SUSPEND on
+    // overflow is kept deliberately — events must not be silently dropped; the buffer
+    // only decouples transient consumer latency from the document's critical sections.
+    private val eventStream = MutableSharedFlow<Event>(extraBufferCapacity = 4096)
     public val events = eventStream.asSharedFlow()
 
     @Volatile

--- a/yorkie/src/test/kotlin/dev/yorkie/core/AttachmentTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/AttachmentTest.kt
@@ -1,0 +1,310 @@
+package dev.yorkie.core
+
+import dev.yorkie.document.Document
+import io.mockk.every
+import io.mockk.spyk
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Job
+import org.junit.After
+import org.junit.Test
+
+/**
+ * Exercises [Attachment]'s watch-liveness / pull-fallback decision (#351 phase 1) against a
+ * FAKE clock rather than real delays: the client's sync loop runs on a real, non-virtualizable
+ * dispatcher (`createSingleThreadDispatcher`), so `runTest`'s virtual time cannot drive it and
+ * `needSync` reads wall-clock time directly. Injecting `nowProvider` makes the decision itself
+ * deterministic and fast, with no coroutines involved at all — see the exec-plan's "Design
+ * decision" section.
+ */
+class AttachmentTest {
+
+    private var now = 0L
+    private val documents = mutableListOf<Document>()
+
+    @After
+    fun tearDown() {
+        documents.forEach { it.close() }
+    }
+
+    /**
+     * A real [Document] resource (not a bare mock — [Attachable] is an interface but
+     * `resource is Document` is checked by [Attachment.needSync] itself, so a mock typed as
+     * [Document] via [spyk] is what the production `resource is Document` check needs),
+     * spied only to stub [Document.hasLocalChanges] (a real, unattached `Document` always has
+     * local changes from its own initial empty-root commit, which would make every
+     * `needRealTimeSync()`-driven assertion trivially true).
+     */
+    private fun documentResource(): Document {
+        val document = spyk(Document(TEST_DOCUMENT_KEY))
+        every { document.hasLocalChanges() } returns false
+        documents += document
+        return document
+    }
+
+    private fun attachment(
+        syncMode: Client.SyncMode? = Client.SyncMode.Polling,
+        watchFallbackDelay: Long = Long.MAX_VALUE,
+        resource: Document = documentResource(),
+    ) = Attachment(
+        resource = resource,
+        syncMode = syncMode,
+        nowProvider = { now },
+        watchFallbackDelay = watchFallbackDelay,
+    )
+
+    /**
+     * Opens a fake watch stream on [this] attachment — [Attachment.watchStreamSilent] (via
+     * [Attachment.needSync]) treats a null [Attachment.watchJobHolder] as "no watch stream is
+     * even supposed to be live," which must never engage fallback regardless of silence.
+     * The [Job] itself is never started; only its presence (non-null holder) matters here.
+     */
+    private fun Attachment<Document>.withOpenWatchStream() = apply {
+        watchJobHolder = WatchJobHolder(resource.getKey(), Job())
+    }
+
+    /** A realtime attachment with an open watch stream — the only shape fallback ever applies to. */
+    private fun realtimeAttachment(watchFallbackDelay: Long = 1_000L) =
+        attachment(syncMode = Client.SyncMode.Realtime, watchFallbackDelay = watchFallbackDelay)
+            .withOpenWatchStream()
+
+    // ========== Y1: injectable clock drives needSync's Polling branch deterministically ==========
+
+    @Test
+    fun `needSync Polling branch is false before documentPollInterval elapses`() {
+        val target = attachment(syncMode = Client.SyncMode.Polling)
+        now = 1_000L
+        target.updateHeartbeatTime()
+
+        now = 1_999L // 999ms elapsed, poll interval 1_000ms
+        assertFalse(target.needSync(heartbeatInterval = 1_000L, documentPollInterval = 1_000L))
+    }
+
+    @Test
+    fun `needSync Polling branch is true once documentPollInterval elapses`() {
+        val target = attachment(syncMode = Client.SyncMode.Polling)
+        now = 1_000L
+        target.updateHeartbeatTime()
+
+        now = 2_000L // exactly 1_000ms elapsed
+        assertTrue(target.needSync(heartbeatInterval = 1_000L, documentPollInterval = 1_000L))
+    }
+
+    @Test
+    fun `updateHeartbeatTime resets the fake clock baseline used by needSync`() {
+        val target = attachment(syncMode = Client.SyncMode.Polling)
+        now = 5_000L
+        target.updateHeartbeatTime()
+
+        now = 5_500L
+        assertFalse(target.needSync(heartbeatInterval = 1_000L, documentPollInterval = 1_000L))
+
+        // A second updateHeartbeatTime() moves the baseline forward again, so the SAME
+        // elapsed-time-since-first-call no longer trips needSync.
+        target.updateHeartbeatTime()
+        now = 6_000L
+        assertFalse(target.needSync(heartbeatInterval = 1_000L, documentPollInterval = 1_000L))
+    }
+
+    // ========== Y1: markWatchResponseReceived resets the liveness clock ==========
+
+    @Test
+    fun `lastWatchResponseTime is seeded to the fake now at construction`() {
+        now = 500L
+        val target = attachment()
+        assertEquals(500L, target.lastWatchResponseTime)
+    }
+
+    @Test
+    fun `markWatchResponseReceived advances lastWatchResponseTime to the fake now`() {
+        now = 500L
+        val target = attachment()
+
+        now = 1_500L
+        target.markWatchResponseReceived()
+        assertEquals(1_500L, target.lastWatchResponseTime)
+    }
+
+    @Test
+    fun `markWatchResponseReceived does not engage fallback when not previously engaged`() {
+        val target = attachment()
+        target.markWatchResponseReceived()
+        assertFalse(target.watchFallbackEngaged)
+    }
+
+    // ========== Y3: fallback decision (AC1-AC3), throttle, transition logging (#351 phase 1) ==========
+
+    @Test
+    fun `AC1 - fallback engages once the watch stream has been silent past the threshold`() {
+        now = 0L
+        val target = realtimeAttachment(watchFallbackDelay = 1_000L)
+        target.updateHeartbeatTime() // poll-interval throttle baseline
+
+        now = 1_000L // silence threshold (1_000ms) AND poll interval (500ms) both crossed
+        assertTrue(target.needSync(heartbeatInterval = 5_000L, documentPollInterval = 500L))
+        assertTrue(target.watchFallbackEngaged)
+    }
+
+    @Test
+    fun `AC2 - fallback disengages once a watch frame is received`() {
+        now = 0L
+        val target = realtimeAttachment(watchFallbackDelay = 1_000L)
+        target.updateHeartbeatTime()
+        now = 1_000L
+        assertTrue(target.needSync(heartbeatInterval = 5_000L, documentPollInterval = 500L))
+        assertTrue(target.watchFallbackEngaged)
+
+        // A watch frame arrives (stream revives): resets the silence clock and disengages.
+        target.markWatchResponseReceived()
+        assertFalse(target.watchFallbackEngaged)
+
+        // A tick before the threshold would elapse again from this new baseline: no re-engage.
+        now = 1_999L
+        assertFalse(target.needSync(heartbeatInterval = 5_000L, documentPollInterval = 500L))
+        assertFalse(target.watchFallbackEngaged)
+    }
+
+    @Test
+    fun `AC3 - fallback never engages while watch frames keep arriving under the threshold`() {
+        now = 0L
+        val target = realtimeAttachment(watchFallbackDelay = 1_000L)
+        target.updateHeartbeatTime()
+
+        // Simulated frames every 400ms, well under the 1_000ms threshold, across many ticks.
+        repeat(20) {
+            now += 400L
+            target.markWatchResponseReceived()
+            assertFalse(target.needSync(heartbeatInterval = 5_000L, documentPollInterval = 500L))
+            assertFalse(target.watchFallbackEngaged)
+        }
+    }
+
+    @Test
+    fun `throttle - second tick within pollInterval of last sync does not re-fire`() {
+        now = 0L
+        val target = realtimeAttachment(watchFallbackDelay = 1_000L)
+        target.updateHeartbeatTime()
+
+        now = 1_000L
+        assertTrue(target.needSync(heartbeatInterval = 5_000L, documentPollInterval = 500L))
+        // Simulates Client.syncInternal's broadened updateHeartbeatTime() reset after the
+        // fallback-triggered sync actually runs.
+        target.updateHeartbeatTime()
+
+        // Still past the silence threshold (watch stream never revived), but well under
+        // documentPollInterval (500ms) since the just-simulated sync — must not fire again,
+        // else every 50ms sync-loop tick would pull: the AC7 storm this throttle exists for.
+        now = 1_100L
+        assertFalse(target.needSync(heartbeatInterval = 5_000L, documentPollInterval = 500L))
+    }
+
+    @Test
+    fun `throttle - fires again once documentPollInterval elapses since the last fallback sync`() {
+        now = 0L
+        val target = realtimeAttachment(watchFallbackDelay = 1_000L)
+        target.updateHeartbeatTime()
+
+        now = 1_000L
+        assertTrue(target.needSync(heartbeatInterval = 5_000L, documentPollInterval = 500L))
+        target.updateHeartbeatTime()
+
+        now = 1_500L // exactly documentPollInterval later
+        assertTrue(target.needSync(heartbeatInterval = 5_000L, documentPollInterval = 500L))
+    }
+
+    @Test
+    fun `boundary - a watch frame at T-epsilon resets the silence clock`() {
+        now = 0L
+        val target = realtimeAttachment(watchFallbackDelay = 1_000L)
+        target.updateHeartbeatTime()
+
+        now = 999L // one ms before the threshold
+        target.markWatchResponseReceived()
+
+        now = 1_000L // would have crossed the ORIGINAL threshold, but the clock just reset
+        assertFalse(target.needSync(heartbeatInterval = 5_000L, documentPollInterval = 500L))
+    }
+
+    @Test
+    fun `guard - no open watch stream never engages fallback`() {
+        now = 0L
+        val target = attachment(syncMode = Client.SyncMode.Realtime, watchFallbackDelay = 1_000L)
+        // Deliberately no withOpenWatchStream(): watchJobHolder stays null.
+        target.updateHeartbeatTime()
+
+        now = 10_000L // far past any threshold
+        assertFalse(target.needSync(heartbeatInterval = 5_000L, documentPollInterval = 500L))
+        assertFalse(target.watchFallbackEngaged)
+    }
+
+    @Test
+    fun `guard - RealtimePushOnly never engages fallback`() {
+        now = 0L
+        val target = attachment(
+            syncMode = Client.SyncMode.RealtimePushOnly,
+            watchFallbackDelay = 1_000L,
+        )
+            .withOpenWatchStream()
+        target.updateHeartbeatTime()
+
+        now = 10_000L
+        assertFalse(target.needSync(heartbeatInterval = 5_000L, documentPollInterval = 500L))
+        assertFalse(target.watchFallbackEngaged)
+    }
+
+    @Test
+    fun `guard - RealtimeSyncOff never engages fallback`() {
+        now = 0L
+        val target = attachment(
+            syncMode = Client.SyncMode.RealtimeSyncOff,
+            watchFallbackDelay = 1_000L,
+        )
+            .withOpenWatchStream()
+        target.updateHeartbeatTime()
+
+        now = 10_000L
+        assertFalse(target.needSync(heartbeatInterval = 5_000L, documentPollInterval = 500L))
+        assertFalse(target.watchFallbackEngaged)
+    }
+
+    @Test
+    fun `guard - Manual never engages fallback`() {
+        now = 0L
+        val target = attachment(syncMode = Client.SyncMode.Manual, watchFallbackDelay = 1_000L)
+            .withOpenWatchStream()
+        target.updateHeartbeatTime()
+
+        now = 10_000L
+        assertFalse(target.needSync(heartbeatInterval = 5_000L, documentPollInterval = 500L))
+        assertFalse(target.watchFallbackEngaged)
+    }
+
+    @Test
+    fun `guard - Polling never engages fallback`() {
+        now = 0L
+        val target = attachment(syncMode = Client.SyncMode.Polling, watchFallbackDelay = 1_000L)
+            .withOpenWatchStream()
+        target.updateHeartbeatTime()
+
+        now = 10_000L
+        // needSync is true here, but via Polling's OWN branch, not fallback.
+        assertTrue(target.needSync(heartbeatInterval = 5_000L, documentPollInterval = 500L))
+        assertFalse(target.watchFallbackEngaged)
+    }
+
+    @Test
+    fun `guard - watchFallbackDelay of Long MAX_VALUE (INFINITE) disables fallback entirely`() {
+        now = 0L
+        val target = realtimeAttachment(watchFallbackDelay = Long.MAX_VALUE)
+        target.updateHeartbeatTime()
+
+        now = Long.MAX_VALUE / 2 // arbitrarily far in the future
+        assertFalse(target.needSync(heartbeatInterval = 5_000L, documentPollInterval = 500L))
+        assertFalse(target.watchFallbackEngaged)
+    }
+
+    private companion object {
+        const val TEST_DOCUMENT_KEY = "attachment-test-doc"
+    }
+}

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -24,6 +24,7 @@ import dev.yorkie.core.MockYorkieService.Companion.EPOCH_MISMATCH_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.MOCK_SESSION_ID
 import dev.yorkie.core.MockYorkieService.Companion.NORMAL_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.REMOVE_ERROR_DOCUMENT_KEY
+import dev.yorkie.core.MockYorkieService.Companion.SILENT_WATCH_DOCUMENT_KEY
 import dev.yorkie.core.MockYorkieService.Companion.TEST_ACTOR_ID
 import dev.yorkie.core.MockYorkieService.Companion.TEST_KEY
 import dev.yorkie.core.MockYorkieService.Companion.TEST_USER_ID
@@ -136,6 +137,32 @@ class ClientTest {
         assertFalse(target.isActive)
         assertIs<Client.Status.Deactivated>(target.status.value)
     }
+
+    // ========== Y2: Options.watchFallbackDelay (pull fallback on watch silence, #351) ==========
+
+    @Test
+    fun `watchFallbackDelay default is 10 seconds`() {
+        assertEquals(10_000.milliseconds, Client.Options().watchFallbackDelay)
+    }
+
+    @Test
+    fun `document attached with default options carries the watchFallbackDelay threshold`() =
+        runTest {
+            runBlocking {
+                val document = Document(NORMAL_DOCUMENT_KEY)
+                target.activateAsync().await()
+                target.attachDocument(document).await()
+
+                assertEquals(
+                    10_000.milliseconds.inWholeMilliseconds,
+                    target.attachmentWatchFallbackDelay(NORMAL_DOCUMENT_KEY),
+                )
+
+                target.detachDocument(document).await()
+                target.deactivateAsync().await()
+                document.close()
+            }
+        }
 
     @Test
     fun `should keep client active when deactivate fails with connect exception`() = runTest {
@@ -401,6 +428,53 @@ class ClientTest {
         target.detachDocument(document).await()
         target.deactivateAsync().await()
     }
+
+    // ========== Y4: Client liveness wiring (pull fallback engage, #351 phase 1) ==========
+    //
+    // Loop-level, real-delay integration test reinforcing that markWatchResponseReceived()'s
+    // wiring at the two Client.kt call sites actually produces real fallback pulls end-to-end —
+    // the disengage-on-revival decision itself (AC2) is already conclusively proven by
+    // AttachmentTest's fake-clock unit tests; this test focuses on the engage side, the part
+    // only a real Client + real sync loop can exercise. Short custom Options keep it fast; a
+    // separate Client (not the class-level `target`) is used so the class-level tests' default
+    // (slow) watchFallbackDelay is untouched.
+
+    @Test
+    fun `Y4 - pull fallback produces real pushPullChanges calls once watch stream goes silent`() =
+        runTest {
+            runBlocking {
+                val fallbackClient = Client(
+                    host = "0.0.0.0",
+                    options = Client.Options(
+                        key = TEST_KEY,
+                        apiKey = TEST_KEY,
+                        syncLoopDuration = 50.milliseconds,
+                        documentPollInterval = 100.milliseconds,
+                        watchFallbackDelay = 200.milliseconds,
+                    ),
+                )
+                fallbackClient.service = service
+                val document = Document(SILENT_WATCH_DOCUMENT_KEY)
+
+                fallbackClient.activateAsync().await()
+                fallbackClient.attachDocument(document).await() // syncMode defaults to Realtime
+
+                // SILENT_WATCH_DOCUMENT_KEY's watch stream sends only its init frame, then
+                // never another — past watchFallbackDelay + documentPollInterval, fallback
+                // must start pulling on its own, repeatedly, without any local edit or
+                // DOCUMENT_CHANGED event ever arriving.
+                delay(600)
+
+                coVerify(atLeast = 2) {
+                    service.pushPullChanges(any(), any())
+                }
+
+                fallbackClient.detachDocument(document).await()
+                fallbackClient.deactivateAsync().await()
+                fallbackClient.close()
+                document.close()
+            }
+        }
 
     @Test
     fun `should emit according event when watch stream fails`() = runTest {
@@ -1169,6 +1243,23 @@ class ClientTest {
         val field = Client::class.java.getDeclaredField("_status")
         field.isAccessible = true
         (field.get(this) as MutableStateFlow<Client.Status>).value = status
+    }
+
+    /**
+     * Reads a resource's [Attachment] out of the client's private `attachments` map,
+     * then reads a private field off it — same reflection technique as [forceStatus] —
+     * so a test can confirm an `Options` value was actually plumbed through to the
+     * `Attachment` the client constructed, without exposing that field publicly.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun Client.attachmentWatchFallbackDelay(documentKey: String): Long {
+        val attachmentsField = Client::class.java.getDeclaredField("attachments")
+        attachmentsField.isAccessible = true
+        val attachments = attachmentsField.get(this) as Map<String, Attachment<out Attachable>>
+        val attachment = attachments.getValue(documentKey)
+        val delayField = Attachment::class.java.getDeclaredField("watchFallbackDelay")
+        delayField.isAccessible = true
+        return delayField.get(attachment) as Long
     }
 
     private fun assertIsInitialChangePack(initialChangePack: ChangePack, changePack: PBChangePack) {

--- a/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/MockYorkieService.kt
@@ -352,6 +352,13 @@ class MockYorkieService(
                     )
                     return
                 }
+                if (documentId == SILENT_WATCH_DOCUMENT_KEY) {
+                    // Init frame only, then silence forever (no error, no close, no more
+                    // frames) — simulates #351's half-open watch stream for the pull
+                    // fallback loop-level test, without waiting out NORMAL_DOCUMENT_KEY's
+                    // full CHANGED/WATCHED/UNWATCHED script first.
+                    return
+                }
                 responseChannel.trySend(
                     watchResponse {
                         event = watchEvent {
@@ -638,6 +645,7 @@ class MockYorkieService(
     companion object {
         internal const val TEST_KEY = "TEST"
         internal const val NORMAL_DOCUMENT_KEY = "NORMAL_DOCUMENT_KEY"
+        internal const val SILENT_WATCH_DOCUMENT_KEY = "SILENT_WATCH_DOCUMENT_KEY"
         internal const val WATCH_SYNC_ERROR_DOCUMENT_KEY = "WATCH_SYNC_ERROR_DOCUMENT_KEY"
         internal const val ATTACH_ERROR_DOCUMENT_KEY = "ATTACH_ERROR_DOCUMENT_KEY"
         internal const val DETACH_ERROR_DOCUMENT_KEY = "DETACH_ERROR_DOCUMENT_KEY"


### PR DESCRIPTION
## What this PR does / why we need it

Fixes two related ways a realtime client can silently stop syncing while still reporting itself Connected — both reproduced live on a two-emulator collaborative-editing rig (SE Zero editor + this SDK + yorkie server v0.7.12).

### 1. Pull starvation when the watch stream goes silent (#351, phase 1)

`Attachment.needSync()` gates PULL on `hasLocalChanges() || changeEventReceived`, and `changeEventReceived` is set only by watch events. A watch stream that dies silently (half-open: no error, no reconnect) therefore starves pull forever while push stays alive: the client keeps sending its edits and never receives peers' edits again until re-attach.

Fix: per-attachment watch-liveness tracking (`lastWatchResponseTime`) + a pull fallback in the realtime sync loop. When the stream has been silent past `Options.watchFallbackDelay` (default 10s, `Duration.INFINITE` disables), the attachment degrades toward Polling semantics — pull once per `documentPollInterval` — until a watch frame arrives again. Engage/disengage transitions are logged, so the previously invisible failure mode is now observable.

### 2. A stalled events collector freezes sync push+pull AND watch reconnect

`Document.eventStream` was a zero-capacity `MutableSharedFlow`: every emit rendezvouses with every collector. Two emit sites sit inside critical sections:

- `applyChangePack` emits `RemoteChange` inline while `Client.syncInternal` holds the per-document mutex → one stalled/slow collector parks the sync loop inside the lock forever: push, pull, and every future attach/detach/sync on that document die, with all threads idle (a pure coroutine deadlock — invisible to thread dumps) and zero log output.
- The watch failure path emitted `StreamConnectionChanged.Disconnected` inline on the reader coroutine → the same stall wedges stream teardown after `safeClose()`, `streamJob.join()` never returns, and the watch loop never reconnects (observed live as a single remaining TCP connection).

A consumer-side variant is fully deterministic: any collector that awaits `updateAsync()` inside its own `document.events` collect body self-deadlocks, because `updateAsync` emits `LocalChange` on the same flow before resolving its `Deferred`.

Fix: `eventStream` gets `extraBufferCapacity = 4096` (SUSPEND overflow kept — events are never dropped; emitters are only decoupled from transient collector latency), and the watch failure path publishes `Disconnected` fire-and-forget so stream teardown can never park the reader.

## Verification

- 542 unit tests green, including 18 new `AttachmentTest` cases driving the fallback decision with a fake clock and loop-level silent-watch tests in `ClientTest`.
- Live two-device validation: with an unfixed build, a repro rig (concurrent typing + forced stream cycling via network toggling + unfocused receiving editor) froze a device inside `applyChangePack` in round 1 — step-marker logging pinpointed the exact suspended statement (`rpc done` with no `applied`). The fixed build survived 12 consecutive rounds; the watch-silence fallback recovered a starved receiver in ~13s (fallback delay + poll interval) without relaunch, beating natural stream reconnection by 20–46s across three independent runs.
- Freeze mechanism additionally cross-verified by independent adversarial code review (the emit-under-mutex chain is the only unbounded suspension point reachable while the attachment mutex is held; RPCs are bounded by the 5-minute timeout oracle, and `publish(SyncStatusChanged)` was already fire-and-forget).

## Which issue(s) this PR fixes

Fixes #351 (phase 1 — bounded staleness instead of permanent divergence; phase 2, half-open stream detection so reconnect actually fires, is intentionally out of scope and can build on the liveness tracking added here).

## Special notes for reviewers

- `watchFallbackDelay` default of 10s was chosen to stay under the server's 15s `ChannelSessionTTL`, so a genuinely dead stream falls back before the server reclaims the session.
- The heartbeat-throttle reuse in `syncInternal` (resetting `lastHeartbeatTime` for Realtime as well as Polling) is what keeps the engaged fallback at one pull per `documentPollInterval` instead of one per 50ms sync-loop tick.
- A separate latent issue was found while investigating and is NOT addressed here: `attachDocument` on a document whose attach response reports `Removed` returns SUCCESS without registering an attachment (a silent zombie client). Happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
