### PR TITLE
Support initialRoot, TreeEdit history convergence, and skipHistory updates

### DIFF
--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/InitialRootTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/InitialRootTest.kt
@@ -80,7 +80,7 @@ class InitialRootTest {
             c2.syncAsync(d2).await()
             assertFalse(d1.history.canUndo())
             assertTrue(d1.history.canRedo())
-            assertEquals(null, d2.getRoot().getOrNull("edit"))
+            assertFalse("edit" in d2.getRoot().keys)
 
             d1.history.redoAsync().await()
             c1.syncAsync(d1).await()

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/InitialRootTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/InitialRootTest.kt
@@ -22,7 +22,7 @@ class InitialRootTest {
     val retryRule = RetryRule(retryCount = 2)
 
     @Test
-    fun `initial tree syncs without replacement and remains outside undo history`() {
+    fun initialTreeSyncsWithoutReplacementAndRemainsOutsideUndoHistory() {
         withTwoClientsAndDocuments(
             attachDocuments = false,
             detachDocuments = false,
@@ -93,7 +93,7 @@ class InitialRootTest {
     }
 
     @Test
-    fun `simultaneous initial roots converge through normal synchronization`() {
+    fun simultaneousInitialRootsConvergeThroughNormalSynchronization() {
         withTwoClientsAndDocuments(
             attachDocuments = false,
             detachDocuments = false,

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/core/InitialRootTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/core/InitialRootTest.kt
@@ -1,0 +1,129 @@
+package dev.yorkie.core
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.yorkie.core.Client.SyncMode.Manual
+import dev.yorkie.document.json.JsonPrimitive
+import dev.yorkie.document.json.JsonTree
+import dev.yorkie.document.json.TreeBuilder.element
+import dev.yorkie.document.json.TreeBuilder.text
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class InitialRootTest {
+
+    @get:Rule
+    val retryRule = RetryRule(retryCount = 2)
+
+    @Test
+    fun `initial tree syncs without replacement and remains outside undo history`() {
+        withTwoClientsAndDocuments(
+            attachDocuments = false,
+            detachDocuments = false,
+            syncMode = Manual,
+        ) { c1, c2, d1, d2, _ ->
+            c1.attachDocument(
+                document = d1,
+                syncMode = Manual,
+                initialRoot = mapOf(
+                    "tree" to { key ->
+                        setNewTree(
+                            key,
+                            element("doc") {
+                                element("p") { text { "initial" } }
+                            },
+                        )
+                    },
+                ),
+            ).await()
+            assertFalse(d1.history.canUndo())
+            c1.syncAsync(d1).await()
+
+            var replacementCalled = false
+            c2.attachDocument(
+                document = d2,
+                syncMode = Manual,
+                initialRoot = mapOf(
+                    "tree" to { key ->
+                        replacementCalled = true
+                        setNewTree(key, element("replacement"))
+                    },
+                ),
+            ).await()
+
+            assertFalse(replacementCalled)
+            assertEquals(
+                "<doc><p>initial</p></doc>",
+                d2.getRoot().getAs<JsonTree>("tree").toXml(),
+            )
+
+            d1.updateAsync { root, _ ->
+                root["edit"] = "value"
+            }.await()
+            assertTrue(d1.history.canUndo())
+            c1.syncAsync(d1).await()
+            c2.syncAsync(d2).await()
+            assertEquals("value", d2.getRoot().getAs<JsonPrimitive>("edit").value)
+
+            d1.history.undoAsync().await()
+            assertEquals(
+                "<doc><p>initial</p></doc>",
+                d1.getRoot().getAs<JsonTree>("tree").toXml(),
+            )
+            c1.syncAsync(d1).await()
+            c2.syncAsync(d2).await()
+            assertFalse(d1.history.canUndo())
+            assertTrue(d1.history.canRedo())
+            assertEquals(null, d2.getRoot().getOrNull("edit"))
+
+            d1.history.redoAsync().await()
+            c1.syncAsync(d1).await()
+            c2.syncAsync(d2).await()
+            assertEquals("value", d2.getRoot().getAs<JsonPrimitive>("edit").value)
+
+            c1.detachDocument(d1).await()
+            c2.detachDocument(d2).await()
+        }
+    }
+
+    @Test
+    fun `simultaneous initial roots converge through normal synchronization`() {
+        withTwoClientsAndDocuments(
+            attachDocuments = false,
+            detachDocuments = false,
+            syncMode = Manual,
+        ) { c1, c2, d1, d2, _ ->
+            listOf(
+                async {
+                    c1.attachDocument(
+                        document = d1,
+                        syncMode = Manual,
+                        initialRoot = mapOf("value" to { key -> this[key] = "one" }),
+                    ).await()
+                },
+                async {
+                    c2.attachDocument(
+                        document = d2,
+                        syncMode = Manual,
+                        initialRoot = mapOf("value" to { key -> this[key] = "two" }),
+                    ).await()
+                },
+            ).awaitAll().forEach { assertTrue(it.isSuccess) }
+
+            c1.syncAsync(d1).await()
+            c2.syncAsync(d2).await()
+            c1.syncAsync(d1).await()
+
+            assertEquals(d1.toJson(), d2.toJson())
+
+            c1.detachDocument(d1).await()
+            c2.detachDocument(d2).await()
+        }
+    }
+}

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/SkipHistoryTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/SkipHistoryTest.kt
@@ -1,0 +1,35 @@
+package dev.yorkie.document
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.yorkie.assertJsonContentEquals
+import dev.yorkie.core.Client.SyncMode.Manual
+import dev.yorkie.core.withTwoClientsAndDocuments
+import kotlin.test.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Covers AC4: a `skipHistory = true` mutation syncs to a peer and both
+ * replicas converge identically to an ordinary update.
+ */
+@RunWith(AndroidJUnit4::class)
+class SkipHistoryTest {
+
+    @Test
+    fun skip_history_update_converges_to_peer_like_an_ordinary_update() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            d1.updateAsync(skipHistory = true) { root, _ ->
+                root["k1"] = "bookkeeping"
+            }.await()
+
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+
+            assertJsonContentEquals("""{"k1":"bookkeeping"}""", d1.toJson())
+            assertJsonContentEquals("""{"k1":"bookkeeping"}""", d2.toJson())
+
+            // The skipHistory write left no undo entry on the originating client.
+            assertFalse(d1.history.canUndo())
+        }
+    }
+}

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/SkipHistoryTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/SkipHistoryTest.kt
@@ -4,13 +4,23 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import dev.yorkie.assertJsonContentEquals
 import dev.yorkie.core.Client.SyncMode.Manual
 import dev.yorkie.core.withTwoClientsAndDocuments
+import dev.yorkie.document.json.JsonTree
+import dev.yorkie.document.json.TreeBuilder.element
+import dev.yorkie.document.json.TreeBuilder.text
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
  * Covers AC4: a `skipHistory = true` mutation syncs to a peer and both
- * replicas converge identically to an ordinary update.
+ * replicas converge identically to an ordinary update. Also covers the
+ * spec 009 C9 convergence probes for the spec 008 single-replica
+ * skipHistory/undo expectations: a pending tree undo entry reconciled
+ * across a skipHistory index shift (F2), and a skipHistory overwrite of
+ * an ordinary key that undoes as a no-op and redoes by LWW (F11) — both
+ * asserted equal on both replicas after undo, after redo, and after
+ * bidirectional sync.
  */
 @RunWith(AndroidJUnit4::class)
 class SkipHistoryTest {
@@ -30,6 +40,89 @@ class SkipHistoryTest {
 
             // The skipHistory write left no undo entry on the originating client.
             assertFalse(d1.history.canUndo())
+        }
+    }
+
+    @Test
+    fun skip_history_tree_index_shift_undo_redo_converges_on_both_replicas() {
+        // F2 case (single-replica pin: DocumentSkipHistoryTest."skipHistory reconciles a
+        // pending tree undo entry across index shift"): c1's ordinary insert leaves a
+        // pending undo entry; c1's skipHistory insert shifts its index range; undo/redo
+        // on c1 must reconcile identically once synced to c2.
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree("tree", element("root") { element("p") {} })
+            }.await()
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").edit(1, 1, text { "A" })
+            }.await()
+            assertEquals("<root><p>A</p></root>", d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.updateAsync(skipHistory = true) { root, _ ->
+                root.getAs<JsonTree>("tree").edit(1, 1, text { "X" })
+            }.await()
+            assertEquals("<root><p>XA</p></root>", d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+            assertEquals(
+                d1.getRoot().getAs<JsonTree>("tree").toXml(),
+                d2.getRoot().getAs<JsonTree>("tree").toXml(),
+            )
+            assertEquals("<root><p>XA</p></root>", d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.undoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+            assertEquals(
+                d1.getRoot().getAs<JsonTree>("tree").toXml(),
+                d2.getRoot().getAs<JsonTree>("tree").toXml(),
+            )
+            assertEquals("<root><p>X</p></root>", d1.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.redoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+            assertEquals(
+                d1.getRoot().getAs<JsonTree>("tree").toXml(),
+                d2.getRoot().getAs<JsonTree>("tree").toXml(),
+            )
+            assertEquals("<root><p>XA</p></root>", d1.getRoot().getAs<JsonTree>("tree").toXml())
+        }
+    }
+
+    @Test
+    fun skip_history_same_key_overwrite_undo_noop_redo_lww_converges() {
+        // F11 case (single-replica pin: DocumentSkipHistoryTest."skipHistory overwrite of
+        // an ordinary key undoes as a no-op and redoes by LWW"): c1's skipHistory write
+        // overwrites an ordinary key; undo is a no-op (the reverse op targets an
+        // already-superseded element); redo resurrects the original value by LWW with a
+        // freshly issued ticket. Both must converge once synced to c2.
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            d1.updateAsync { root, _ ->
+                root["k"] = "1"
+            }.await()
+
+            d1.updateAsync(skipHistory = true) { root, _ ->
+                root["k"] = "bookkeeping"
+            }.await()
+
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+            assertJsonContentEquals("""{"k":"bookkeeping"}""", d1.toJson())
+            assertJsonContentEquals("""{"k":"bookkeeping"}""", d2.toJson())
+
+            d1.history.undoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+            assertJsonContentEquals("""{"k":"bookkeeping"}""", d1.toJson())
+            assertJsonContentEquals("""{"k":"bookkeeping"}""", d2.toJson())
+
+            d1.history.redoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+            assertJsonContentEquals("""{"k":"1"}""", d1.toJson())
+            assertJsonContentEquals("""{"k":"1"}""", d2.toJson())
         }
     }
 }

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/UndoRedoTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/UndoRedoTest.kt
@@ -233,7 +233,7 @@ class UndoRedoTest {
     }
 
     @Test
-    fun `tree undo and redo converge after a concurrent append`() {
+    fun test_tree_undo_and_redo_converge_after_a_concurrent_append() {
         withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
             d1.updateAsync { root, _ ->
                 root.setNewTree("tree", element("root") { element("p") {} })
@@ -281,7 +281,7 @@ class UndoRedoTest {
     }
 
     @Test
-    fun `tree undo consumes a change whose target vanished remotely`() {
+    fun test_tree_undo_consumes_a_change_whose_target_vanished_remotely() {
         withTwoClientsAndDocuments(
             attachDocuments = false,
             syncMode = Manual,

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/UndoRedoTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/UndoRedoTest.kt
@@ -5,6 +5,7 @@ import dev.yorkie.core.Client.SyncMode.Manual
 import dev.yorkie.core.withTwoClientsAndDocuments
 import dev.yorkie.document.json.JsonCounter
 import dev.yorkie.document.json.JsonPrimitive
+import dev.yorkie.document.json.JsonText
 import dev.yorkie.document.json.JsonTree
 import dev.yorkie.document.json.TreeBuilder.element
 import dev.yorkie.document.json.TreeBuilder.text
@@ -277,6 +278,41 @@ class UndoRedoTest {
             // Remote history changes stay outside B's history; B still undoes its own append.
             d2.history.undoAsync().await()
             assertEquals("<root><p>123</p></root>", d2.getRoot().getAs<JsonTree>("tree").toXml())
+        }
+    }
+
+    @Test
+    fun test_text_undo_and_redo_converge_after_a_concurrent_overlapping_edit() {
+        // F10 scenario 2: c1 edits and holds the undo; c2 commits a remote edit
+        // overlapping the END of c1's pending undo range; c1 undoes — both replicas
+        // must converge (the reconciled local range must equal the serialized wire
+        // range, or the two replicas diverge).
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewText("text").edit(0, 0, "abcde")
+            }.await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+
+            // c1 makes an edit to be undone later: delete [1,4) -> "ae".
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonText>("text").edit(1, 4, "")
+            }.await()
+
+            // c2 concurrently replaces [3,5) — overlaps the END of c1's pending undo range.
+            d2.updateAsync { root, _ ->
+                root.getAs<JsonText>("text").edit(3, 5, "Z")
+            }.await()
+            c2.syncAsync().await()
+            c1.syncAsync().await()
+
+            d1.history.undoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+
+            val text1 = d1.getRoot().getAs<JsonText>("text").toString()
+            val text2 = d2.getRoot().getAs<JsonText>("text").toString()
+            assertEquals(text1, text2)
         }
     }
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/UndoRedoTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/UndoRedoTest.kt
@@ -5,6 +5,9 @@ import dev.yorkie.core.Client.SyncMode.Manual
 import dev.yorkie.core.withTwoClientsAndDocuments
 import dev.yorkie.document.json.JsonCounter
 import dev.yorkie.document.json.JsonPrimitive
+import dev.yorkie.document.json.JsonTree
+import dev.yorkie.document.json.TreeBuilder.element
+import dev.yorkie.document.json.TreeBuilder.text
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -226,6 +229,98 @@ class UndoRedoTest {
             // Both should see the original value
             assertEquals("original", d1.getRoot().getAs<JsonPrimitive>("k1").value)
             assertEquals("original", d2.getRoot().getAs<JsonPrimitive>("k1").value)
+        }
+    }
+
+    @Test
+    fun `tree undo and redo converge after a concurrent append`() {
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
+            d1.updateAsync { root, _ ->
+                root.setNewTree("tree", element("root") { element("p") {} })
+            }.await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+
+            listOf("1", "2", "3").forEachIndexed { index, value ->
+                d1.updateAsync { root, _ ->
+                    root.getAs<JsonTree>("tree").edit(index + 1, index + 1, text { value })
+                }.await()
+            }
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+            assertFalse(d2.history.canUndo())
+
+            d2.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").edit(4, 4, text { " 456" })
+            }.await()
+            c2.syncAsync().await()
+            c1.syncAsync().await()
+
+            d1.history.undoAsync().await()
+            assertEquals("<root><p>12 456</p></root>", d1.getRoot().getAs<JsonTree>("tree").toXml())
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+            assertEquals("<root><p>12 456</p></root>", d2.getRoot().getAs<JsonTree>("tree").toXml())
+
+            d1.history.redoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+            assertEquals(
+                "<root><p>123 456</p></root>",
+                d1.getRoot().getAs<JsonTree>("tree").toXml(),
+            )
+            assertEquals(
+                "<root><p>123 456</p></root>",
+                d2.getRoot().getAs<JsonTree>("tree").toXml(),
+            )
+
+            // Remote history changes stay outside B's history; B still undoes its own append.
+            d2.history.undoAsync().await()
+            assertEquals("<root><p>123</p></root>", d2.getRoot().getAs<JsonTree>("tree").toXml())
+        }
+    }
+
+    @Test
+    fun `tree undo consumes a change whose target vanished remotely`() {
+        withTwoClientsAndDocuments(
+            attachDocuments = false,
+            syncMode = Manual,
+        ) { c1, c2, d1, d2, _ ->
+            c1.attachDocument(
+                document = d1,
+                syncMode = Manual,
+                initialRoot = mapOf(
+                    "tree" to { key ->
+                        setNewTree(
+                            key,
+                            element("root") { element("p") { text { "x" } } },
+                        )
+                    },
+                ),
+            ).await()
+            c2.attachDocument(d2, syncMode = Manual).await()
+            assertFalse(d1.history.canUndo())
+
+            d1.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").edit(2, 2, text { "y" })
+            }.await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
+
+            d2.updateAsync { root, _ ->
+                root.getAs<JsonTree>("tree").edit(2, 3)
+            }.await()
+            c2.syncAsync().await()
+            c1.syncAsync().await()
+            assertFalse(d1.hasLocalChanges())
+            assertTrue(d1.history.canUndo())
+
+            assertTrue(d1.history.undoAsync().await().isSuccess)
+
+            assertEquals("<root><p>x</p></root>", d1.getRoot().getAs<JsonTree>("tree").toXml())
+            assertFalse(d1.hasLocalChanges())
+            assertFalse(d1.history.canUndo())
+            assertFalse(d1.history.canRedo())
         }
     }
 }

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeUndoTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeUndoTest.kt
@@ -61,7 +61,7 @@ class JsonTreeUndoTest {
      */
     @Test
     fun test_undo_and_redo_text_delete() {
-        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
             d1.updateAsync { root, _ ->
                 root.setNewTree(
                     "tree",
@@ -71,26 +71,36 @@ class JsonTreeUndoTest {
                 )
             }.await()
             c1.syncAsync().await()
+            c2.syncAsync().await()
 
             d1.updateAsync { root, _ ->
                 root.getAs<JsonTree>("tree").edit(2, 4)
             }.await()
             c1.syncAsync().await()
+            c2.syncAsync().await()
             assertEquals(
                 "<root><p>hlo</p></root>",
                 d1.getRoot().getAs<JsonTree>("tree").toXml(),
             )
 
             d1.history.undoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
             assertEquals(
                 "<root><p>hello</p></root>",
                 d1.getRoot().getAs<JsonTree>("tree").toXml(),
             )
+            assertEquals(
+                "<root><p>hello</p></root>",
+                d2.getRoot().getAs<JsonTree>("tree").toXml(),
+            )
 
             d1.history.redoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
             assertEquals(
                 "<root><p>hlo</p></root>",
-                d1.getRoot().getAs<JsonTree>("tree").toXml(),
+                d2.getRoot().getAs<JsonTree>("tree").toXml(),
             )
         }
     }
@@ -100,7 +110,7 @@ class JsonTreeUndoTest {
      */
     @Test
     fun test_undo_and_redo_text_replace() {
-        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
             d1.updateAsync { root, _ ->
                 root.setNewTree(
                     "tree",
@@ -110,6 +120,7 @@ class JsonTreeUndoTest {
                 )
             }.await()
             c1.syncAsync().await()
+            c2.syncAsync().await()
 
             // edit(2, 4, "ELL") deletes [2, 4) = "el" and inserts "ELL",
             // producing "hELLlo".
@@ -117,21 +128,26 @@ class JsonTreeUndoTest {
                 root.getAs<JsonTree>("tree").edit(2, 4, text { "ELL" })
             }.await()
             c1.syncAsync().await()
+            c2.syncAsync().await()
             assertEquals(
                 "<root><p>hELLlo</p></root>",
                 d1.getRoot().getAs<JsonTree>("tree").toXml(),
             )
 
             d1.history.undoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
             assertEquals(
                 "<root><p>hello</p></root>",
-                d1.getRoot().getAs<JsonTree>("tree").toXml(),
+                d2.getRoot().getAs<JsonTree>("tree").toXml(),
             )
 
             d1.history.redoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
             assertEquals(
                 "<root><p>hELLlo</p></root>",
-                d1.getRoot().getAs<JsonTree>("tree").toXml(),
+                d2.getRoot().getAs<JsonTree>("tree").toXml(),
             )
         }
     }
@@ -708,7 +724,7 @@ class JsonTreeUndoTest {
     }
 
     private fun runSplitUndoRedoCase(splitIdx: Int, afterXml: String) {
-        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
             d1.updateAsync { root, _ ->
                 root.setNewTree(
                     "tree",
@@ -718,24 +734,32 @@ class JsonTreeUndoTest {
                 )
             }.await()
             c1.syncAsync().await()
+            c2.syncAsync().await()
             val before = d1.getRoot().getAs<JsonTree>("tree").toXml()
 
             d1.updateAsync { root, _ ->
                 root.getAs<JsonTree>("tree").edit(splitIdx, splitIdx, 1)
             }.await()
             c1.syncAsync().await()
+            c2.syncAsync().await()
             assertEquals(afterXml, d1.getRoot().getAs<JsonTree>("tree").toXml())
 
             d1.history.undoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
             assertEquals(before, d1.getRoot().getAs<JsonTree>("tree").toXml())
+            assertEquals(before, d2.getRoot().getAs<JsonTree>("tree").toXml())
 
             d1.history.redoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
             assertEquals(afterXml, d1.getRoot().getAs<JsonTree>("tree").toXml())
+            assertEquals(afterXml, d2.getRoot().getAs<JsonTree>("tree").toXml())
         }
     }
 
     private fun runL2SplitUndoRedoCase(splitIdx: Int, afterXml: String) {
-        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
             d1.updateAsync { root, _ ->
                 root.setNewTree(
                     "tree",
@@ -745,19 +769,27 @@ class JsonTreeUndoTest {
                 )
             }.await()
             c1.syncAsync().await()
+            c2.syncAsync().await()
             val before = d1.getRoot().getAs<JsonTree>("tree").toXml()
 
             d1.updateAsync { root, _ ->
                 root.getAs<JsonTree>("tree").edit(splitIdx, splitIdx, 2)
             }.await()
             c1.syncAsync().await()
+            c2.syncAsync().await()
             assertEquals(afterXml, d1.getRoot().getAs<JsonTree>("tree").toXml())
 
             d1.history.undoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
             assertEquals(before, d1.getRoot().getAs<JsonTree>("tree").toXml())
+            assertEquals(before, d2.getRoot().getAs<JsonTree>("tree").toXml())
 
             d1.history.redoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
             assertEquals(afterXml, d1.getRoot().getAs<JsonTree>("tree").toXml())
+            assertEquals(afterXml, d2.getRoot().getAs<JsonTree>("tree").toXml())
         }
     }
 
@@ -769,7 +801,7 @@ class JsonTreeUndoTest {
      */
     @Test
     fun test_undo_cross_boundary_merge_restores_siblings() {
-        withTwoClientsAndDocuments(syncMode = Manual) { c1, _, d1, _, _ ->
+        withTwoClientsAndDocuments(syncMode = Manual) { c1, c2, d1, d2, _ ->
             d1.updateAsync { root, _ ->
                 root.setNewTree(
                     "t",
@@ -780,6 +812,7 @@ class JsonTreeUndoTest {
                 )
             }.await()
             c1.syncAsync().await()
+            c2.syncAsync().await()
             val before = "<doc><p>AB</p><p>CD</p></doc>"
             assertEquals(before, d1.getRoot().getAs<JsonTree>("t").toXml())
 
@@ -787,14 +820,21 @@ class JsonTreeUndoTest {
                 root.getAs<JsonTree>("t").editByPath(listOf(0, 2), listOf(1, 0))
             }.await()
             c1.syncAsync().await()
+            c2.syncAsync().await()
             assertEquals("<doc><p>ABCD</p></doc>", d1.getRoot().getAs<JsonTree>("t").toXml())
 
             assertTrue(d1.history.canUndo())
             d1.history.undoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
             assertEquals(before, d1.getRoot().getAs<JsonTree>("t").toXml())
+            assertEquals(before, d2.getRoot().getAs<JsonTree>("t").toXml())
 
             d1.history.redoAsync().await()
+            c1.syncAsync().await()
+            c2.syncAsync().await()
             assertEquals("<doc><p>ABCD</p></doc>", d1.getRoot().getAs<JsonTree>("t").toXml())
+            assertEquals("<doc><p>ABCD</p></doc>", d2.getRoot().getAs<JsonTree>("t").toXml())
         }
     }
 

--- a/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeUndoTest.kt
+++ b/yorkie/src/androidTest/kotlin/dev/yorkie/document/json/JsonTreeUndoTest.kt
@@ -100,6 +100,10 @@ class JsonTreeUndoTest {
             c2.syncAsync().await()
             assertEquals(
                 "<root><p>hlo</p></root>",
+                d1.getRoot().getAs<JsonTree>("tree").toXml(),
+            )
+            assertEquals(
+                "<root><p>hlo</p></root>",
                 d2.getRoot().getAs<JsonTree>("tree").toXml(),
             )
         }
@@ -139,12 +143,20 @@ class JsonTreeUndoTest {
             c2.syncAsync().await()
             assertEquals(
                 "<root><p>hello</p></root>",
+                d1.getRoot().getAs<JsonTree>("tree").toXml(),
+            )
+            assertEquals(
+                "<root><p>hello</p></root>",
                 d2.getRoot().getAs<JsonTree>("tree").toXml(),
             )
 
             d1.history.redoAsync().await()
             c1.syncAsync().await()
             c2.syncAsync().await()
+            assertEquals(
+                "<root><p>hELLlo</p></root>",
+                d1.getRoot().getAs<JsonTree>("tree").toXml(),
+            )
             assertEquals(
                 "<root><p>hELLlo</p></root>",
                 d2.getRoot().getAs<JsonTree>("tree").toXml(),

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -116,9 +116,16 @@ import dev.yorkie.api.v1.ChannelEvent.Type as PbChannelEventType
  * Initializers for missing root keys when attaching a [Document].
  *
  * Each map key is authoritative: its initializer receives that key and is invoked only when the
- * server-provided root does not contain it. Initial values become ordinary Yorkie changes but are
- * removed from undo history before attachment completes. Concurrent first attachments may both
+ * server-provided root does not contain it. The absence guard checks only the mapped key itself —
+ * an initializer is expected to write only that key; writes to other keys are not guarded against
+ * and are not part of the documented contract. Initial values become ordinary Yorkie changes but
+ * are removed from undo history before attachment completes. Concurrent first attachments may both
  * initialize a missing key and converge through normal CRDT conflict resolution.
+ *
+ * The initializer stays a callback (`suspend JsonObject.(key: String) -> Unit`) rather than a
+ * plain value map because a value cannot express [JsonObject.setNewTree] or
+ * [JsonObject.setNewText] construction; Java consumers that need only primitive/object values can
+ * still use this shape by writing directly to the receiver inside the lambda.
  */
 public typealias InitialRoot = Map<String, suspend JsonObject.(key: String) -> Unit>
 
@@ -1053,10 +1060,22 @@ public class Client(
      * from undo history before the attached event. Concurrent first attachments are not globally
      * serialized; their ordinary CRDT changes converge through normal conflict resolution.
      *
+     * The document is marked [ResourceStatus.Attached] and registered with this client BEFORE the
+     * [initialRoot] initializers run, so a throwing initializer leaves the document attached and
+     * detachable rather than rolled back; the returned deferred still resolves to failure. Document
+     * events emitted by the initializer change are always preceded by the `Attached`
+     * [Document.Event.DocumentStatusChanged] event.
+     *
      * @param initialPresence The initial presence of the client.
      * @param syncMode The synchronization mode of the document.
      * @param schema The schema used to validate the document.
-     * @param disableGC Whether this attachment opts out of tombstone garbage collection.
+     * @param disableGC declares that this attachment will not produce or consume
+     * tombstones. The server skips minVV tracking and omits the response
+     * VersionVector for this client. Use only with Counter or primitive
+     * workloads where no client consumes tombstones; misuse on a document
+     * that uses Tree, Text, or Array deletions leads to undefined GC behavior
+     * on this client. Controls only the wire contract and is distinct from
+     * any local-only [Document] GC pass.
      * @param disablePresence Whether this attachment opts out of presence.
      * @param initialRoot Initializers for root keys absent from the authoritative server response.
      */
@@ -1134,30 +1153,14 @@ public class Client(
                 document.setDisablePresence(response.disablePresence)
                 document.applyChangePack(pack)
 
+                // JS SDK v0.7.16 ordering (packages/sdk/src/client/client.ts:665-793 @ 28a5a42e):
+                // Removed early-return (no clearHistory here — JS parity) → applyStatus(Attached)
+                // → attachment registration → runWatchLoop → initialRoot update → single
+                // unconditional clearHistory. On an initializer throw, the document stays
+                // Attached and registered (detachable), matching JS's no-rollback behavior.
                 if (document.getStatus() == ResourceStatus.Removed) {
-                    document.clearHistory()
                     return@async SUCCESS
                 }
-
-                val initialRootResult = try {
-                    document.updateAsync { root, _ ->
-                        initialRoot.forEach { (key, initializer) ->
-                            if (root.getOrNull(key) == null) {
-                                initializer(root, key)
-                            }
-                        }
-                    }.await()
-                } catch (t: Throwable) {
-                    ensureActive()
-                    Result.failure(t)
-                }
-                if (initialRootResult.isFailure) {
-                    return@async initialRootResult
-                }
-
-                // Clear undo/redo stacks so that initialRoot setup operations
-                // are not reachable via undo. Mirrors JS SDK PR #1238.
-                document.clearHistory()
 
                 document.applyStatus(ResourceStatus.Attached)
                 attachments[documentKey] = Attachment(
@@ -1173,6 +1176,26 @@ public class Client(
                 if (syncMode != SyncMode.Manual && syncMode != SyncMode.Polling) {
                     runWatchLoop(documentKey)
                 }
+
+                val initialRootResult = try {
+                    document.updateAsync { root, _ ->
+                        initialRoot.forEach { (key, initializer) ->
+                            if (key !in root.keys) {
+                                initializer(root, key)
+                            }
+                        }
+                    }.await()
+                } catch (t: Throwable) {
+                    ensureActive()
+                    Result.failure(t)
+                }
+                if (initialRootResult.isFailure) {
+                    return@async initialRootResult
+                }
+
+                // Clear undo/redo stacks so that initialRoot setup operations
+                // are not reachable via undo. Mirrors JS SDK PR #1238.
+                document.clearHistory()
             }
             SUCCESS
         }

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -45,6 +45,7 @@ import dev.yorkie.document.Document.Event.PresenceChanged.MyPresence.Initialized
 import dev.yorkie.document.Document.Event.PresenceChanged.Others
 import dev.yorkie.document.Document.Event.StreamConnectionChanged
 import dev.yorkie.document.Document.Event.SyncStatusChanged
+import dev.yorkie.document.json.JsonObject
 import dev.yorkie.document.presence.P
 import dev.yorkie.document.presence.PresenceInfo
 import dev.yorkie.document.presence.Presences.Companion.asPresences
@@ -110,6 +111,16 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.OkHttpClient
 import dev.yorkie.api.v1.ChannelEvent.Type as PbChannelEventType
+
+/**
+ * Initializers for missing root keys when attaching a [Document].
+ *
+ * Each map key is authoritative: its initializer receives that key and is invoked only when the
+ * server-provided root does not contain it. Initial values become ordinary Yorkie changes but are
+ * removed from undo history before attachment completes. Concurrent first attachments may both
+ * initialize a missing key and converge through normal CRDT conflict resolution.
+ */
+public typealias InitialRoot = Map<String, suspend JsonObject.(key: String) -> Unit>
 
 /**
  * Client that can communicate with the server.
@@ -1023,6 +1034,40 @@ public class Client(
         schema: String? = null,
         disableGC: Boolean = false,
         disablePresence: Boolean = false,
+    ): Deferred<OperationResult> = attachDocument(
+        document = document,
+        initialPresence = initialPresence,
+        syncMode = syncMode,
+        schema = schema,
+        disableGC = disableGC,
+        disablePresence = disablePresence,
+        initialRoot = emptyMap(),
+    )
+
+    /**
+     * Attaches the given [Document] to this [Client] and initializes missing root keys.
+     *
+     * The authoritative server response is applied first. Each [initialRoot] initializer is then
+     * invoked only if its map key is absent, and receives that key as its argument. All invoked
+     * initializers form one atomic local change. This change synchronizes normally, but is removed
+     * from undo history before the attached event. Concurrent first attachments are not globally
+     * serialized; their ordinary CRDT changes converge through normal conflict resolution.
+     *
+     * @param initialPresence The initial presence of the client.
+     * @param syncMode The synchronization mode of the document.
+     * @param schema The schema used to validate the document.
+     * @param disableGC Whether this attachment opts out of tombstone garbage collection.
+     * @param disablePresence Whether this attachment opts out of presence.
+     * @param initialRoot Initializers for root keys absent from the authoritative server response.
+     */
+    public fun attachDocument(
+        document: Document,
+        initialPresence: P = emptyMap(),
+        syncMode: SyncMode = SyncMode.Realtime,
+        schema: String? = null,
+        disableGC: Boolean = false,
+        disablePresence: Boolean = false,
+        initialRoot: InitialRoot,
     ): Deferred<OperationResult> {
         return scope.async {
             checkYorkieError(
@@ -1089,13 +1134,31 @@ public class Client(
                 document.setDisablePresence(response.disablePresence)
                 document.applyChangePack(pack)
 
+                if (document.getStatus() == ResourceStatus.Removed) {
+                    document.clearHistory()
+                    return@async SUCCESS
+                }
+
+                val initialRootResult = try {
+                    document.updateAsync { root, _ ->
+                        initialRoot.forEach { (key, initializer) ->
+                            if (root.getOrNull(key) == null) {
+                                initializer(root, key)
+                            }
+                        }
+                    }.await()
+                } catch (t: Throwable) {
+                    ensureActive()
+                    Result.failure(t)
+                }
+                if (initialRootResult.isFailure) {
+                    return@async initialRootResult
+                }
+
                 // Clear undo/redo stacks so that initialRoot setup operations
                 // are not reachable via undo. Mirrors JS SDK PR #1238.
                 document.clearHistory()
 
-                if (document.getStatus() == ResourceStatus.Removed) {
-                    return@async SUCCESS
-                }
                 document.applyStatus(ResourceStatus.Attached)
                 attachments[documentKey] = Attachment(
                     resource = document,

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -119,13 +119,13 @@ import dev.yorkie.api.v1.ChannelEvent.Type as PbChannelEventType
  * server-provided root does not contain it. The absence guard checks only the mapped key itself —
  * an initializer is expected to write only that key; writes to other keys are not guarded against
  * and are not part of the documented contract. Initial values become ordinary Yorkie changes but
- * are removed from undo history before attachment completes. Concurrent first attachments may both
- * initialize a missing key and converge through normal CRDT conflict resolution.
+ * are history-exempt via `skipHistory`, so they never enter the undo/redo history. Concurrent
+ * first attachments may both initialize a missing key and converge through normal CRDT conflict
+ * resolution.
  *
- * The initializer stays a callback (`suspend JsonObject.(key: String) -> Unit`) rather than a
- * plain value map because a value cannot express [JsonObject.setNewTree] or
- * [JsonObject.setNewText] construction; Java consumers that need only primitive/object values can
- * still use this shape by writing directly to the receiver inside the lambda.
+ * The initializer is a `suspend JsonObject.(key: String) -> Unit` lambda, which is awkward to
+ * construct from Java; Java consumers should prefer the no-`initialRoot` [attachDocument]
+ * overload instead.
  */
 public typealias InitialRoot = Map<String, suspend JsonObject.(key: String) -> Unit>
 
@@ -1056,15 +1056,18 @@ public class Client(
      *
      * The authoritative server response is applied first. Each [initialRoot] initializer is then
      * invoked only if its map key is absent, and receives that key as its argument. All invoked
-     * initializers form one atomic local change. This change synchronizes normally, but is removed
-     * from undo history before the attached event. Concurrent first attachments are not globally
-     * serialized; their ordinary CRDT changes converge through normal conflict resolution.
+     * initializers form one atomic local change. This change runs as a history-exempt
+     * `skipHistory` update, so it never enters the undo/redo history. Concurrent first
+     * attachments are not globally serialized; their ordinary CRDT changes converge through
+     * normal conflict resolution.
      *
      * The document is marked [ResourceStatus.Attached] and registered with this client BEFORE the
      * [initialRoot] initializers run, so a throwing initializer leaves the document attached and
-     * detachable rather than rolled back; the returned deferred still resolves to failure. Document
-     * events emitted by the initializer change are always preceded by the `Attached`
-     * [Document.Event.DocumentStatusChanged] event.
+     * detachable rather than rolled back; the returned deferred still resolves to failure, and
+     * history is already cleared. A user edit made after the `Attached` event while an
+     * initializer is still running keeps its undo entry, index-reconciled against the
+     * initializer change. Document events emitted by the initializer change are always preceded
+     * by the `Attached` [Document.Event.DocumentStatusChanged] event.
      *
      * @param initialPresence The initial presence of the client.
      * @param syncMode The synchronization mode of the document.
@@ -1153,14 +1156,24 @@ public class Client(
                 document.setDisablePresence(response.disablePresence)
                 document.applyChangePack(pack)
 
-                // JS SDK v0.7.16 ordering (packages/sdk/src/client/client.ts:665-793 @ 28a5a42e):
-                // Removed early-return (no clearHistory here — JS parity) → applyStatus(Attached)
-                // → attachment registration → runWatchLoop → initialRoot update → single
-                // unconditional clearHistory. On an initializer throw, the document stays
-                // Attached and registered (detachable), matching JS's no-rollback behavior.
+                // Ordering (spec 009 — closes the PR #358 clearHistory window; JS SDK v0.7.16
+                // reference at packages/sdk/src/client/client.ts:665-793 @ 28a5a42e admits no
+                // interleaving because that block is synchronous, so no JS-observable case
+                // changes): Removed early-return → single clearHistory() (wipes pre-attach/offline
+                // entries) → applyStatus(Attached) → attachment registration → runWatchLoop →
+                // initialRoot updateAsync(skipHistory = true) (never enters history, so it needs
+                // no trailing cleanup) → return. History is already cleared before the initializer
+                // runs, so a user edit made after the Attached event while the initializer is
+                // still suspended keeps its undo entry instead of being silently wiped. On an
+                // initializer throw the document still stays Attached and registered (detachable,
+                // matching JS's no-rollback behavior), and history is already cleared.
                 if (document.getStatus() == ResourceStatus.Removed) {
                     return@async SUCCESS
                 }
+
+                // Clear undo/redo stacks so that pre-attach/offline entries and the upcoming
+                // initialRoot setup are not reachable via undo. Mirrors JS SDK PR #1238.
+                document.clearHistory()
 
                 document.applyStatus(ResourceStatus.Attached)
                 attachments[documentKey] = Attachment(
@@ -1178,7 +1191,7 @@ public class Client(
                 }
 
                 val initialRootResult = try {
-                    document.updateAsync { root, _ ->
+                    document.updateAsync(skipHistory = true) { root, _ ->
                         initialRoot.forEach { (key, initializer) ->
                             if (key !in root.keys) {
                                 initializer(root, key)
@@ -1192,10 +1205,6 @@ public class Client(
                 if (initialRootResult.isFailure) {
                     return@async initialRootResult
                 }
-
-                // Clear undo/redo stacks so that initialRoot setup operations
-                // are not reachable via undo. Mirrors JS SDK PR #1238.
-                document.clearHistory()
             }
             SUCCESS
         }

--- a/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/core/Client.kt
@@ -1064,10 +1064,10 @@ public class Client(
      * The document is marked [ResourceStatus.Attached] and registered with this client BEFORE the
      * [initialRoot] initializers run, so a throwing initializer leaves the document attached and
      * detachable rather than rolled back; the returned deferred still resolves to failure, and
-     * history is already cleared. A user edit made after the `Attached` event while an
-     * initializer is still running keeps its undo entry, index-reconciled against the
+     * history is already cleared. A user edit made after the [ResourceStatus.Attached] event
+     * while an initializer is still running keeps its undo entry, index-reconciled against the
      * initializer change. Document events emitted by the initializer change are always preceded
-     * by the `Attached` [Document.Event.DocumentStatusChanged] event.
+     * by the [ResourceStatus.Attached] [Document.Event.DocumentStatusChanged] event.
      *
      * @param initialPresence The initial presence of the client.
      * @param syncMode The synchronization mode of the document.
@@ -1159,21 +1159,22 @@ public class Client(
                 // Ordering (spec 009 — closes the PR #358 clearHistory window; JS SDK v0.7.16
                 // reference at packages/sdk/src/client/client.ts:665-793 @ 28a5a42e admits no
                 // interleaving because that block is synchronous, so no JS-observable case
-                // changes): Removed early-return → single clearHistory() (wipes pre-attach/offline
-                // entries) → applyStatus(Attached) → attachment registration → runWatchLoop →
+                // changes): single clearHistory() (wipes pre-attach/offline entries; runs before
+                // the Removed check for develop parity, so a reused Document instance whose
+                // server-side copy was removed cannot undo into an unsyncable state) → Removed
+                // early-return → applyStatus(Attached) → attachment registration → runWatchLoop →
                 // initialRoot updateAsync(skipHistory = true) (never enters history, so it needs
                 // no trailing cleanup) → return. History is already cleared before the initializer
                 // runs, so a user edit made after the Attached event while the initializer is
                 // still suspended keeps its undo entry instead of being silently wiped. On an
                 // initializer throw the document still stays Attached and registered (detachable,
                 // matching JS's no-rollback behavior), and history is already cleared.
+                // Mirrors JS SDK PR #1238 for the history flush itself.
+                document.clearHistory()
+
                 if (document.getStatus() == ResourceStatus.Removed) {
                     return@async SUCCESS
                 }
-
-                // Clear undo/redo stacks so that pre-attach/offline entries and the upcoming
-                // initialRoot setup are not reachable via undo. Mirrors JS SDK PR #1238.
-                document.clearHistory()
 
                 document.applyStatus(ResourceStatus.Attached)
                 attachments[documentKey] = Attachment(

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -221,6 +221,16 @@ public class Document(
     }
 
     /**
+     * Kept for binary compatibility with code compiled against SDK versions
+     * where [updateAsync] lacked the skipHistory parameter.
+     */
+    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility.")
+    public fun updateAsync(
+        message: String? = null,
+        updater: suspend (root: JsonObject, presence: DocPresence) -> Unit,
+    ): Deferred<OperationResult> = updateAsync(message, skipHistory = false, updater = updater)
+
+    /**
      * Executes the given [updater] to update this document.
      *
      * @param skipHistory Skips recording this change on the undo/redo history

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -222,9 +222,16 @@ public class Document(
 
     /**
      * Executes the given [updater] to update this document.
+     *
+     * @param skipHistory Skips recording this change on the undo/redo history
+     * stacks when true. The change still mutates the document, emits events,
+     * and syncs normally; only the undo entry and redo-stack clearing are
+     * skipped, mirroring how remote changes bypass local history. Defaults
+     * to false, which preserves existing history behavior.
      */
     public fun updateAsync(
         message: String? = null,
+        skipHistory: Boolean = false,
         updater: suspend (root: JsonObject, presence: DocPresence) -> Unit,
     ): Deferred<OperationResult> {
         return scope.async {
@@ -316,12 +323,14 @@ public class Document(
             changeID = context.getNextId()
 
             // Push reverse ops for undo
-            val reverseHistoryOps = reverseOps.map { HistoryOperation.Op(it) }
-            if (reverseHistoryOps.isNotEmpty()) {
-                internalHistory.pushUndo(reverseHistoryOps)
-            }
-            if (operationInfos.isNotEmpty()) {
-                internalHistory.clearRedo()
+            if (!skipHistory) {
+                val reverseHistoryOps = reverseOps.map { HistoryOperation.Op(it) }
+                if (reverseHistoryOps.isNotEmpty()) {
+                    internalHistory.pushUndo(reverseHistoryOps)
+                }
+                if (operationInfos.isNotEmpty()) {
+                    internalHistory.clearRedo()
+                }
             }
 
             if (change.hasOperations) {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -222,10 +222,8 @@ public class Document(
     }
 
     /**
-     * Kept for binary compatibility with code compiled against SDK versions
-     * where [updateAsync] lacked the skipHistory parameter.
+     * Executes the given [updater] to update this document.
      */
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Binary compatibility.")
     public fun updateAsync(
         message: String? = null,
         updater: suspend (root: JsonObject, presence: DocPresence) -> Unit,
@@ -234,15 +232,19 @@ public class Document(
     /**
      * Executes the given [updater] to update this document.
      *
+     * A `skipHistory` write is treated exactly like a remote client's write for history
+     * purposes: pending undo/redo entries are index-reconciled against it, but an entry
+     * whose target element it overwrites or removes is not retargeted and undoes/redoes
+     * as a no-op or replay, as with remote changes.
+     *
      * @param skipHistory Skips recording this change on the undo/redo history
      * stacks when true. The change still mutates the document, emits events,
      * and syncs normally; only the undo entry and redo-stack clearing are
-     * skipped, mirroring how remote changes bypass local history. Defaults
-     * to false, which preserves existing history behavior.
+     * skipped, mirroring how remote changes bypass local history.
      */
     public fun updateAsync(
         message: String? = null,
-        skipHistory: Boolean = false,
+        skipHistory: Boolean,
         updater: suspend (root: JsonObject, presence: DocPresence) -> Unit,
     ): Deferred<OperationResult> {
         return scope.async {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -182,7 +182,8 @@ public class Document(
             .orEmpty()
 
     /**
-     * Provides undo/redo operations for this document.
+     * Provides undo/redo operations for local user changes in this document.
+     * The resulting document changes are synchronized normally.
      */
     public val history: DocumentHistory = object : DocumentHistory {
         override fun canUndo(): Boolean = internalHistory.hasUndo() && !isUpdating

--- a/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/Document.kt
@@ -12,6 +12,7 @@ import dev.yorkie.document.Document.Event.PresenceChanged.MyPresence
 import dev.yorkie.document.Document.Event.PresenceChanged.Others
 import dev.yorkie.document.change.Change
 import dev.yorkie.document.change.ChangeContext
+import dev.yorkie.document.change.ChangeExecutionResult
 import dev.yorkie.document.change.ChangeID
 import dev.yorkie.document.change.ChangePack
 import dev.yorkie.document.change.CheckPoint
@@ -324,7 +325,11 @@ public class Document(
                 return@async result
             }
             val change = context.toChange()
-            val localResult = change.execute(root, _presences.value)
+            val localResult = change.execute(
+                root,
+                _presences.value,
+                if (skipHistory) OpSource.LocalNoHistory else OpSource.Local,
+            )
             val operationInfos = localResult.opInfos
             val newPresences = localResult.newPresences
             val reverseOps = localResult.reverseOps
@@ -332,8 +337,12 @@ public class Document(
             localChanges += change
             changeID = context.getNextId()
 
-            // Push reverse ops for undo
-            if (!skipHistory) {
+            if (skipHistory) {
+                // A skipHistory write is treated exactly like a remote client's write for
+                // history purposes: pending undo/redo entries are index-reconciled against
+                // it, but it is never itself pushed onto the undo stack.
+                reconcileHistoryEdits(localResult)
+            } else {
                 val reverseHistoryOps = reverseOps.map { HistoryOperation.Op(it) }
                 if (reverseHistoryOps.isNotEmpty()) {
                     internalHistory.pushUndo(reverseHistoryOps)
@@ -664,70 +673,7 @@ public class Document(
             // Reconcile text and tree undo/redo stack entries against remote edits.
             // Only reconcile against changes from other clients.
             if (change.id.actor != changeID.actor) {
-                var opInfoIndex = 0
-                for (executedOp in remoteResult.executedOperations) {
-                    when (executedOp) {
-                        is EditOperation -> {
-                            // For text edits there is at most one EditOpInfo per operation.
-                            while (opInfoIndex < remoteResult.opInfos.size) {
-                                val opInfo = remoteResult.opInfos[opInfoIndex]
-                                opInfoIndex++
-                                if (opInfo is OperationInfo.EditOpInfo) {
-                                    internalHistory.reconcileTextEdit(
-                                        executedOp.parentCreatedAt,
-                                        opInfo.from,
-                                        opInfo.to,
-                                        opInfo.value.text.length,
-                                    )
-                                    break
-                                }
-                            }
-                        }
-
-                        is TreeEditOperation -> {
-                            // For tree edits there may be multiple TreeEditOpInfos per operation
-                            // (split/merge decomposes into multiple ranges). Reconcile using the
-                            // first deletion range's from/to and the inserted node count.
-                            var firstTreeEditOpInfo: OperationInfo.TreeEditOpInfo? = null
-                            while (opInfoIndex < remoteResult.opInfos.size) {
-                                val opInfo = remoteResult.opInfos[opInfoIndex]
-                                opInfoIndex++
-                                if (opInfo is OperationInfo.TreeEditOpInfo) {
-                                    if (firstTreeEditOpInfo == null) {
-                                        firstTreeEditOpInfo = opInfo
-                                    }
-                                    // Keep consuming TreeEditOpInfos for this operation
-                                    val next = remoteResult.opInfos.getOrNull(opInfoIndex)
-                                    if (next !is OperationInfo.TreeEditOpInfo) break
-                                } else {
-                                    break
-                                }
-                            }
-                            firstTreeEditOpInfo?.let { opInfo ->
-                                val insertedSize = opInfo.nodes?.size ?: 0
-                                internalHistory.reconcileTreeEdit(
-                                    executedOp.parentCreatedAt,
-                                    opInfo.from,
-                                    opInfo.to,
-                                    insertedSize,
-                                )
-                            }
-                        }
-
-                        else -> {
-                            // Skip opInfos for non-Edit operations
-                            while (opInfoIndex < remoteResult.opInfos.size) {
-                                val opInfo = remoteResult.opInfos[opInfoIndex]
-                                opInfoIndex++
-                                if (opInfo !is OperationInfo.EditOpInfo &&
-                                    opInfo !is OperationInfo.TreeEditOpInfo
-                                ) {
-                                    break
-                                }
-                            }
-                        }
-                    }
-                }
+                reconcileHistoryEdits(remoteResult)
             }
 
             if (opInfos.isNotEmpty()) {
@@ -740,6 +686,80 @@ public class Document(
                 changeID.syncLamport(change.id)
             } else {
                 changeID.syncClocks(change.id)
+            }
+        }
+    }
+
+    /**
+     * Reconciles pending undo/redo stack entries against the operations in [result].
+     * Adjusts index-based undo ranges so that entries created before [result] was executed
+     * still target the correct positions afterward. Used both for remote changes from other
+     * clients ([applyChanges]) and for local `skipHistory` changes ([updateAsync]), which are
+     * treated identically for history-reconciliation purposes.
+     */
+    private fun reconcileHistoryEdits(result: ChangeExecutionResult) {
+        var opInfoIndex = 0
+        for (executedOp in result.executedOperations) {
+            when (executedOp) {
+                is EditOperation -> {
+                    // For text edits there is at most one EditOpInfo per operation.
+                    while (opInfoIndex < result.opInfos.size) {
+                        val opInfo = result.opInfos[opInfoIndex]
+                        opInfoIndex++
+                        if (opInfo is OperationInfo.EditOpInfo) {
+                            internalHistory.reconcileTextEdit(
+                                executedOp.parentCreatedAt,
+                                opInfo.from,
+                                opInfo.to,
+                                opInfo.value.text.length,
+                            )
+                            break
+                        }
+                    }
+                }
+
+                is TreeEditOperation -> {
+                    // For tree edits there may be multiple TreeEditOpInfos per operation
+                    // (split/merge decomposes into multiple ranges). Reconcile using the
+                    // first deletion range's from/to and the inserted node count.
+                    var firstTreeEditOpInfo: OperationInfo.TreeEditOpInfo? = null
+                    while (opInfoIndex < result.opInfos.size) {
+                        val opInfo = result.opInfos[opInfoIndex]
+                        opInfoIndex++
+                        if (opInfo is OperationInfo.TreeEditOpInfo) {
+                            if (firstTreeEditOpInfo == null) {
+                                firstTreeEditOpInfo = opInfo
+                            }
+                            // Keep consuming TreeEditOpInfos for this operation
+                            val next = result.opInfos.getOrNull(opInfoIndex)
+                            if (next !is OperationInfo.TreeEditOpInfo) break
+                        } else {
+                            break
+                        }
+                    }
+                    firstTreeEditOpInfo?.let { opInfo ->
+                        val insertedSize = opInfo.nodes?.size ?: 0
+                        internalHistory.reconcileTreeEdit(
+                            executedOp.parentCreatedAt,
+                            opInfo.from,
+                            opInfo.to,
+                            insertedSize,
+                        )
+                    }
+                }
+
+                else -> {
+                    // Skip opInfos for non-Edit operations
+                    while (opInfoIndex < result.opInfos.size) {
+                        val opInfo = result.opInfos[opInfoIndex]
+                        opInfoIndex++
+                        if (opInfo !is OperationInfo.EditOpInfo &&
+                            opInfo !is OperationInfo.TreeEditOpInfo
+                        ) {
+                            break
+                        }
+                    }
+                }
             }
         }
     }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/crdt/CrdtTree.kt
@@ -284,6 +284,13 @@ internal data class CrdtTree(
         executedAt: TimeTicket,
         issueTimeTicket: (() -> TimeTicket)? = null,
         versionVector: VersionVector? = null,
+        /**
+         * Whether to capture deep-copy snapshots of removed top-level nodes for reverse
+         * (undo) operation generation. Defaults to true. Callers that will never produce a
+         * reverse operation for this edit (e.g. a history-exempt `skipHistory` change, or
+         * remote application) can pass false to skip the allocation.
+         */
+        captureRemovedNodes: Boolean = true,
     ): TreeOperationResult {
         var diff = DataSize(
             data = 0,
@@ -456,9 +463,14 @@ internal data class CrdtTree(
         // tombstoned, so that a reverse TreeEditOperation can convert them to plain
         // TreeNode snapshots for undo re-insertion. Only root-level removed nodes are
         // captured; their children are already included in each node's subtree via deepCopy().
-        val removedNodes = nodesToBeRemoved
-            .filter { it.parent !in nodesToBeRemoved }
-            .map(CrdtTreeNode::deepCopy)
+        // Skipped entirely when the caller will never produce a reverse op (F2).
+        val removedNodes = if (captureRemovedNodes) {
+            nodesToBeRemoved
+                .filter { it.parent !in nodesToBeRemoved }
+                .map(CrdtTreeNode::deepCopy)
+        } else {
+            emptyList()
+        }
 
         // 02. Delete: delete the nodes that are marked as removed.
         val gcPairs = mutableListOf<GCPair<CrdtTreeNode>>()

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/AddOperation.kt
@@ -38,11 +38,17 @@ internal data class AddOperation(
             parentObject.insertAfter(prevCreatedAt, copiedValue)
             root.registerElement(copiedValue, parentObject)
 
-            val reverseOp = RemoveOperation(
-                createdAt = copiedValue.createdAt,
-                parentCreatedAt = parentCreatedAt,
-                executedAt = executedAt,
-            )
+            val reverseOps = if (source.producesReverseOps) {
+                listOf(
+                    RemoveOperation(
+                        createdAt = copiedValue.createdAt,
+                        parentCreatedAt = parentCreatedAt,
+                        executedAt = executedAt,
+                    ),
+                )
+            } else {
+                emptyList()
+            }
 
             ExecutionResult(
                 opInfos = listOf(
@@ -51,7 +57,7 @@ internal data class AddOperation(
                         root.createPath(parentCreatedAt),
                     ),
                 ),
-                reverseOps = listOf(reverseOp),
+                reverseOps = reverseOps,
             )
         } else {
             parentObject ?: logError(TAG, "fail to find $parentCreatedAt")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/ArraySetOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/ArraySetOperation.kt
@@ -45,13 +45,17 @@ internal data class ArraySetOperation(
 
         root.registerElement(value, null)
 
-        val reverseOp = previousValue?.let {
-            ArraySetOperation(
-                createdAt = createdAt,
-                value = it.deepCopy(),
-                parentCreatedAt = parentCreatedAt,
-                executedAt = executedAt,
-            )
+        val reverseOp = if (source.producesReverseOps) {
+            previousValue?.let {
+                ArraySetOperation(
+                    createdAt = createdAt,
+                    value = it.deepCopy(),
+                    parentCreatedAt = parentCreatedAt,
+                    executedAt = executedAt,
+                )
+            }
+        } else {
+            null
         }
 
         return ExecutionResult(

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/EditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/EditOperation.kt
@@ -15,8 +15,8 @@ import dev.yorkie.util.Logger.Companion.logError
  * [EditOperation] is an operations representing editing rich text.
  */
 internal data class EditOperation(
-    val fromPos: RgaTreeSplitPos,
-    val toPos: RgaTreeSplitPos,
+    var fromPos: RgaTreeSplitPos,
+    var toPos: RgaTreeSplitPos,
     val content: String,
     override var parentCreatedAt: TimeTicket,
     override var executedAt: TimeTicket,
@@ -61,6 +61,11 @@ internal data class EditOperation(
                 fromPos to toPos
             }
 
+            if (isUndoOp) {
+                fromPos = actualFrom
+                toPos = actualTo
+            }
+
             val result = parentObject.edit(
                 RgaTreeSplitPosRange(actualFrom, actualTo),
                 content,
@@ -82,9 +87,11 @@ internal data class EditOperation(
                 )
             }
 
-            // Reverse ops are only generated for local and undo/redo operations.
-            // Remote applications (applyChanges) do not produce reverse ops.
-            val reverseOps = if (source == OpSource.Local || source == OpSource.UndoRedo) {
+            // Reverse ops are only generated for local and undo/redo operations that
+            // actually changed something. Remote applications (applyChanges) and
+            // history-exempt (skipHistory) changes do not produce reverse ops, nor
+            // does a zero-effect edit (empty opInfos).
+            val reverseOps = if (opInfos.isNotEmpty() && source.producesReverseOps) {
                 // fromIndex is the document index where this edit starts in the live text.
                 // Use the opInfo value computed during the edit (before any insertion offset).
                 val fromIndex = opInfos.filterIsInstance<OperationInfo.EditOpInfo>()

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/IncreaseOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/IncreaseOperation.kt
@@ -65,16 +65,22 @@ internal data class IncreaseOperation(
                     copiedValue.value as Long
                 }
 
-                val negatedValue = if (copiedValue.type == Type.Integer) {
-                    CrdtPrimitive(-(copiedValue.value as Int), copiedValue.createdAt)
+                val reverseOps = if (source.producesReverseOps) {
+                    val negatedValue = if (copiedValue.type == Type.Integer) {
+                        CrdtPrimitive(-(copiedValue.value as Int), copiedValue.createdAt)
+                    } else {
+                        CrdtPrimitive(-(copiedValue.value as Long), copiedValue.createdAt)
+                    }
+                    listOf(
+                        IncreaseOperation(
+                            value = negatedValue,
+                            parentCreatedAt = parentCreatedAt,
+                            executedAt = executedAt,
+                        ),
+                    )
                 } else {
-                    CrdtPrimitive(-(copiedValue.value as Long), copiedValue.createdAt)
+                    emptyList()
                 }
-                val reverseOp = IncreaseOperation(
-                    value = negatedValue,
-                    parentCreatedAt = parentCreatedAt,
-                    executedAt = executedAt,
-                )
 
                 ExecutionResult(
                     opInfos = listOf(
@@ -83,7 +89,7 @@ internal data class IncreaseOperation(
                             root.createPath(parentCreatedAt),
                         ),
                     ),
-                    reverseOps = listOf(reverseOp),
+                    reverseOps = reverseOps,
                 )
             }
         } else {

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/MoveOperation.kt
@@ -41,12 +41,18 @@ internal data class MoveOperation(
             }
             val index = parentObject.subPathOf(createdAt).toInt()
 
-            val reverseOp = MoveOperation(
-                prevCreatedAt = prevCreatedAtBefore,
-                createdAt = createdAt,
-                parentCreatedAt = parentCreatedAt,
-                executedAt = executedAt,
-            )
+            val reverseOps = if (source.producesReverseOps) {
+                listOf(
+                    MoveOperation(
+                        prevCreatedAt = prevCreatedAtBefore,
+                        createdAt = createdAt,
+                        parentCreatedAt = parentCreatedAt,
+                        executedAt = executedAt,
+                    ),
+                )
+            } else {
+                emptyList()
+            }
 
             ExecutionResult(
                 opInfos = listOf(
@@ -56,7 +62,7 @@ internal data class MoveOperation(
                         path = root.createPath(parentCreatedAt),
                     ),
                 ),
-                reverseOps = listOf(reverseOp),
+                reverseOps = reverseOps,
             )
         } else {
             parentObject ?: logError(TAG, "fail to find $parentCreatedAt")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/OpSource.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/OpSource.kt
@@ -8,4 +8,21 @@ internal enum class OpSource {
     Local,
     Remote,
     UndoRedo,
+
+    /**
+     * A local change executed with `skipHistory = true`. Behaves like [Local] for
+     * the document mutation itself, but is treated as history-exempt: it produces
+     * no reverse operations (see [producesReverseOps]) since it is never pushed
+     * onto the undo stack.
+     */
+    LocalNoHistory,
+    ;
+
+    /**
+     * Returns true when operations executed with this source should generate
+     * reverse operations for the undo/redo stack. Only [Local] and [UndoRedo]
+     * changes are ever pushed onto the undo stack, so only they need reverse ops.
+     */
+    val producesReverseOps: Boolean
+        get() = this == Local || this == UndoRedo
 }

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/RemoveOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/RemoveOperation.kt
@@ -47,30 +47,34 @@ internal data class RemoveOperation(
             root.registerRemovedElement(element)
             val index = if (parentObject is CrdtArray) key?.toInt() else null
 
-            val reverseOps = when (parentObject) {
-                is CrdtArray -> {
-                    val elementCopy = element.deepCopy()
-                    val addOp = AddOperation(
-                        prevCreatedAt = prevCreatedAtForArray!!,
-                        value = stripChildren(elementCopy),
-                        parentCreatedAt = parentCreatedAt,
-                        executedAt = executedAt,
-                    )
-                    listOf(addOp) + childSetOps(element, element.createdAt, executedAt)
-                }
-
-                is CrdtObject -> {
-                    listOf(
-                        SetOperation(
-                            key = key ?: "",
-                            value = element.deepCopy(),
+            val reverseOps = if (source.producesReverseOps) {
+                when (parentObject) {
+                    is CrdtArray -> {
+                        val elementCopy = element.deepCopy()
+                        val addOp = AddOperation(
+                            prevCreatedAt = prevCreatedAtForArray!!,
+                            value = stripChildren(elementCopy),
                             parentCreatedAt = parentCreatedAt,
                             executedAt = executedAt,
-                        ),
-                    )
-                }
+                        )
+                        listOf(addOp) + childSetOps(element, element.createdAt, executedAt)
+                    }
 
-                else -> emptyList()
+                    is CrdtObject -> {
+                        listOf(
+                            SetOperation(
+                                key = key ?: "",
+                                value = element.deepCopy(),
+                                parentCreatedAt = parentCreatedAt,
+                                executedAt = executedAt,
+                            ),
+                        )
+                    }
+
+                    else -> emptyList()
+                }
+            } else {
+                emptyList()
             }
 
             ExecutionResult(

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/SetOperation.kt
@@ -51,17 +51,22 @@ internal data class SetOperation(
                 root.registerRemovedElement(copiedValue)
             }
 
-            val reverseOp = if (previousValue != null) {
-                SetOperation(key, previousValue.deepCopy(), parentCreatedAt, executedAt)
+            val reverseOps = if (source.producesReverseOps) {
+                val reverseOp = if (previousValue != null) {
+                    SetOperation(key, previousValue.deepCopy(), parentCreatedAt, executedAt)
+                } else {
+                    RemoveOperation(copiedValue.createdAt, parentCreatedAt, executedAt)
+                }
+                listOf(reverseOp)
             } else {
-                RemoveOperation(copiedValue.createdAt, parentCreatedAt, executedAt)
+                emptyList()
             }
 
             ExecutionResult(
                 opInfos = listOf(
                     OperationInfo.SetOpInfo(key, root.createPath(parentCreatedAt)),
                 ),
-                reverseOps = listOf(reverseOp),
+                reverseOps = reverseOps,
             )
         } else {
             parentObject ?: logError(TAG, "fail to find $parentCreatedAt")

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/StyleOperation.kt
@@ -58,7 +58,7 @@ internal data class StyleOperation(
                 reverseAttrsToRemove.addAll(result.attributesToRemove)
             }
 
-            val reverseOps = if (source == OpSource.Local || source == OpSource.UndoRedo) {
+            val reverseOps = if (source.producesReverseOps) {
                 buildReverseOps(reversePrevAttributes, reverseAttrsToRemove)
             } else {
                 emptyList()

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
@@ -119,6 +119,7 @@ internal data class TreeEditOperation(
                 editedAt,
                 issueTimeTicket(editedAt),
                 versionVector,
+                captureRemovedNodes = source.producesReverseOps,
             )
 
         root.acc(result.dataSize)
@@ -140,9 +141,7 @@ internal data class TreeEditOperation(
 
         // Reverse ops are only generated for local and undo/redo operations.
         val reverseOps =
-            if (opInfos.isNotEmpty() &&
-                (source == OpSource.Local || source == OpSource.UndoRedo)
-            ) {
+            if (opInfos.isNotEmpty() && source.producesReverseOps) {
                 val fromIndex =
                     opInfos
                         .filterIsInstance<OperationInfo.TreeEditOpInfo>()

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeEditOperation.kt
@@ -21,9 +21,9 @@ import dev.yorkie.util.Logger.Companion.logError
  */
 internal data class TreeEditOperation(
     override var parentCreatedAt: TimeTicket,
-    val fromPos: CrdtTreePos,
-    val toPos: CrdtTreePos,
-    val contents: List<CrdtTreeNode>?,
+    var fromPos: CrdtTreePos,
+    var toPos: CrdtTreePos,
+    var contents: List<CrdtTreeNode>?,
     val splitLevel: Int,
     override var executedAt: TimeTicket,
     /**
@@ -104,6 +104,12 @@ internal data class TreeEditOperation(
                 else -> contents?.map(CrdtTreeNode::deepCopy)
             }
 
+        if (isUndoOp) {
+            fromPos = actualFrom
+            toPos = actualTo
+            contents = editContents?.map(CrdtTreeNode::deepCopy)
+        }
+
         val editedAt = executedAt
         val result =
             tree.edit(
@@ -134,7 +140,9 @@ internal data class TreeEditOperation(
 
         // Reverse ops are only generated for local and undo/redo operations.
         val reverseOps =
-            if (source == OpSource.Local || source == OpSource.UndoRedo) {
+            if (opInfos.isNotEmpty() &&
+                (source == OpSource.Local || source == OpSource.UndoRedo)
+            ) {
                 val fromIndex =
                     opInfos
                         .filterIsInstance<OperationInfo.TreeEditOpInfo>()
@@ -355,9 +363,7 @@ internal data class TreeEditOperation(
 
     private fun issueTimeTicket(executedAt: TimeTicket): () -> TimeTicket {
         var delimiter = executedAt.delimiter
-        if (contents != null) {
-            delimiter += contents.size.toUInt()
-        }
+        contents?.let { delimiter += it.size.toUInt() }
         return { TimeTicket(executedAt.lamport, ++delimiter, executedAt.actorID) }
     }
 

--- a/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeStyleOperation.kt
+++ b/yorkie/src/main/kotlin/dev/yorkie/document/operation/TreeStyleOperation.kt
@@ -92,7 +92,7 @@ internal data class TreeStyleOperation(
             else -> emptyList()
         }
 
-        val reverseOps = if (source == OpSource.Local || source == OpSource.UndoRedo) {
+        val reverseOps = if (source.producesReverseOps) {
             buildReverseOps(reversePrevAttributes, reverseAttrsToRemove)
         } else {
             emptyList()

--- a/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
@@ -51,6 +51,7 @@ import dev.yorkie.util.YorkieException
 import dev.yorkie.util.YorkieException.Code.ErrUnimplemented
 import java.util.Date
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertThrows
 import org.junit.Test
@@ -314,6 +315,67 @@ class ConverterTest {
         assertEquals(styleOperation, converted[7])
         assertEquals(treeEditOperation, converted[8])
         assertEquals(treeStyleOperation, converted[9])
+    }
+
+    @Test
+    fun `should round trip the effective history tree edit payload`() {
+        fun ticket(lamport: Long) = TimeTicket(lamport, 0u, ActorID.INITIAL_ACTOR_ID)
+
+        val treeTicket = ticket(1)
+        val rootNode = CrdtTreeElement(CrdtTreeNodeID(treeTicket, 0), DEFAULT_ROOT_TYPE)
+        val paragraph = CrdtTreeElement(CrdtTreeNodeID(ticket(2), 0), "p")
+        paragraph.append(CrdtTreeText(CrdtTreeNodeID(ticket(3), 0), "12"))
+        rootNode.append(paragraph)
+        val tree = CrdtTree(rootNode, treeTicket)
+        val root = CrdtRoot(CrdtObject(InitialTimeTicket, memberNodes = ElementRht()))
+        root.rootObject.set("tree", tree, treeTicket)
+        root.registerElement(tree, root.rootObject)
+
+        val three = CrdtTreeText(CrdtTreeNodeID(ticket(4), 0), "3")
+        val (insertFrom, insertTo) = tree.indexRangeToPosRange(3 to 3)
+        val insert =
+            TreeEditOperation(treeTicket, insertFrom, insertTo, listOf(three), 0, ticket(4))
+        val delete = insert.execute(root, OpSource.Local, null).reverseOps.single()
+            as TreeEditOperation
+
+        delete.executedAt = ticket(5)
+        val deleteResult = delete.execute(root, OpSource.UndoRedo, null)
+        val decodedDelete = listOf(delete.toPBOperation()).toOperations().single()
+            as TreeEditOperation
+
+        assertFalse(decodedDelete.fromPos == decodedDelete.toPos)
+        assertEquals(delete.fromPos, decodedDelete.fromPos)
+        assertEquals(delete.toPos, decodedDelete.toPos)
+        assertEquals(delete.splitLevel, decodedDelete.splitLevel)
+
+        val restore = deleteResult.reverseOps.single() as TreeEditOperation
+        restore.executedAt = ticket(6)
+        restore.execute(root, OpSource.UndoRedo, null)
+        val decodedRestore = listOf(restore.toPBOperation()).toOperations().single()
+            as TreeEditOperation
+
+        assertEquals(restore.fromPos, decodedRestore.fromPos)
+        assertEquals(restore.toPos, decodedRestore.toPos)
+        assertEquals(restore.contents?.map { it.id }, decodedRestore.contents?.map { it.id })
+        assertEquals("<root><p>123</p></root>", tree.toXml())
+
+        val splitPos = tree.indexRangeToPosRange(2 to 2).first
+        val split =
+            TreeEditOperation(
+                treeTicket,
+                splitPos,
+                splitPos,
+                null,
+                1,
+                ticket(7),
+                undoFromOffset = 2,
+                undoToOffset = 2,
+            )
+        split.execute(root, OpSource.UndoRedo, null)
+        val decodedSplit = listOf(split.toPBOperation()).toOperations().single()
+            as TreeEditOperation
+
+        assertEquals(1, decodedSplit.splitLevel)
     }
 
     @Test

--- a/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/api/ConverterTest.kt
@@ -356,6 +356,9 @@ class ConverterTest {
 
         assertEquals(restore.fromPos, decodedRestore.fromPos)
         assertEquals(restore.toPos, decodedRestore.toPos)
+        // F15: restore.contents must be non-empty — otherwise the id comparison below
+        // would pass vacuously on a reverted `contents` rebuild (null == null).
+        assertFalse(restore.contents.isNullOrEmpty())
         assertEquals(restore.contents?.map { it.id }, decodedRestore.contents?.map { it.id })
         assertEquals("<root><p>123</p></root>", tree.toXml())
 
@@ -376,6 +379,53 @@ class ConverterTest {
             as TreeEditOperation
 
         assertEquals(1, decodedSplit.splitLevel)
+    }
+
+    @Test
+    fun `should round trip the effective history text edit payload`() {
+        fun ticket(lamport: Long) = TimeTicket(lamport, 0u, ActorID.INITIAL_ACTOR_ID)
+
+        val textTicket = ticket(1)
+        val text = CrdtText(RgaTreeSplit(), textTicket)
+        val root = CrdtRoot(CrdtObject(InitialTimeTicket, memberNodes = ElementRht()))
+        root.rootObject.set("text", text, textTicket)
+        root.registerElement(text, root.rootObject)
+
+        text.edit(text.indexRangeToPosRange(0, 0), "Hello", ticket(2))
+
+        val (insertFrom, insertTo) = text.indexRangeToPosRange(2, 2)
+        val insert = EditOperation(
+            fromPos = insertFrom,
+            toPos = insertTo,
+            content = "XYZ",
+            parentCreatedAt = textTicket,
+            executedAt = ticket(3),
+            attributes = emptyMap(),
+        )
+        val delete = insert.execute(root, OpSource.Local, null).reverseOps.single()
+            as EditOperation
+
+        delete.executedAt = ticket(4)
+        val deleteResult = delete.execute(root, OpSource.UndoRedo, null)
+        val decodedDelete = listOf(delete.toPBOperation()).toOperations().single()
+            as EditOperation
+
+        // F10: the reconciled range (assigned back onto fromPos/toPos by execute()) is
+        // what gets serialized — not the stale capture-time positions.
+        assertEquals(delete.fromPos, decodedDelete.fromPos)
+        assertEquals(delete.toPos, decodedDelete.toPos)
+
+        val restore = deleteResult.reverseOps.single() as EditOperation
+        restore.executedAt = ticket(5)
+        restore.execute(root, OpSource.UndoRedo, null)
+        val decodedRestore = listOf(restore.toPBOperation()).toOperations().single()
+            as EditOperation
+
+        assertEquals(restore.fromPos, decodedRestore.fromPos)
+        assertEquals(restore.toPos, decodedRestore.toPos)
+        // Net effect of insert -> undo(delete) -> undo-the-undo(restore) is the original
+        // insert persisting, mirroring the tree round-trip test's "123" end state above.
+        assertEquals("HeXYZllo", text.toString())
     }
 
     @Test

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -13,7 +13,10 @@ import dev.yorkie.api.v1.DetachDocumentRequest
 import dev.yorkie.api.v1.PushPullChangesRequest
 import dev.yorkie.api.v1.RemoveDocumentRequest
 import dev.yorkie.api.v1.YorkieServiceClientInterface
+import dev.yorkie.api.v1.attachDocumentResponse
+import dev.yorkie.api.v1.changePack
 import dev.yorkie.api.v1.deactivateClientResponse
+import dev.yorkie.api.v1.rule
 import dev.yorkie.assertJsonContentEquals
 import dev.yorkie.core.Client.SyncMode.Manual
 import dev.yorkie.core.Client.SyncMode.RealtimePushOnly
@@ -37,7 +40,15 @@ import dev.yorkie.document.change.Change
 import dev.yorkie.document.change.ChangeID
 import dev.yorkie.document.change.ChangePack
 import dev.yorkie.document.change.CheckPoint
+import dev.yorkie.document.json.JsonArray
+import dev.yorkie.document.json.JsonCounter
+import dev.yorkie.document.json.JsonDedupCounter
+import dev.yorkie.document.json.JsonObject
+import dev.yorkie.document.json.JsonPrimitive
 import dev.yorkie.document.json.JsonText
+import dev.yorkie.document.json.JsonTree
+import dev.yorkie.document.json.TreeBuilder.element
+import dev.yorkie.document.json.TreeBuilder.text
 import dev.yorkie.document.presence.PresenceChange
 import dev.yorkie.document.time.VersionVector
 import dev.yorkie.document.time.VersionVector.Companion.INITIAL_VERSION_VECTOR
@@ -53,11 +64,13 @@ import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.unmockkStatic
+import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineStart
@@ -355,6 +368,250 @@ class ClientTest {
             detachRequestCaptor.captured.changePack.toChangePack().changes.last()
         assertIs<PresenceChange.Clear>(detachmentChange.presenceChange)
         target.deactivateAsync().await()
+    }
+
+    @Test
+    fun `attachDocument initializes every missing root type after the server response`() = runTest {
+        // given
+        mockkStatic(Base64::class)
+        every { Base64.encodeToString(any(), any()) } returns "mockk"
+        val document = Document(NORMAL_DOCUMENT_KEY)
+        val events = mutableListOf<Document.Event>()
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) {
+            document.events.collect(events::add)
+        }
+        var existingInitializerCalled = false
+        target.activateAsync().await()
+
+        // when
+        val result = target.attachDocument(
+            document = document,
+            syncMode = Manual,
+            initialRoot = linkedMapOf(
+                "k1" to { key ->
+                    existingInitializerCalled = true
+                    this[key] = 5
+                },
+                "null" to { key -> set(key, null as JsonPrimitive?) },
+                "boolean" to { key -> this[key] = true },
+                "integer" to { key -> this[key] = 1 },
+                "long" to { key -> this[key] = 2L },
+                "double" to { key -> this[key] = 3.5 },
+                "string" to { key -> this[key] = "value" },
+                "bytes" to { key -> this[key] = byteArrayOf(1, 2) },
+                "date" to { key -> this[key] = Date(1_000) },
+                "object" to { key -> setNewObject(key)["nested"] = "value" },
+                "array" to { key -> setNewArray(key).put("value") },
+                "text" to { key -> setNewText(key).edit(0, 0, "value") },
+                "counterInt" to { key -> setNewCounter(key, 1) },
+                "counterLong" to { key -> setNewCounter(key, 2L) },
+                "dedupCounter" to { key -> setNewDedupCounter(key).add("actor") },
+                "tree" to { key ->
+                    setNewTree(
+                        key,
+                        element("doc") {
+                            element("p") { text { "value" } }
+                        },
+                    )
+                },
+            ),
+        ).await()
+        withTimeout(1_000) {
+            while (events.none {
+                    it is Document.Event.DocumentStatusChanged &&
+                        it.docStatus == ResourceStatus.Attached
+                }
+            ) {
+                delay(1)
+            }
+        }
+
+        // then
+        assertTrue(result.isSuccess)
+        assertFalse(existingInitializerCalled)
+        val root = document.getRoot()
+        assertEquals(4, root.getAs<JsonPrimitive>("k1").value)
+        assertEquals(JsonPrimitive.Type.Null, root.getAs<JsonPrimitive>("null").type)
+        assertEquals(JsonPrimitive.Type.Boolean, root.getAs<JsonPrimitive>("boolean").type)
+        assertEquals(JsonPrimitive.Type.Integer, root.getAs<JsonPrimitive>("integer").type)
+        assertEquals(JsonPrimitive.Type.Long, root.getAs<JsonPrimitive>("long").type)
+        assertEquals(JsonPrimitive.Type.Double, root.getAs<JsonPrimitive>("double").type)
+        assertEquals(JsonPrimitive.Type.String, root.getAs<JsonPrimitive>("string").type)
+        assertEquals(JsonPrimitive.Type.Bytes, root.getAs<JsonPrimitive>("bytes").type)
+        assertEquals(JsonPrimitive.Type.Date, root.getAs<JsonPrimitive>("date").type)
+        assertEquals("value", root.getAs<JsonObject>("object").getAs<JsonPrimitive>("nested").value)
+        assertEquals("value", root.getAs<JsonArray>("array").getAs<JsonPrimitive>(0)?.value)
+        assertEquals("value", root.getAs<JsonText>("text").values.single().text)
+        assertEquals(1, root.getAs<JsonCounter>("counterInt").value)
+        assertEquals(2L, root.getAs<JsonCounter>("counterLong").value)
+        assertEquals(1, root.getAs<JsonDedupCounter>("dedupCounter").value)
+        assertEquals("<doc><p>value</p></doc>", root.getAs<JsonTree>("tree").toXml())
+        assertEquals(1, events.count { it is Document.Event.LocalChange })
+        val lifecycleEvents = events.filter {
+            it is Document.Event.LocalChange ||
+                it is Document.Event.DocumentStatusChanged
+        }
+        assertIs<Document.Event.LocalChange>(lifecycleEvents.first())
+        assertEquals(
+            ResourceStatus.Attached,
+            assertIs<Document.Event.DocumentStatusChanged>(lifecycleEvents.last()).docStatus,
+        )
+        assertFalse(document.history.canUndo())
+        assertFalse(document.history.canRedo())
+
+        collector.cancel()
+        target.detachDocument(document).await()
+        target.deactivateAsync().await()
+        document.close()
+        unmockkStatic(Base64::class)
+    }
+
+    @Test
+    fun `attachDocument rolls back all initial root entries when an initializer fails`() = runTest {
+        // given
+        val document = Document(NORMAL_DOCUMENT_KEY)
+        val statuses = mutableListOf<Document.Event.DocumentStatusChanged>()
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) {
+            document.events.filterIsInstance<Document.Event.DocumentStatusChanged>()
+                .collect(statuses::add)
+        }
+        target.activateAsync().await()
+
+        // when
+        val result = target.attachDocument(
+            document = document,
+            syncMode = Manual,
+            initialRoot = linkedMapOf(
+                "first" to { key -> this[key] = 1 },
+                "second" to { error("initializer failed") },
+            ),
+        ).await()
+        delay(10)
+
+        // then
+        assertTrue(result.isFailure)
+        assertNull(document.getRoot().getOrNull("first"))
+        assertEquals(ResourceStatus.Detached, document.getStatus())
+        assertFalse(target.has(NORMAL_DOCUMENT_KEY))
+        assertTrue(statuses.none { it.docStatus == ResourceStatus.Attached })
+
+        collector.cancel()
+        target.deactivateAsync().await()
+        document.close()
+    }
+
+    @Test
+    fun `attachDocument rolls back initial root entries on schema and size validation failures`() =
+        runTest {
+            // given
+            val schemaKey = "SCHEMA_INITIAL_ROOT"
+            val sizeKey = "SIZE_INITIAL_ROOT"
+            coEvery {
+                service.attachDocument(
+                    match { it.changePack.documentKey == schemaKey },
+                    any(),
+                )
+            } returns ResponseMessage.Success(
+                attachDocumentResponse {
+                    documentId = schemaKey
+                    changePack = changePack { documentKey = schemaKey }
+                    schemaRules.add(
+                        rule {
+                            path = "\$.value"
+                            type = "integer"
+                        },
+                    )
+                },
+                emptyMap(),
+                emptyMap(),
+            )
+            coEvery {
+                service.attachDocument(
+                    match { it.changePack.documentKey == sizeKey },
+                    any(),
+                )
+            } returns ResponseMessage.Success(
+                attachDocumentResponse {
+                    documentId = sizeKey
+                    changePack = changePack { documentKey = sizeKey }
+                    maxSizePerDocument = 1
+                },
+                emptyMap(),
+                emptyMap(),
+            )
+            val schemaDocument = Document(schemaKey)
+            val sizeDocument = Document(sizeKey)
+            target.activateAsync().await()
+
+            // when
+            val schemaResult = target.attachDocument(
+                document = schemaDocument,
+                syncMode = Manual,
+                initialRoot = mapOf("value" to { key -> this[key] = "invalid" }),
+            ).await()
+            val sizeResult = target.attachDocument(
+                document = sizeDocument,
+                syncMode = Manual,
+                initialRoot = mapOf("value" to { key -> this[key] = "too large" }),
+            ).await()
+
+            // then
+            assertTrue(schemaResult.isFailure)
+            assertTrue(sizeResult.isFailure)
+            listOf(schemaDocument, sizeDocument).forEach { document ->
+                assertNull(document.getRoot().getOrNull("value"))
+                assertEquals(ResourceStatus.Detached, document.getStatus())
+                assertFalse(target.has(document.getKey()))
+                document.close()
+            }
+
+            target.deactivateAsync().await()
+        }
+
+    @Test
+    fun `attachDocument skips initial root when the server returns a removed document`() = runTest {
+        // given
+        val documentKey = "REMOVED_INITIAL_ROOT"
+        coEvery {
+            service.attachDocument(
+                match { it.changePack.documentKey == documentKey },
+                any(),
+            )
+        } returns ResponseMessage.Success(
+            attachDocumentResponse {
+                documentId = documentKey
+                changePack = changePack {
+                    this.documentKey = documentKey
+                    isRemoved = true
+                }
+            },
+            emptyMap(),
+            emptyMap(),
+        )
+        val document = Document(documentKey)
+        var initializerCalled = false
+        target.activateAsync().await()
+
+        // when
+        val result = target.attachDocument(
+            document = document,
+            syncMode = Manual,
+            initialRoot = mapOf(
+                "value" to { key ->
+                    initializerCalled = true
+                    this[key] = "unexpected"
+                },
+            ),
+        ).await()
+
+        // then
+        assertTrue(result.isSuccess)
+        assertFalse(initializerCalled)
+        assertEquals(ResourceStatus.Removed, document.getStatus())
+        assertFalse(target.has(documentKey))
+
+        target.deactivateAsync().await()
+        document.close()
     }
 
     @Test

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -616,6 +616,15 @@ class ClientTest {
         )
         val document = Document(documentKey)
         var initializerCalled = false
+        // A pre-attach offline edit on the Detached document: proves an undo entry exists
+        // for the Removed path to clear — the attach-path clearHistory runs BEFORE the
+        // Removed early-return (develop parity, spec 009 / PR #358 r3841896627), so a reused
+        // Document instance whose server-side copy was removed cannot undo into an
+        // unsyncable state.
+        mockkStatic(Base64::class)
+        every { Base64.encodeToString(any(), any()) } returns "mockk"
+        document.updateAsync { root, _ -> root["pre"] = 1 }.await()
+        assertTrue(document.history.canUndo())
         target.activateAsync().await()
 
         // when
@@ -635,9 +644,12 @@ class ClientTest {
         assertFalse(initializerCalled)
         assertEquals(ResourceStatus.Removed, document.getStatus())
         assertFalse(target.has(documentKey))
+        assertFalse(document.history.canUndo())
+        assertFalse(document.history.canRedo())
 
         target.deactivateAsync().await()
         document.close()
+        unmockkStatic(Base64::class)
     }
 
     @Test

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -472,7 +472,15 @@ class ClientTest {
     fun `attachDocument leaves the document attached and detachable when an initializer fails`() =
         runTest {
             // given
+            mockkStatic(Base64::class)
+            every { Base64.encodeToString(any(), any()) } returns "mockk"
             val document = Document(NORMAL_DOCUMENT_KEY)
+            // A pre-attach offline edit on the Detached document: proves an undo entry
+            // exists to be cleared by the moved-up attach-path clearHistory (spec 009 AC4).
+            // Its VersionVector must encode via Base64 when the attach request's ChangePack
+            // is built, hence the mock above.
+            document.updateAsync { root, _ -> root["pre"] = 1 }.await()
+            assertTrue(document.history.canUndo())
             val statuses = mutableListOf<Document.Event.DocumentStatusChanged>()
             val collector = launch(start = CoroutineStart.UNDISPATCHED) {
                 document.events.filterIsInstance<Document.Event.DocumentStatusChanged>()
@@ -503,11 +511,16 @@ class ClientTest {
             assertEquals(ResourceStatus.Attached, document.getStatus())
             assertTrue(target.has(NORMAL_DOCUMENT_KEY))
             assertTrue(statuses.any { it.docStatus == ResourceStatus.Attached })
+            // The moved-up clearHistory() runs before applyStatus, so history is cleared
+            // even though the initializer threw afterward (spec 009 AC4).
+            assertFalse(document.history.canUndo())
+            assertFalse(document.history.canRedo())
 
             collector.cancel()
             target.detachDocument(document).await()
             target.deactivateAsync().await()
             document.close()
+            unmockkStatic(Base64::class)
         }
 
     @Test

--- a/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/core/ClientTest.kt
@@ -451,11 +451,13 @@ class ClientTest {
             it is Document.Event.LocalChange ||
                 it is Document.Event.DocumentStatusChanged
         }
-        assertIs<Document.Event.LocalChange>(lifecycleEvents.first())
+        // JS ordering (F3/F4): the document is marked Attached before the initialRoot
+        // update runs, so its DocumentStatusChanged event precedes the LocalChange event.
         assertEquals(
             ResourceStatus.Attached,
-            assertIs<Document.Event.DocumentStatusChanged>(lifecycleEvents.last()).docStatus,
+            assertIs<Document.Event.DocumentStatusChanged>(lifecycleEvents.first()).docStatus,
         )
+        assertIs<Document.Event.LocalChange>(lifecycleEvents.last())
         assertFalse(document.history.canUndo())
         assertFalse(document.history.canRedo())
 
@@ -467,41 +469,49 @@ class ClientTest {
     }
 
     @Test
-    fun `attachDocument rolls back all initial root entries when an initializer fails`() = runTest {
-        // given
-        val document = Document(NORMAL_DOCUMENT_KEY)
-        val statuses = mutableListOf<Document.Event.DocumentStatusChanged>()
-        val collector = launch(start = CoroutineStart.UNDISPATCHED) {
-            document.events.filterIsInstance<Document.Event.DocumentStatusChanged>()
-                .collect(statuses::add)
+    fun `attachDocument leaves the document attached and detachable when an initializer fails`() =
+        runTest {
+            // given
+            val document = Document(NORMAL_DOCUMENT_KEY)
+            val statuses = mutableListOf<Document.Event.DocumentStatusChanged>()
+            val collector = launch(start = CoroutineStart.UNDISPATCHED) {
+                document.events.filterIsInstance<Document.Event.DocumentStatusChanged>()
+                    .collect(statuses::add)
+            }
+            target.activateAsync().await()
+
+            // when
+            val result = target.attachDocument(
+                document = document,
+                syncMode = Manual,
+                initialRoot = linkedMapOf(
+                    "first" to { key -> this[key] = 1 },
+                    "second" to { error("initializer failed") },
+                ),
+            ).await()
+            delay(10)
+
+            // then: JS ordering (F3) — the document is registered as Attached BEFORE the
+            // initialRoot update runs, so a throwing initializer does not roll anything
+            // back; the attach deferred still resolves to failure, but the document stays
+            // attached and detachable rather than left in limbo.
+            assertTrue(result.isFailure)
+            // The throwing updater's change is never committed to root, so "first" is
+            // never observable even though its own write inside the same change succeeded
+            // before the throw.
+            assertNull(document.getRoot().getOrNull("first"))
+            assertEquals(ResourceStatus.Attached, document.getStatus())
+            assertTrue(target.has(NORMAL_DOCUMENT_KEY))
+            assertTrue(statuses.any { it.docStatus == ResourceStatus.Attached })
+
+            collector.cancel()
+            target.detachDocument(document).await()
+            target.deactivateAsync().await()
+            document.close()
         }
-        target.activateAsync().await()
-
-        // when
-        val result = target.attachDocument(
-            document = document,
-            syncMode = Manual,
-            initialRoot = linkedMapOf(
-                "first" to { key -> this[key] = 1 },
-                "second" to { error("initializer failed") },
-            ),
-        ).await()
-        delay(10)
-
-        // then
-        assertTrue(result.isFailure)
-        assertNull(document.getRoot().getOrNull("first"))
-        assertEquals(ResourceStatus.Detached, document.getStatus())
-        assertFalse(target.has(NORMAL_DOCUMENT_KEY))
-        assertTrue(statuses.none { it.docStatus == ResourceStatus.Attached })
-
-        collector.cancel()
-        target.deactivateAsync().await()
-        document.close()
-    }
 
     @Test
-    fun `attachDocument rolls back initial root entries on schema and size validation failures`() =
+    fun `attachDocument leaves the document attached on schema and size validation failures`() =
         runTest {
             // given
             val schemaKey = "SCHEMA_INITIAL_ROOT"
@@ -555,13 +565,16 @@ class ClientTest {
                 initialRoot = mapOf("value" to { key -> this[key] = "too large" }),
             ).await()
 
-            // then
+            // then: reorder consequence (F3) — schema/size validation now throws inside the
+            // post-registration initialRoot update, so both documents stay Attached and
+            // detachable rather than rolling back to Detached.
             assertTrue(schemaResult.isFailure)
             assertTrue(sizeResult.isFailure)
             listOf(schemaDocument, sizeDocument).forEach { document ->
                 assertNull(document.getRoot().getOrNull("value"))
-                assertEquals(ResourceStatus.Detached, document.getStatus())
-                assertFalse(target.has(document.getKey()))
+                assertEquals(ResourceStatus.Attached, document.getStatus())
+                assertTrue(target.has(document.getKey()))
+                target.detachDocument(document).await()
                 document.close()
             }
 

--- a/yorkie/src/test/kotlin/dev/yorkie/document/DocumentSkipHistoryTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/DocumentSkipHistoryTest.kt
@@ -181,4 +181,16 @@ class DocumentSkipHistoryTest {
             target.getRoot().getAs<JsonTree>("tree").toXml(),
         )
     }
+
+    @Test
+    fun `pre-skipHistory two-parameter updateAsync stays on the JVM binary surface`() {
+        // given: callers compiled before skipHistory existed link against
+        // updateAsync(message, updater) — kept via a hidden bridge overload.
+        val bridges = Document::class.java.methods.filter {
+            it.name == "updateAsync" && it.parameterCount == 2
+        }
+
+        // then
+        assertEquals(1, bridges.size)
+    }
 }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/DocumentSkipHistoryTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/DocumentSkipHistoryTest.kt
@@ -302,6 +302,43 @@ class DocumentSkipHistoryTest {
     }
 
     @Test
+    fun `a user edit in the attach clearHistory-to-skipHistory window keeps its undo entry`() =
+        runTest {
+            // Reproduces the fixed attach ordering sequentially (spec 009 AC1): the racy
+            // gated-concurrent variant is unsafe — see the discovery note in the round build
+            // report — so this pins the identical observable window guarantee deterministically.
+
+            // 1. Attach-path clearHistory, moved up ahead of applyStatus(Attached). Wipes any
+            // prior/offline entries.
+            target.clearHistory()
+
+            // 2. A user edit lands in the window between that clearHistory and the initialRoot
+            // update completing.
+            target.updateAsync { root, _ ->
+                root.setNewText("text").edit(0, 0, "user")
+            }.await()
+            assertTrue(target.history.canUndo())
+
+            // 3. The initialRoot update itself, run with skipHistory = true so it never enters
+            // history.
+            target.updateAsync(skipHistory = true) { root, _ ->
+                if ("seed" !in root.keys) {
+                    root["seed"] = 42
+                }
+            }.await()
+
+            // No trailing clearHistory wipes the user edit's entry, and the skipHistory update
+            // added no entry of its own.
+            assertTrue(target.history.canUndo())
+
+            // Undo reverts only the user edit; the initialRoot value stays intact.
+            target.history.undoAsync().await()
+            assertEquals("", target.getRoot().getAs<JsonText>("text").toString())
+            assertEquals(42, target.getRoot().getAs<JsonPrimitive>("seed").value)
+            assertTrue(target.history.canRedo())
+        }
+
+    @Test
     fun `positional two-parameter updateAsync call compiles and runs`() = runTest {
         val updater: suspend (JsonObject, DocPresence) -> Unit =
             { root, _ -> root["k"] = "positional" }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/DocumentSkipHistoryTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/DocumentSkipHistoryTest.kt
@@ -1,18 +1,20 @@
 package dev.yorkie.document
 
+import dev.yorkie.document.json.JsonObject
 import dev.yorkie.document.json.JsonPrimitive
+import dev.yorkie.document.json.JsonText
 import dev.yorkie.document.json.JsonTree
 import dev.yorkie.document.json.TreeBuilder.element
 import dev.yorkie.document.json.TreeBuilder.text
+import dev.yorkie.document.presence.DocPresence
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.After
-import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.junit.Assert.assertTrue as jAssertTrue
 
 /**
  * Covers `updateAsync(skipHistory = true, ...)`: history-exempt local
@@ -40,7 +42,7 @@ class DocumentSkipHistoryTest {
             root["k1"] = "1"
         }.await()
         val canUndoAfterE1 = target.history.canUndo()
-        jAssertTrue(canUndoAfterE1)
+        assertTrue(canUndoAfterE1)
 
         // E2 - skipHistory, must not add an undo entry
         target.updateAsync(skipHistory = true) { root, _ ->
@@ -105,12 +107,12 @@ class DocumentSkipHistoryTest {
         }.await()
 
         target.history.undoAsync().await()
-        jAssertTrue(target.history.canRedo())
+        assertTrue(target.history.canRedo())
 
         target.updateAsync(skipHistory = true) { root, _ ->
             root["k"] = "bookkeeping"
         }.await()
-        jAssertTrue(target.history.canRedo())
+        assertTrue(target.history.canRedo())
 
         target.history.redoAsync().await()
         assertEquals("1", target.getRoot().getAs<JsonPrimitive>("k").value)
@@ -183,14 +185,143 @@ class DocumentSkipHistoryTest {
     }
 
     @Test
-    fun `pre-skipHistory two-parameter updateAsync stays on the JVM binary surface`() {
-        // given: callers compiled before skipHistory existed link against
-        // updateAsync(message, updater) — kept via a hidden bridge overload.
-        val bridges = Document::class.java.methods.filter {
-            it.name == "updateAsync" && it.parameterCount == 2
+    fun `skipHistory tree deletion produces no undo entry and its mutation persists`() = runTest {
+        // given: <doc><p>AB</p></doc>
+        target.updateAsync { root, _ ->
+            root.setNewTree("tree", element("doc") { element("p") { text { "AB" } } })
+        }.await()
+
+        // Ordinary deletion: removes "A"; restores on undo (contrast case, AC8).
+        target.updateAsync { root, _ ->
+            root.getAs<JsonTree>("tree").edit(1, 2)
+        }.await()
+        assertEquals("<doc><p>B</p></doc>", target.getRoot().getAs<JsonTree>("tree").toXml())
+        target.history.undoAsync().await()
+        assertEquals("<doc><p>AB</p></doc>", target.getRoot().getAs<JsonTree>("tree").toXml())
+        target.history.redoAsync().await()
+        assertEquals("<doc><p>B</p></doc>", target.getRoot().getAs<JsonTree>("tree").toXml())
+        val canUndoAfterOrdinary = target.history.canUndo()
+        assertTrue(canUndoAfterOrdinary)
+
+        // skipHistory deletion: removes "B"; produces zero reverse ops (AC8) — no new
+        // undo entry is pushed, and the deletion is permanent (not reachable via undo).
+        target.updateAsync(skipHistory = true) { root, _ ->
+            root.getAs<JsonTree>("tree").edit(1, 2)
+        }.await()
+        assertEquals("<doc><p></p></doc>", target.getRoot().getAs<JsonTree>("tree").toXml())
+        assertEquals(canUndoAfterOrdinary, target.history.canUndo())
+
+        // The one available undo entry is still the ordinary deletion above, not the
+        // skipHistory one. Its reverse op re-inserts "A" at the reconciled point (the
+        // skipHistory deletion shifted/collapsed that point when it removed "B"); "B"
+        // itself never comes back since the skipHistory deletion produced no reverse op.
+        target.history.undoAsync().await()
+        assertEquals("<doc><p>A</p></doc>", target.getRoot().getAs<JsonTree>("tree").toXml())
+    }
+
+    @Test
+    fun `skipHistory overwrite of an ordinary key undoes as a no-op and redoes by LWW`() = runTest {
+        // E1 - ordinary: k = "1"
+        target.updateAsync { root, _ ->
+            root["k"] = "1"
+        }.await()
+        assertEquals("1", target.getRoot().getAs<JsonPrimitive>("k").value)
+
+        // E2 - skipHistory overwrite: k = "bookkeeping"
+        target.updateAsync(skipHistory = true) { root, _ ->
+            root["k"] = "bookkeeping"
+        }.await()
+        assertEquals("bookkeeping", target.getRoot().getAs<JsonPrimitive>("k").value)
+
+        // Undo direction: E1's reverse op is a Remove targeting the specific "1"
+        // element, which the skipHistory write already tombstoned (superseded by
+        // "bookkeeping"). Removing an already-superseded element is a no-op on the
+        // active value — remote-like semantics mean createdAt is not retargeted —
+        // so "bookkeeping" is what survives, not "1".
+        target.history.undoAsync().await()
+        assertEquals("bookkeeping", target.getRoot().getAs<JsonPrimitive>("k").value)
+
+        // Redo direction: replaying E1 is an ordinary Set of "1" with a freshly
+        // issued (newer) ticket, so it wins LWW over "bookkeeping" exactly as any
+        // genuinely remote write with a newer ticket would — this is the same
+        // remote-like contract, not a special-cased no-op.
+        target.history.redoAsync().await()
+        assertEquals("1", target.getRoot().getAs<JsonPrimitive>("k").value)
+    }
+
+    @Test
+    fun `skipHistory reconciles a pending tree undo entry across index shift`() = runTest {
+        // given: <root><p></p></root>
+        target.updateAsync { root, _ ->
+            root.setNewTree("tree", element("root") { element("p") {} })
+        }.await()
+
+        // E1 - ordinary insert "A" at index 1
+        target.updateAsync { root, _ ->
+            root.getAs<JsonTree>("tree").edit(1, 1, text { "A" })
+        }.await()
+        assertEquals("<root><p>A</p></root>", target.getRoot().getAs<JsonTree>("tree").toXml())
+
+        // E2 - skipHistory insert "X" before "A", shifting E1's undo range right by one.
+        target.updateAsync(skipHistory = true) { root, _ ->
+            root.getAs<JsonTree>("tree").edit(1, 1, text { "X" })
+        }.await()
+        assertEquals("<root><p>XA</p></root>", target.getRoot().getAs<JsonTree>("tree").toXml())
+
+        // Undo E1: reconciliation must have shifted the undo range past "X" so only
+        // "A" (the user's edit) is removed; "X" (bookkeeping) survives.
+        target.history.undoAsync().await()
+        assertEquals("<root><p>X</p></root>", target.getRoot().getAs<JsonTree>("tree").toXml())
+
+        // Redo replays symmetrically.
+        target.history.redoAsync().await()
+        assertEquals("<root><p>XA</p></root>", target.getRoot().getAs<JsonTree>("tree").toXml())
+    }
+
+    @Test
+    fun `skipHistory reconciles a pending text undo entry across index shift`() = runTest {
+        // given: setNewText, ordinary insert "A"
+        target.updateAsync { root, _ ->
+            root.setNewText("text").edit(0, 0, "A")
+        }.await()
+        assertEquals("A", target.getRoot().getAs<JsonText>("text").toString())
+
+        // skipHistory insert "X" before "A", shifting the pending undo range right.
+        target.updateAsync(skipHistory = true) { root, _ ->
+            root.getAs<JsonText>("text").edit(0, 0, "X")
+        }.await()
+        assertEquals("XA", target.getRoot().getAs<JsonText>("text").toString())
+
+        // Undo the ordinary insert: only "A" is removed, "X" survives.
+        target.history.undoAsync().await()
+        assertEquals("X", target.getRoot().getAs<JsonText>("text").toString())
+
+        // Redo replays symmetrically.
+        target.history.redoAsync().await()
+        assertEquals("XA", target.getRoot().getAs<JsonText>("text").toString())
+    }
+
+    @Test
+    fun `positional two-parameter updateAsync call compiles and runs`() = runTest {
+        val updater: suspend (JsonObject, DocPresence) -> Unit =
+            { root, _ -> root["k"] = "positional" }
+
+        target.updateAsync("msg", updater).await()
+
+        assertEquals("positional", target.getRoot().getAs<JsonPrimitive>("k").value)
+    }
+
+    @Test
+    fun `pre-skipHistory two-parameter updateAsync binary surface is preserved`() {
+        // The original pre-skipHistory updateAsync(message, updater) overload must keep
+        // its exact `$default` synthetic (receiver + message + updater + mask + marker =
+        // 5 params) so bytecode compiled against the old signature still links. The
+        // 3-param overload's own `$default` synthetic has 6 params (skipHistory added),
+        // so filtering on `== 5` isolates only the preserved original.
+        val defaults = Document::class.java.declaredMethods.filter {
+            it.name == "updateAsync\$default" && it.parameterCount == 5
         }
 
-        // then
-        assertEquals(1, bridges.size)
+        assertEquals(1, defaults.size)
     }
 }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/DocumentSkipHistoryTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/DocumentSkipHistoryTest.kt
@@ -1,0 +1,184 @@
+package dev.yorkie.document
+
+import dev.yorkie.document.json.JsonPrimitive
+import dev.yorkie.document.json.JsonTree
+import dev.yorkie.document.json.TreeBuilder.element
+import dev.yorkie.document.json.TreeBuilder.text
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.Assert.assertTrue as jAssertTrue
+
+/**
+ * Covers `updateAsync(skipHistory = true, ...)`: history-exempt local
+ * updates skip both `pushUndo` and `clearRedo` while mutation, sync
+ * queueing, and failure semantics stay unchanged.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DocumentSkipHistoryTest {
+    private lateinit var target: Document
+
+    @Before
+    fun setUp() {
+        target = Document("")
+    }
+
+    @After
+    fun tearDown() {
+        target.close()
+    }
+
+    @Test
+    fun `skipHistory update adds no undo entry and preserves undo depth`() = runTest {
+        // E1 - ordinary
+        target.updateAsync { root, _ ->
+            root["k1"] = "1"
+        }.await()
+        val canUndoAfterE1 = target.history.canUndo()
+        jAssertTrue(canUndoAfterE1)
+
+        // E2 - skipHistory, must not add an undo entry
+        target.updateAsync(skipHistory = true) { root, _ ->
+            root["k2"] = "2"
+        }.await()
+        val canUndoAfterE2 = target.history.canUndo()
+        assertEquals(canUndoAfterE1, canUndoAfterE2)
+
+        // E3 - ordinary
+        target.updateAsync { root, _ ->
+            root["k3"] = "3"
+        }.await()
+
+        // Two undos exactly consume E1 and E3; E2 is never a target.
+        target.history.undoAsync().await()
+        target.history.undoAsync().await()
+        assertFalse(target.history.canUndo())
+    }
+
+    @Test
+    fun `undo twice reverses E3 then E1 while E2 mutation survives`() = runTest {
+        // Distinct keys per write: each key's own reverse op targets that
+        // key's specific creation ticket, so undoing E1 after two more
+        // writes to OTHER keys stays observably meaningful (a reverse op for
+        // a repeatedly-overwritten single key would otherwise target a
+        // stale, already-superseded ticket).
+        target.updateAsync { root, _ ->
+            root["k1"] = "1"
+        }.await()
+
+        target.updateAsync(skipHistory = true) { root, _ ->
+            root["k2"] = "2"
+        }.await()
+
+        target.updateAsync { root, _ ->
+            root["k3"] = "3"
+        }.await()
+        assertEquals("""{"k1":"1","k2":"2","k3":"3"}""", target.toJson())
+
+        // Undo #1 reverses E3 (removes k3); k1 and k2 (E2's mutation) survive.
+        target.history.undoAsync().await()
+        assertEquals("""{"k1":"1","k2":"2"}""", target.toJson())
+
+        // Undo #2 reverses E1 (removes k1); k2 (E2's mutation) still survives.
+        target.history.undoAsync().await()
+        assertEquals("""{"k2":"2"}""", target.toJson())
+        assertFalse(target.history.canUndo())
+    }
+
+    @Test
+    fun `skipHistory update as first write leaves undo unavailable`() = runTest {
+        target.updateAsync(skipHistory = true) { root, _ ->
+            root["k"] = "1"
+        }.await()
+        assertFalse(target.history.canUndo())
+    }
+
+    @Test
+    fun `skipHistory update preserves a non-empty redo stack`() = runTest {
+        target.updateAsync { root, _ ->
+            root["k"] = "1"
+        }.await()
+
+        target.history.undoAsync().await()
+        jAssertTrue(target.history.canRedo())
+
+        target.updateAsync(skipHistory = true) { root, _ ->
+            root["k"] = "bookkeeping"
+        }.await()
+        jAssertTrue(target.history.canRedo())
+
+        target.history.redoAsync().await()
+        assertEquals("1", target.getRoot().getAs<JsonPrimitive>("k").value)
+    }
+
+    @Test
+    fun `failing updater inside skipHistory update leaves stacks and content unchanged`() =
+        runTest {
+            target.updateAsync { root, _ ->
+                root["k"] = "1"
+            }.await()
+            val canUndoBefore = target.history.canUndo()
+            val canRedoBefore = target.history.canRedo()
+
+            val result = target.updateAsync(skipHistory = true) { root, _ ->
+                root["k"] = "2"
+                error("boom")
+            }.await()
+
+            assertTrue(result.isFailure)
+            assertEquals("1", target.getRoot().getAs<JsonPrimitive>("k").value)
+            assertEquals(canUndoBefore, target.history.canUndo())
+            assertEquals(canRedoBefore, target.history.canRedo())
+        }
+
+    @Test
+    fun `style undo fidelity survives a skipHistory bookkeeping tree write`() = runTest {
+        // Build <doc><p></p></doc>, then insert "A" (ordinary edit).
+        target.updateAsync { root, _ ->
+            root.setNewTree("tree", element("doc") { element("p") {} })
+        }.await()
+
+        target.updateAsync { root, _ ->
+            root.getAs<JsonTree>("tree").edit(1, 1, text { "A" })
+        }.await()
+        assertEquals("<doc><p>A</p></doc>", target.getRoot().getAs<JsonTree>("tree").toXml())
+
+        // Ordinary style: bold the "p" element wrapping "A".
+        target.updateAsync { root, _ ->
+            root.getAs<JsonTree>("tree").style(0, 1, mapOf("bold" to "true"))
+        }.await()
+        assertEquals(
+            """<doc><p bold="true">A</p></doc>""",
+            target.getRoot().getAs<JsonTree>("tree").toXml(),
+        )
+
+        // skipHistory bookkeeping write: a second, unrelated style attribute.
+        target.updateAsync(skipHistory = true) { root, _ ->
+            root.getAs<JsonTree>("tree").style(0, 1, mapOf("dirty" to "true"))
+        }.await()
+        assertEquals(
+            """<doc><p bold="true" dirty="true">A</p></doc>""",
+            target.getRoot().getAs<JsonTree>("tree").toXml(),
+        )
+
+        // First undo reverses the ordinary style (un-bolds), leaving "A" and the
+        // skipHistory bookkeeping attribute intact.
+        target.history.undoAsync().await()
+        assertEquals(
+            """<doc><p dirty="true">A</p></doc>""",
+            target.getRoot().getAs<JsonTree>("tree").toXml(),
+        )
+
+        // Second undo reverses the original insert, removing "A"; bookkeeping stays.
+        target.history.undoAsync().await()
+        assertEquals(
+            """<doc><p dirty="true"></p></doc>""",
+            target.getRoot().getAs<JsonTree>("tree").toXml(),
+        )
+    }
+}

--- a/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtRootTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/crdt/CrdtRootTest.kt
@@ -9,6 +9,7 @@ import dev.yorkie.document.time.VersionVector
 import dev.yorkie.helper.maxVectorOf
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CrdtRootTest {
@@ -160,5 +161,37 @@ class CrdtRootTest {
         // then the LWW-losing new value is also registered as garbage
         assertEquals(2, root.garbageLength)
         assertEquals("""{"key":2}""", root.rootObject.toJson())
+    }
+
+    // F2/AC8: a skipHistory (LocalNoHistory) change generates zero reverse ops at the
+    // source, while Local and Remote keep their existing behavior.
+    @Test
+    fun `should generate reverse ops only for sources that push undo history`() {
+        // given
+        val root = CrdtRoot(CrdtObject(TimeTicket.InitialTimeTicket, memberNodes = ElementRht()))
+        val actor = "000000000000000000000001"
+        fun tick(lamport: Long) = TimeTicket(lamport = lamport, delimiter = 0u, actorID = actor)
+
+        // when: Local produces a reverse op (existing behavior, unchanged)
+        val localResult = SetOperation(
+            "key",
+            CrdtPrimitive(1, tick(1)),
+            TimeTicket.InitialTimeTicket,
+            tick(1),
+        ).execute(root, OpSource.Local, null)
+
+        // then
+        assertEquals(1, localResult.reverseOps.size)
+
+        // when: LocalNoHistory (skipHistory) produces zero reverse ops (F2)
+        val skipHistoryResult = SetOperation(
+            "key",
+            CrdtPrimitive(2, tick(2)),
+            TimeTicket.InitialTimeTicket,
+            tick(2),
+        ).execute(root, OpSource.LocalNoHistory, null)
+
+        // then
+        assertTrue(skipHistoryResult.reverseOps.isEmpty())
     }
 }

--- a/yorkie/src/test/kotlin/dev/yorkie/document/operation/EditOperationReverseTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/operation/EditOperationReverseTest.kt
@@ -152,6 +152,53 @@ class EditOperationReverseTest {
         assertFalse(op.isUndoOp)
     }
 
+    @Test
+    fun `undo op mutates fromPos and toPos to the reconciled range before serialization`() {
+        // given: text is "Hello"
+        val (text, root) = buildTextRoot()
+        text.edit(text.indexRangeToPosRange(0, 0), "Hello", makeTicket(3))
+
+        // The op is constructed with stale/mismatched fromPos-toPos (a sentinel position
+        // unrelated to the real reconciled range) plus undoFromOffset/undoToOffset [1,3) —
+        // simulating a reverse op whose offsets were shifted by reconcileOperation after
+        // construction. execute() must derive the actual range from the offsets and write
+        // it back into fromPos/toPos so the wire-serialized range matches (F10).
+        val expectedRange = text.indexRangeToPosRange(1, 3)
+        val staleNodeId = RgaTreeSplitNodeID(makeTicket(99), 0)
+        val op = EditOperation(
+            fromPos = RgaTreeSplitPos(staleNodeId, 0),
+            toPos = RgaTreeSplitPos(staleNodeId, 0),
+            content = "",
+            parentCreatedAt = textTicket,
+            executedAt = makeTicket(4),
+            attributes = emptyMap(),
+            undoFromOffset = 1,
+            undoToOffset = 3,
+        )
+
+        // when
+        op.execute(root, OpSource.UndoRedo, null)
+
+        // then
+        assertEquals(expectedRange.first, op.fromPos)
+        assertEquals(expectedRange.second, op.toPos)
+    }
+
+    @Test
+    fun `zero-effect edit with empty opInfos returns no reverse op`() {
+        // given: text is "Hello"
+        val (text, root) = buildTextRoot()
+        text.edit(text.indexRangeToPosRange(0, 0), "Hello", makeTicket(3))
+
+        // when: a point range with no content changes nothing
+        val op = makeEditOp(text, 2, 2, "", 4)
+        val result = op.execute(root, OpSource.Local, null)
+
+        // then
+        assertTrue(result.opInfos.isEmpty())
+        assertTrue(result.reverseOps.isEmpty())
+    }
+
     // --- reconcileOperation cases ---
     // reconcileOperation adjusts the undoFromOffset / undoToOffset of an undo op.
 

--- a/yorkie/src/test/kotlin/dev/yorkie/document/operation/TreeEditOperationReverseTest.kt
+++ b/yorkie/src/test/kotlin/dev/yorkie/document/operation/TreeEditOperationReverseTest.kt
@@ -131,6 +131,49 @@ class TreeEditOperationReverseTest {
         assertEquals("p", snapshot.type)
     }
 
+    @Test
+    fun `history edit retains the range and rebuilt contents it applies`() {
+        // given: <root><p>123 456</p></root>, with "3" inserted by a separate change
+        val (tree, root) = buildTreeRoot()
+        val pNode = CrdtTreeElement(CrdtTreeNodeID(makeTicket(3), 0), "p")
+        makeTreeEditOp(tree, 0, 0, listOf(pNode), 3).execute(root, OpSource.Local, null)
+        val prefix = CrdtTreeText(CrdtTreeNodeID(makeTicket(4), 0), "12")
+        makeTreeEditOp(tree, 1, 1, listOf(prefix), 4).execute(root, OpSource.Local, null)
+        val three = CrdtTreeText(CrdtTreeNodeID(makeTicket(5), 0), "3")
+        val insertResult =
+            makeTreeEditOp(tree, 3, 3, listOf(three), 5).execute(root, OpSource.Local, null)
+        val suffix = CrdtTreeText(CrdtTreeNodeID(makeTicket(6), 0), " 456")
+        makeTreeEditOp(tree, 4, 4, listOf(suffix), 6).execute(root, OpSource.Remote, null)
+
+        // when: the history deletion executes from its reconciled integer range
+        val delete = insertResult.reverseOps.single() as TreeEditOperation
+        val expectedDeleteRange = tree.indexRangeToPosRange(3 to 4)
+        delete.executedAt = makeTicket(7)
+        val deleteResult = delete.execute(root, OpSource.UndoRedo, null)
+
+        // then: its wire-visible range is the non-zero range applied to the tree
+        assertTrue(deleteResult.opInfos.isNotEmpty())
+        assertEquals(expectedDeleteRange.first, delete.fromPos)
+        assertEquals(expectedDeleteRange.second, delete.toPos)
+        assertFalse(delete.fromPos == delete.toPos)
+        assertEquals("<root><p>12 456</p></root>", tree.toXml())
+
+        // and: a history restoration retains the fresh node IDs applied locally
+        val removeResult = makeTreeEditOp(tree, 1, 3, null, 8).execute(root, OpSource.Local, null)
+        val restore = removeResult.reverseOps.single() as TreeEditOperation
+        val expectedRestorePos = tree.indexRangeToPosRange(1 to 1).first
+        restore.executedAt = makeTicket(9)
+        restore.execute(root, OpSource.UndoRedo, null)
+
+        val restored = restore.contents.orEmpty().single()
+        assertEquals(expectedRestorePos, restore.fromPos)
+        assertEquals(expectedRestorePos, restore.toPos)
+        assertEquals(makeTicket(9).copy(delimiter = 1u), restored.id.createdAt)
+        assertEquals(restored.id, tree.findFloorNode(restored.id)?.id)
+        assertFalse(restored === tree.findFloorNode(restored.id))
+        assertEquals("<root><p>12 456</p></root>", tree.toXml())
+    }
+
     // #1234: pure splits at any level > 0 produce a boundary-deletion reverse op tagged
     // with redoSplitLevel so redo re-splits (was only splitLevel == 1 before).
 
@@ -300,6 +343,31 @@ class TreeEditOperationReverseTest {
         // collapses to point at remoteFrom + remoteContentSize
         assertEquals(3, op.undoFromOffset)
         assertEquals(3, op.undoToOffset)
+    }
+
+    @Test
+    fun `collapsed history edit emits no change or reverse operation`() {
+        val (tree, root) = buildTreeRoot()
+        val pNode = CrdtTreeElement(CrdtTreeNodeID(makeTicket(3), 0), "p")
+        makeTreeEditOp(tree, 0, 0, listOf(pNode), 3).execute(root, OpSource.Local, null)
+        val pos = tree.indexRangeToPosRange(1 to 1).first
+        val op =
+            TreeEditOperation(
+                parentCreatedAt = treeTicket,
+                fromPos = pos,
+                toPos = pos,
+                contents = null,
+                splitLevel = 0,
+                executedAt = makeTicket(4),
+                undoFromOffset = 1,
+                undoToOffset = 1,
+            )
+
+        val result = op.execute(root, OpSource.UndoRedo, null)
+
+        assertTrue(result.opInfos.isEmpty())
+        assertTrue(result.reverseOps.isEmpty())
+        assertEquals("<root><p></p></root>", tree.toXml())
     }
 
     @Test


### PR DESCRIPTION
> **RTCOLLABPLATFORM-745**: [[Yorkie Android SDK] Support initialRoot in Client.attachDocument](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-745)
> **RTCOLLABPLATFORM-746**: [[Yorkie Android SDK] Support history-exempt local updates (updateAsync skipHistory)](https://jira.navercorp.com/browse/RTCOLLABPLATFORM-746)

#### What this PR does / why we need it?

## Summary

- Add attach-time `initialRoot` support matching Yorkie iOS and JS behavior.
- Preserve existing server content and exclude initialization from undo history.
- Make history-generated TreeEdit undo/redo changes converge on remote replicas after concurrent edits.
- Add a history-exempt local update: `updateAsync(skipHistory = true)` mutates and syncs as usual but records no undo entry and preserves the redo stack.
- Retain the existing `attachDocument`/`updateAsync` overloads and TreeEdit protobuf schema.

## Changes

- Add the public `InitialRoot` type alias and a new `attachDocument` overload.
- Initialize only missing keys after applying the authoritative server response.
- Support every value type constructible through `JsonObject`.
- Normalize history TreeEdit positions and rebuilt content onto the queued operation before serialization.
- Keep rebuilt wire content detached from later live-tree mutations and suppress reverse history for ineffective edits.
- Add an additive `skipHistory: Boolean = false` parameter to `Document.updateAsync`; when `true`, the change skips `pushUndo` and `clearRedo` while mutation, validation, event emission, and sync stay unchanged.
- Add atomic-failure, lifecycle-ordering, wire-payload, history, tree-sync, split/merge, convergence, and skip-history undo/redo tests.
- Keep the server protocol, dependencies, release version, and root `CHANGELOG.md` unchanged.

#### Any background context you want to provide?

Initial values and undo/redo results are ordinary Yorkie changes that synchronize through the existing push-pull flow. The TreeEdit fix reuses the existing operation converter and protobuf fields; no server or wire-schema change is required.

`skipHistory` exists for consumer-plugin bookkeeping writes (run-settlement flush, remote reconciliation) that are not user actions; without it, such a write tops the undo stack and the user's undo reverses bookkeeping instead of their own edit. Neither the JS nor the iOS SDK has this capability today — it is a new, local-only flag mirroring the history semantics of remote changes; nothing serializes.

#### What are the relevant tickets?

- RTCOLLABPLATFORM-745
- RTCOLLABPLATFORM-746

## Test plan

- [x] Attach a fresh document with initial values and confirm undo/redo history is empty.
- [x] Attach another client and confirm existing initial content is preserved and synchronized.
- [x] Make a normal edit, then confirm undo preserves the initial root and redo restores the edit.
- [x] Run the exact two-client TreeEdit scenario and confirm `12 456` after undo and `123 456` after redo on both replicas.
- [x] Verify delete, replace, split, merge, vanished-target, and history-isolation behavior.
- [x] Round-trip the effective history TreeEdit range, rebuilt IDs, content, and split level through protobuf conversion.
- [x] Publish the PR branch SNAPSHOT and run zero-plugins-android's unchanged collaborative-edit connected suite.
- [x] Interleave an ordinary edit, a `skipHistory` write, and another ordinary edit; confirm undo reverses only the ordinary edits and the skip write is never visited.
- [x] Confirm a `skipHistory` write preserves a pending redo stack and that a bolded edit un-bolds (not deletes) on undo past a skip write.
- [x] Sync a `skipHistory` mutation to a second attached client and confirm identical convergence to an ordinary update.

### Checklist

- [x] Added relevant JVM and Android instrumented tests.
- [x] Didn't break existing attach, Text history, or ordinary TreeEdit behavior.
- [x] No public API, protobuf schema, server, dependency, release-version, or root-changelog change beyond the approved `initialRoot` API and the additive `updateAsync(skipHistory)` parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
